### PR TITLE
verify_busy_dist_port: remove use of grep via os:cmd, timer:sleep

### DIFF
--- a/tests/cause_bdp.erl
+++ b/tests/cause_bdp.erl
@@ -23,13 +23,6 @@
 -module(cause_bdp).
 -compile(export_all).
 
-log_file() ->
-    log_dir() ++ "/console.log".
-
-log_dir() ->
-    {ok, LogDir} = application:get_env(riak_core, platform_log_dir),
-    filename:absname(LogDir).
-
 spam_nodes(TargetNodes) ->
         [[spawn(?MODULE, spam, [N]) || _ <- lists:seq(1,10*1000)] || N <- TargetNodes].
 

--- a/tests/verify_bdp_event_handler.erl
+++ b/tests/verify_bdp_event_handler.erl
@@ -1,0 +1,133 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2012 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(verify_bdp_event_handler).
+
+-behaviour(gen_event).
+
+%% API
+-export([add_handler/1]).
+
+%% gen_event callbacks
+-export([init/1, handle_event/2, handle_call/2, 
+         handle_info/2, terminate/2, code_change/3]).
+
+-record(state, {
+          test_pid :: pid()
+         }).
+
+%%%===================================================================
+%%% gen_event callbacks
+%%%===================================================================
+
+add_handler(Pid) ->
+    gen_event:add_handler(riak_sysmon_handler, ?MODULE, Pid).
+
+%%%===================================================================
+%%% gen_event callbacks
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Whenever a new event handler is added to an event manager,
+%% this function is called to initialize the event handler.
+%%
+%% @spec init(Args) -> {ok, State}
+%% @end
+%%--------------------------------------------------------------------
+init(Pid) ->
+    {ok, #state{test_pid=Pid}}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Whenever an event manager receives an event sent using
+%% gen_event:notify/2 or gen_event:sync_notify/2, this function is
+%% called for each installed event handler to handle the event.
+%%
+%% @spec handle_event(Event, State) ->
+%%                          {ok, State} |
+%%                          {swap_handler, Args1, State1, Mod2, Args2} |
+%%                          remove_handler
+%% @end
+%%--------------------------------------------------------------------
+handle_event({monitor, _, busy_dist_port, {_Port, _}}, State) ->
+    %% notify test busy_dist_port event fired
+    State#state.test_pid ! go,
+    {ok, State};
+handle_event(_Event, State) ->
+    {ok, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Whenever an event manager receives a request sent using
+%% gen_event:call/3,4, this function is called for the specified
+%% event handler to handle the request.
+%%
+%% @spec handle_call(Request, State) ->
+%%                   {ok, Reply, State} |
+%%                   {swap_handler, Reply, Args1, State1, Mod2, Args2} |
+%%                   {remove_handler, Reply}
+%% @end
+%%--------------------------------------------------------------------
+handle_call(_, State) ->
+    {ok, ok, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% This function is called for each installed event handler when
+%% an event manager receives any other message than an event or a
+%% synchronous request (or a system message).
+%%
+%% @spec handle_info(Info, State) ->
+%%                         {ok, State} |
+%%                         {swap_handler, Args1, State1, Mod2, Args2} |
+%%                         remove_handler
+%% @end
+%%--------------------------------------------------------------------
+handle_info(_Info, State) ->
+    {ok, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Whenever an event handler is deleted from an event manager, this
+%% function is called. It should be the opposite of Module:init/1 and
+%% do any necessary cleaning up.
+%%
+%% @spec terminate(Reason, State) -> void()
+%% @end
+%%--------------------------------------------------------------------
+terminate(_Reason, _State) ->
+    ok.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Convert process state when code is changed
+%%
+%% @spec code_change(OldVsn, State, Extra) -> {ok, NewState}
+%% @end
+%%--------------------------------------------------------------------
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.


### PR DESCRIPTION
ran into what I think is a subtle race condition while implementing the improved version of the `verify_busy_dist_port` test @joedevivo and I discussed so submitting a PR for my PR: https://github.com/basho/riak_test/pull/103. 

the tl;dr of below goes something like: this is an improved implementation of the test but i think no matter what the test will need some from of periodic retry + max retry. 

bit of background:
- the test registers a `riak_sysmon` handler to monitor for `busy_dist_port` events on the riak node
- it also registers a `riak_test_lager_backend`on the riak node to capture log messages in memory
- the riak node already has the `riak_core_sysmon_handler` installed before installing the test's handler. side note: `riak_core_sysmon_handler` is for the most part what we are testing (make sure `riak_sysmon` fires the `busy_dist_port` event, which is handled by `riak_core_sysmon_handler`, which subsequently logs the event). 

attempt at describing the race condition:
1. the vm fires the busy_dist_port event, which propagates to bolth 
    `riak_core_sysmon_handler` and `verify_bdp_event_handler` via `gen_event:notify` . 
2. `verify_bdp_event_handler:handle_event/2` and 
     `riak_core_sysmon_handler:handle_event/2` execute concurrently. the former 
      sends a message to the test process. the latter calls `lager:info` 
      (if functioning correctly) to log the BDP event. 
3.  when logging, as i understand it, lager calls `gen_event:sync_notify` 
       which waits for a reply from each  backend (including `riak_test_lager_backend`). 
4. when the test process receives the message from `verify_bdp_event_handler` 
      that it the BDP event fired the test process does a `gen_event:call` to `riak_test_lager_backend` for the logs. 

3 & 4 is where the race starts. If somehow the message from `gen_event:call` (4) reaches the inbox of `riak_test_lager_backend` before the `gen_event:sync_notify` (3) the test fails although the message was correctly logged. In practice, I haven't seen this yet because its basically a inter-vm message in 4 trying to beat out an intra-vm message in 3 but its possible. However, I noticed this because I originally tried to have `verify_bdp_event_handler` call `riak_test_lager_backend:get_logs/0` instead of the test process. In that case, the test would fail improperly about 90% of the time. 

So like the tl;dr says, basically i think we need a little periodic retry in the test still just to make it bulletproof but besides that i think this method is an improvement over the calls out to `grep` plus periodic sleeping in the first implementation. 
