### PR TITLE
A fix for mapred_verify_rt

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -17,7 +17,7 @@
         {kvc, "1.2.1", {git, "https://github.com/etrepum/kvc", {tag, "v1.2.1"}}}
        ]}.
 
-{escript_incl_apps, [lager, getopt, riakhttpc, riakc, ibrowse, mochiweb, kvc]}.
+{escript_incl_apps, [lager, getopt, riakhttpc, riakc, ibrowse, mochiweb, kvc, mapred_verify]}.
 
 {plugin_dir, "src"}.
 {plugins, [rebar_riak_test_plugin]}.


### PR DESCRIPTION
added mapred_verify to the escript def

Test with something like this:
./riak_test -c rtdev_mixed -t mapred_verify_rt
