### PR TITLE
Added the capacity for a ~/.riak_test.config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,12 @@
 
 Assumes `riak_test` and `riak` and/or `riak-ee` are all checked out in the same parent folder
 
-1. Edit your `rtdev.config` file's rt_deps url
+1. Edit your `cp riak_test.config.sample` to `~/.riak_test.config` 
+1. Update your new `~/.riak_test.config` file's rt_deps url
 1. `cd ../riak[-ee]`
 1. `make devrel`
 1. `. ../riak_test/rtdev-setup.sh`
 1. `cd back to riak_test`
-1. `riak_test rtdev.config verify_build_cluster`
+1. `riak_test rtdev verify_build_cluster`
 
-
+`~/.riak_test.config` stores multiple configurations, and you can pass them by name as the first argument to `riak_test`. First it looks for a file with that name in your local directory, if it doesn't find it, it looks for something with that name in `~/.riak_test.config`

--- a/riak_test.config.sample
+++ b/riak_test.config.sample
@@ -1,0 +1,39 @@
+{rtdev, [
+	{rt_deps, ["/Users/joe/dev/basho/riak/deps","deps"]},
+	{rt_max_wait_time, 180000},
+	{rt_retry_delay, 500},
+	{rt_harness, rtdev},
+	{rtdev_path, "/tmp/rt"}
+]}.
+
+{rtdev_mixed, [
+	{rt_deps, ["/Users/joe/dev/basho/riak/deps"]},
+	{rt_max_wait_time, 180000},
+	{rt_retry_delay, 500},
+	{rt_harness, rtdev},
+	{rtdev_path, [{root, "/tmp/rt"},
+				  {current, "/tmp/rt/current"},
+				  {"1.1.4", "/tmp/rt/riak-1.1.4"},
+				  {"1.0.3", "/tmp/rt/riak-1.0.3"}]}
+]}.
+
+{rtdev_ee, [
+	{rt_deps, ["/Users/joe/dev/basho/riak_ee/deps","deps"]},
+	{rt_max_wait_time, 180000},
+	{rt_retry_delay, 500},
+	{rt_harness, rtdev},
+	{rtdev_path, "/tmp/rt_ee"}
+]}.
+
+{rtdev_ee_mixed, [
+	{rt_deps, ["/Users/joe/dev/basho/riak_ee/deps"]},
+	{rt_max_wait_time, 180000},
+	{rt_retry_delay, 500},
+	{rt_harness, rtdev},
+	{rtdev_path, [{root, "/tmp/rt"},
+				  {current, "/tmp/rt/current"},
+				  {"1.1.4", "/tmp/rt/riak_ee-1.1.4"},
+				  {"1.0.3", "/tmp/rt/riak_ee-1.0.3"}]}
+]}.
+
+


### PR DESCRIPTION
Rage PR

You're only going to configure riak_test once, but your configuration might get blown away by git. Now you can configure riak_test in the `~/.riak_test.config` file. It can hold multiple named configurations, so go nuts.
