### PR TITLE
Fix partition_repair when run from the suite

### DIFF
--- a/tests/partition_repair.erl
+++ b/tests/partition_repair.erl
@@ -21,9 +21,6 @@
 -compile(export_all).
 -include_lib("eunit/include/eunit.hrl").
 
--import(rt, [enable_search_hook/2,
-             get_ring/1]).
-
 -define(FMT(S, L), lists:flatten(io_lib:format(S, L))).
 
 %% @doc This test verifies that partition repair successfully repairs
@@ -76,7 +73,7 @@ confirm() ->
     end,
 
     lager:info("Enable search hook"),
-    enable_search_hook(hd(Nodes), Bucket),
+    rt:enable_search_hook(hd(Nodes), Bucket),
 
     lager:info("Insert Scott's spam emails"),
     {ok, C} = riak:client_connect(hd(Nodes)),
@@ -85,7 +82,7 @@ confirm() ->
     lager:info("Stash ITFs for each partition"),
     %% need to load the module so riak can see the fold fun
     load_module_on_riak(Nodes, ?MODULE),
-    Ring = get_ring(hd(Nodes)),
+    Ring = rt:get_ring(hd(Nodes)),
     Owners = riak_core_ring:all_owners(Ring),
     [stash_data(riak_search, Owner) || Owner <- Owners],
 


### PR DESCRIPTION
The giddyup suite does not define the backend for the `partition_repair` test, leading to a `function_clause` error when trying to determine the data directory for KV partitions. This makes it fallback to `bitcask` when it gets `undefined`.  Also, removed some unused imports.
