### PR TITLE
Bumped python client version to 1.5-stable, for fuzzy versioning.

### DIFF
--- a/tests/client_python_verify.erl
+++ b/tests/client_python_verify.erl
@@ -64,7 +64,10 @@ prereqs() ->
     rt:stream_cmd(Cmd),
 
     lager:info("[PREREQ] Resetting python client to tag '~s'", [?PYTHON_CLIENT_TAG]),
-    TagCmd = io_lib:format("git reset --hard ~s", [?PYTHON_CLIENT_TAG]),
+    %% @todo below is how to reset to a tag, use that when 1.5.2 is available
+    %%TagCmd = io_lib:format("git reset --hard ~s", [?PYTHON_CLIENT_TAG]),
+    rt:stream_cmd("git reset --hard", [{cd, ?PYTHON_CHECKOUT}]),
+    TagCmd = io_lib:format("git checkout -b ~s", [?PYTHON_CLIENT_TAG]),
     rt:stream_cmd(TagCmd, [{cd, ?PYTHON_CHECKOUT}]),
 
     lager:info("[PREREQ] Installing an isolated environment with virtualenv in ~s", [?PYTHON_CHECKOUT]),


### PR DESCRIPTION
So, the python tests fail because they can't understand the concept of a pre-release version number.

@seancribbs fixed this in the python client's 1.5-stable branch, but that was introduced after the 1.5.1 tag. So, for python tests to pass, we need to use 1.5-stable until such time as 1.5.2+ is tagged.
