### PR TITLE
update rtdev:check_node/1 to work w/ atom version specifiers

### DIFF
--- a/src/rtdev.erl
+++ b/src/rtdev.erl
@@ -431,8 +431,8 @@ check_node({_N, Version}) ->
     case proplists:is_defined(Version, rt:config(rtdev_path)) of
         true -> ok;
         _ ->
-            lager:error("You don't have Riak ~s installed", [Version]),
-            erlang:error("You don't have Riak " ++ Version ++ " installed" )
+            lager:error("You don't have Riak ~s installed or configured", [Version]),
+            erlang:error("You don't have Riak " ++ atom_to_list(Version) ++ " installed or configured")
     end.
 
 set_backend(Backend) ->


### PR DESCRIPTION
previous version specifiers were strings, the change to atoms (e.g. `previous`, `legacy`)
caused an error in `rtdev:check_node/1`. Also, updated message to suggest that configuration could be the problem.

Example of the error on master:

```
22:44:13.245 [warning] verify_basic_upgrade failed: {badarg,[{erlang,'++',[previous," installed"],[]},{rtdev,check_node,1,[{file,"src/rtdev.erl"},{line,435}]},{rtdev,'-deploy_nodes/1-lc$^1/1-1-',1,[{file,"src/rtdev.erl"},{line,223}]},{rtdev,deploy_nodes,1,[{file,"src/rtdev.erl"},{line,223}]},{rt,deploy_nodes,2,[{file,"src/rt.erl"},{line,272}]},{rt,build_cluster,3,[{file,"src/rt.erl"},{line,767}]},{verify_basic_upgrade,confirm,0,[{file,"tests/verify_basic_upgrade.erl"},{line,29}]}]}
```
