### PR TITLE
Fix riaknostic test for Riak that includes riaknostic

### DIFF
--- a/tests/riaknostic_rt.erl
+++ b/tests/riaknostic_rt.erl
@@ -35,7 +35,7 @@ confirm() ->
     riaknostic_bootstrap(Node1),
 
     %% Run through all tests on Node1
-    check_riaknostic_exectute(Node1),
+    check_riaknostic_execute(Node1),
     check_riaknostic_usage(Node1),
     check_riaknostic_command_list(Node1),
     check_riaknostic_log_levels(Node1),
@@ -66,7 +66,7 @@ riaknostic_install(true, Node) ->
     ok.
 
 %% Check that riaknostic executes
-check_riaknostic_exectute(Node) ->
+check_riaknostic_execute(Node) ->
     %% Execute
     lager:info("**  Check Riaknostic executes"),
     {ok, RiaknosticOut} = rt:admin(Node, ["diag"]),


### PR DESCRIPTION
In Riak 1.3.0 riaknostic was included by default.  These
tests assumed riaknostic was _not_ installed and would
fail on 1.3+ nodes.  This change fixes that and refactors
the test to be a little more readable.

Tested on Riak master (1.3) and Riak 1.2.1
