### PR TITLE
verify_basic_upgrade failures

### DIFF
--- a/tests/verify_basic_upgrade.erl
+++ b/tests/verify_basic_upgrade.erl
@@ -41,7 +41,7 @@ confirm() ->
 upgrade(Node, NewVsn) ->
     lager:info("Upgrading ~p to ~p", [Node, NewVsn]),
     rt:upgrade(Node, NewVsn),
-    timer:sleep(1000),
+    rt:wait_for_service(Node, riak_kv),
     lager:info("Ensuring keys still exist"),
     rt:systest_read(Node, 100, 1),
     ?assertEqual([], rt:systest_read(Node, 100, 1)),


### PR DESCRIPTION
Hopefully it just requires adding some proper wait functions. Here is the log in giddyup for the failures in Fedora 17:
http://basho-giddyup.herokuapp.com/#/logs/2065

On FreeBSD, we see potentially a different issue. The failure seems to happen while waiting for the service to come up:
http://basho-giddyup.herokuapp.com/#/logs/2030
