### PR TITLE
remove dead code so 'make docs' works

### DIFF
--- a/src/rt.erl
+++ b/src/rt.erl
@@ -480,10 +480,6 @@ wait_until(Node, Fun, TimeoutFun) ->
     wait_until(Node, Fun, Retry, Delay, TimeoutFun).
 
 %% @deprecated Use {@link wait_until/2} instead.
-%% wait_until(Node, Fun, Retry) ->
-%%    wait_until(Node, Fun, Retry, 500).
-
-%% @deprecated Use {@link wait_until/2} instead.
 wait_until(Node, Fun, Retry, Delay, TimeoutFun) ->
     Pass = Fun(Node),
     case {Retry, Pass} of


### PR DESCRIPTION
With this dead code, edoc complains:

./src/rt.erl, function wait_until/5: at line 486: multiple @deprecated tag.
