### PR TITLE
rt:stop/1 now uses straight rpc.

### DIFF
--- a/src/rt.erl
+++ b/src/rt.erl
@@ -226,7 +226,7 @@ async_start(Node) ->
 
 %% @doc Stop the specified Riak `Node'.
 stop(Node) ->
-    ?HARNESS:stop(Node).
+    rpc:call(Node, init, stop, []).
 
 %% @doc Stop the specified Riak `Node' and wait until it is not pingable
 stop_and_wait(Node) ->

--- a/tests/basic_command_line.erl
+++ b/tests/basic_command_line.erl
@@ -85,7 +85,7 @@ start_test(Node) ->
 stop_test(Node) ->
     ?assert(rt:is_pingable(Node)),
 
-    ok = rt:stop(Node),
+    {ok, "ok\n"} = rt:riak(Node, "stop"),
 
     ?assertNot(rt:is_pingable(Node)),
     ok.


### PR DESCRIPTION
It's so simple...
