### PR TITLE
Listing keys still times out

### DIFF
--- a/tests/loaded_upgrade.erl
+++ b/tests/loaded_upgrade.erl
@@ -132,7 +132,10 @@ list_keys(_, _, 0, _) ->
 list_keys(Pid, Bucket, Attempts, TimeOut) ->
     Res = riakc_pb_socket:list_keys(Pid, Bucket, TimeOut),
     case Res of
-        {error, Err} when Err =:= timeout; is_tuple(Err), element(1, Err) == timeout ->
+        {error, Err} when
+          Err =:= timeout;
+          Err =:= <<"timeout">>;
+          is_tuple(Err), element(1, Err) =:= timeout ->
             ?assertMatch(ok, wait_for_reconnect(Pid)),
             NewAttempts = Attempts - 1,
             NewTimeOut = TimeOut * 2,


### PR DESCRIPTION
The time-out detection code I just added checks for responses 'timeout' and also {error, {'timeout', _}}, but apparently we are very creative and can sometimes return {error, <<"timeout">>}, like here:

http://giddyup.basho.com/#/projects/riak/scorecards/9/9-291-loaded_upgrade-ubuntu-1004-32-eleveldb-previous/3340

We need to check for that too and prevent the test from failing from a simple time out
