### PR TITLE
Cluster building should waste the ring/data dirs

### DIFF
--- a/bin/rtdev-current.sh
+++ b/bin/rtdev-current.sh
@@ -20,6 +20,14 @@ mkdir $RT_DEST_DIR/current
 cd $cwd
 echo " - Copying devrel to $RT_DEST_DIR/current"
 cp -p -P -R dev $RT_DEST_DIR/current
+cd $RT_DEST_DIR/current
+for f in dev/dev?
+do
+    if [ -d $f ]; then
+        echo " - Cleaning dir $RT_DEST_DIR/current/$f/data"
+        rm -rf $f/data && mkdir -p $f/data/ring
+    fi
+done
 echo " - Writing $RT_DEST_DIR/current/VERSION"
 echo -n $VERSION > $RT_DEST_DIR/current/VERSION
 cd $RT_DEST_DIR


### PR DESCRIPTION
If you run rtdev-current.sh on a riak directory that you've built a cluster on before, it copies the ring as well, so that the check_singleton_node check fails in build/deploy_cluster.  

Deleting the ring file, either at copy time or at the start of cluster building, should prevent this issue.
