### PR TITLE
Use the aliased or found python in the virtualenv creation.

### DIFF
--- a/tests/client_python_verify.erl
+++ b/tests/client_python_verify.erl
@@ -71,5 +71,5 @@ prereqs() ->
     rt:stream_cmd(TagCmd, [{cd, ?PYTHON_CHECKOUT}]),
 
     lager:info("[PREREQ] Installing an isolated environment with virtualenv in ~s", [?PYTHON_CHECKOUT]),
-    rt:stream_cmd("virtualenv --clear --no-site-packages .", [{cd, ?PYTHON_CHECKOUT}]),
+    rt:stream_cmd("virtualenv --clear --no-site-packages -P `which python` .", [{cd, ?PYTHON_CHECKOUT}]),
     ok.


### PR DESCRIPTION
This should fix additional python version problems on CentOS 5.
