### PR TITLE
Link walk url test failing on CentOS 6

### DIFF
--- a/src/rt.erl
+++ b/src/rt.erl
@@ -759,10 +759,11 @@ build_cluster(NumNodes, Versions, InitialConfig) ->
     [join(Node, Node1) || Node <- OtherNodes],
 
     ?assertEqual(ok, wait_until_nodes_ready(Nodes)),
-    ?assertEqual(ok, wait_until_no_pending_changes(Nodes)),
 
     %% Ensure each node owns a portion of the ring
     wait_until_nodes_agree_about_ownership(Nodes),
+    ?assertEqual(ok, wait_until_no_pending_changes(Nodes)),
+
     lager:info("Cluster built: ~p", [Nodes]),
     Nodes.
 


### PR DESCRIPTION
This has only been seen in one box, one run so far. We are getting a 500:
19:41:23.704 [info] Verifying ("a","1") '_,next,1/b,next,1/_,next,1/_,next,1/_,next,1' -> ["v2"]
19:41:24.006 [error] Error in process <0.13011.0> on node 'riak_test@127.0.0.1' with exit value: {{badmatch,{ok,"500",[{"Server","MochiWeb/1.1 WebMachine/1.9.2 (someone had painted it blue)"},{"Expires","Tue, 08 Jan 2013 00:51:23 GMT"},{"Date","Tue, 08 Jan 2013 00:41:24 GMT"},{"Content-Type","text/html"},{"Content-Len...
