### PR TITLE
update riakc to 1.3.0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -13,7 +13,7 @@
         {meck, ".*", {git, "git://github.com/eproxus/meck"}},
         {mapred_verify, ".*", {git, "git://github.com/basho/mapred_verify"}},
         {riakc, "1.3.0", {git, "git://github.com/basho/riak-erlang-client", {tag, "1.3.0"}}},
-        {riakhttpc, ".*", {git, "git://github.com/basho/riak-erlang-http-client"}}
+        {riakhttpc, "1.3.0", {git, "git://github.com/basho/riak-erlang-http-client", {tag, "1.3.0"}}}
        ]}.
 
 {escript_incl_apps, [lager, getopt, riakhttpc, riakc, ibrowse]}.


### PR DESCRIPTION
depends on https://github.com/basho/riak-erlang-http-client/pull/11
