### PR TITLE
Run mapred_verify tests

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,7 +9,8 @@
 
 {deps, [
         {lager, "1.0.0", {git, "git://github.com/basho/lager", {tag, "1.0.0"}}},
-        {meck, ".*", {git, "git://github.com/eproxus/meck"}}
+        {meck, ".*", {git, "git://github.com/eproxus/meck"}},
+        {mapred_verify, ".*", {git, "git://github.com/basho/mapred_verify"}}
        ]}.
 
 {escript_incl_apps, [lager]}.

--- a/rtdev.config
+++ b/rtdev.config
@@ -1,4 +1,4 @@
-{rt_deps, ["/Users/jtuple/basho/CLEAN2/riak/deps"]}.
+{rt_deps, ["/Users/jtuple/basho/CLEAN2/riak/deps","deps"]}.
 {rt_max_wait_time, 180000}.
 {rt_retry_delay, 500}.
 {rt_harness, rtdev}.

--- a/tests/mapred_verify_rt.erl
+++ b/tests/mapred_verify_rt.erl
@@ -1,0 +1,34 @@
+%% @doc Runs the mapred_verify tests from
+%% http://github.com/basho/mapred_verify
+
+-module(mapred_verify_rt).
+
+-export([mapred_verify_rt/0]).
+
+-define(NODE_COUNT, 3).
+
+mapred_verify_rt() ->
+    lager:info("Deploy ~b nodes", [?NODE_COUNT]),
+    Nodes = rt:deploy_nodes(?NODE_COUNT),
+    
+    lager:info("Join nodes"),
+    lists:foreach(fun(N) -> rt:join(N, hd(Nodes)) end, tl(Nodes)),
+    
+    lager:info("Wait for cluster to be ready"),
+    rt:wait_until_all_members(Nodes),
+    rt:wait_until_nodes_ready(Nodes),
+    rt:wait_until_no_pending_changes(Nodes),
+    
+    PrivDir = code:priv_dir(mapred_verify),
+    MRVProps = [{node, hd(Nodes)},
+                %% don't need 'path' because riak_test does that for us
+                {keycount, 1000},
+                {bodysize, 1},
+                {populate, true},
+                {runjobs, true},
+                {testdef, filename:join(PrivDir, "tests.def")}],
+    
+    lager:info("Run mapred_verify"),
+    0 = mapred_verify:do_verification(MRVProps),
+    lager:info("~s: PASS", [atom_to_list(?MODULE)]),
+    ok.


### PR DESCRIPTION
Added a new test, `mapred_verify_rt` (sorry for the `_rt`; had to find something that didn't conflict with the `mapred_verify` module), that runs the http://github.com/basho/mapred_verify tests. I've tested this in rtdev mode, but not rtbe mode.
