### PR TITLE
Fix multiple of ten failures = pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ riak_test
 .DS_Store
 out
 search-corpus/spam.0
+erl_crash.dump

--- a/tests/client_ruby_verify.erl
+++ b/tests/client_ruby_verify.erl
@@ -41,7 +41,7 @@ confirm() ->
             {"PB_PORT", integer_to_list(PB_Port)},
             {"RIAK_VERSION", binary_to_list(rt:get_version())}
         ]}]),
-    ?assert(rt:str(RubyLog, "0 failures")),
+    ?assert(rt:str(RubyLog, " 0 failures")),
     ?assert(Code =:= 0),
     pass.
 


### PR DESCRIPTION
Also, adding dump file name to gitignore

/cc @joedevivo 

Joe: can't verify because I have non-zero tests failures at the moment, but thought it looked safe. Noticed that the log file includes # of tests, comma space then # of failures.
