### PR TITLE
Added wait for ring to converge after bucket creation for both tests.

### DIFF
--- a/tests/replication.erl
+++ b/tests/replication.erl
@@ -258,13 +258,12 @@ replication([AFirst|_] = ANodes, [BFirst|_] = BNodes, Connected) ->
     case nodes_all_have_version(ANodes, "1.1.0") of
         true ->
 
-            FollowsA = ANodes -- [LeaderA],
-            make_bucket([LeaderA|FollowsA], NoRepl, [{repl, false}]),
+            make_bucket(ANodes, NoRepl, [{repl, false}]),
 
             case nodes_all_have_version(ANodes, "1.2.0") of
                 true ->
-                    make_bucket([LeaderA|FollowsA], RealtimeOnly, [{repl, realtime}]),
-                    make_bucket([LeaderA|FollowsA], FullsyncOnly, [{repl, fullsync}]),
+                    make_bucket(ANodes, RealtimeOnly, [{repl, realtime}]),
+                    make_bucket(ANodes, FullsyncOnly, [{repl, fullsync}]),
 
                     %% disconnect the other cluster, so realtime doesn't happen
                     lager:info("disconnect the 2 clusters"),

--- a/tests/replication2.erl
+++ b/tests/replication2.erl
@@ -234,11 +234,10 @@ replication([AFirst|_] = ANodes, [BFirst|_] = BNodes, Connected) ->
 
     lager:info("Nodes restarted"),
 
-    FollowsA = ANodes -- [LeaderA],
-    make_bucket([LeaderA|FollowsA], NoRepl, [{repl, false}]),
+    replication:make_bucket(ANodes, NoRepl, [{repl, false}]),
 
-    make_bucket([LeaderA|FollowsA], RealtimeOnly, [{repl, realtime}]),
-    make_bucket([LeaderA|FollowsA], FullsyncOnly, [{repl, fullsync}]),
+    replication:make_bucket(ANodes, RealtimeOnly, [{repl, realtime}]),
+    replication:make_bucket(ANodes, FullsyncOnly, [{repl, fullsync}]),
 
     %% disconnect the other cluster, so realtime doesn't happen
     lager:info("disconnect the 2 clusters"),
@@ -596,9 +595,6 @@ nodes_all_have_version(Nodes, Version) ->
 client_count(Node) ->
     Clients = rpc:call(Node, supervisor, which_children, [riak_repl_client_sup]),
     length(Clients).
-
-make_bucket(Nodes, Name, Args) ->
-    replication:make_bucket(Nodes, Name, Args).
 
 start_and_wait_until_fullsync_complete(Node) ->
     Status0 = rpc:call(Node, riak_repl_console, status, [quiet]),


### PR DESCRIPTION
Per Andrew's suggestion, I added a wait_for_ring_converged() check after bucket creation. We probably had a race condition across the nodes.

Before running the fix, I was getting failures on line 297 of replication.erl, which suggested that maybe the bucket wasn't created correctly before the writes/reads. Also, the riak_test cabal was reporting failures of this test and also replication2 at other locations.

After this change, both tests run correctly on my Mac. We need to commit the fix and try on other platforms, of course.

Thanks again to @Vagabond for the insights.
