### PR TITLE
Fix clean_data_dir using dot dir

### DIFF
--- a/src/rt.erl
+++ b/src/rt.erl
@@ -760,7 +760,7 @@ clean_cluster(Nodes) when is_list(Nodes) ->
     clean_data_dir(Nodes).
 
 clean_data_dir(Nodes) ->
-    clean_data_dir(Nodes, ".").
+    clean_data_dir(Nodes, "").
 
 clean_data_dir(Nodes, SubDir) when not is_list(Nodes) ->
     clean_data_dir([Nodes], SubDir);


### PR DESCRIPTION
Silly me added that dot there on refactoring for no good reason. @jaredmorrow pointed out how it made the rm command fail. Simply removing it makes clean_data_dir do its thing.
