### PR TITLE
Refactor basic_command_line test.

### DIFF
--- a/tests/basic_command_line.erl
+++ b/tests/basic_command_line.erl
@@ -110,12 +110,6 @@ ping_down_test(Node) ->
     ok.
 
 attach_up_test(Node) ->
-
-    %% check /usr/sbin/riak attach')
-    %% Sort of a punt on this test, it tests that attach
-    %% connects to the pipe, but doesn't run any commands.
-    %% This is probably okay for a basic cmd line test
-
     lager:info("Testing riak attach"),
 
     rt:attach(Node, [{expect, "\(^D to exit\)"},


### PR DESCRIPTION
- Try to do as much as possible while the node is up/down, without
  changing its state. Rapidly starting and stopping the node has
  strange effects.
- We should consider removing the restart functionality from the
  `riak` script, as it leaves things in undetermined states.
