### PR TITLE
Moved common repl2 functions to repl_util and added log_to_nodes tracing...

### DIFF
--- a/tests/repl_util.erl
+++ b/tests/repl_util.erl
@@ -1,6 +1,29 @@
 -module(repl_util).
--export([make_cluster/1, name_cluster/2]).
--compile(export_all).
+-export([make_cluster/1,
+         name_cluster/2,
+         node_has_version/2,
+         nodes_with_version/2,
+         nodes_all_have_version/2,
+         wait_until_is_leader/1,
+         is_leader/1,
+         wait_until_is_not_leader/1,
+         wait_until_leader/1,
+         wait_until_new_leader/2,
+         wait_until_leader_converge/1,
+         wait_until_connection/1,
+         wait_until_no_connection/1,
+         wait_for_reads/5,
+         start_and_wait_until_fullsync_complete/1,
+         connect_cluster/3,
+         disconnect_cluster/2,
+         wait_for_connection/2,
+         enable_realtime/2,
+         disable_realtime/2,
+         enable_fullsync/2,
+         start_realtime/2,
+         stop_realtime/2,
+         do_write/5
+        ]).
 -include_lib("eunit/include/eunit.hrl").
 
 make_cluster(Nodes) ->
@@ -192,3 +215,20 @@ do_write(Node, Start, End, Bucket, W) ->
             lists:flatten([rt:systest_write(Node, S, S, Bucket, W) ||
                     {S, _Error} <- Errors])
     end.
+
+%% does the node meet the version requirement?
+node_has_version(Node, Version) ->
+    NodeVersion =  rtdev:node_version(rtdev:node_id(Node)),
+    case NodeVersion of
+        current ->
+            %% current always satisfies any version check
+            true;
+        _ ->
+            NodeVersion >= Version
+    end.
+
+nodes_with_version(Nodes, Version) ->
+    [Node || Node <- Nodes, node_has_version(Node, Version)].
+
+nodes_all_have_version(Nodes, Version) ->
+    Nodes == nodes_with_version(Nodes, Version).

--- a/tests/replication2.erl
+++ b/tests/replication2.erl
@@ -1,7 +1,6 @@
 -module(replication2).
 -behavior(riak_test).
 -export([confirm/0]).
--compile(export_all).
 -include_lib("eunit/include/eunit.hrl").
 
 -import(rt, [deploy_nodes/2,
@@ -591,27 +590,3 @@ collect_results(Workers, Acc) ->
         {'DOWN', _, _, Pid, _Reason} ->
             collect_results(lists:keydelete(Pid, 1, Workers), Acc)
     end.
-
-%% does the node meet the version requirement?
-node_has_version(Node, Version) ->
-    NodeVersion =  rtdev:node_version(rtdev:node_id(Node)),
-    case NodeVersion of
-        current ->
-            %% current always satisfies any version check
-            true;
-        _ ->
-            NodeVersion >= Version
-    end.
-
-nodes_with_version(Nodes, Version) ->
-    [Node || Node <- Nodes, node_has_version(Node, Version)].
-
-nodes_all_have_version(Nodes, Version) ->
-    Nodes == nodes_with_version(Nodes, Version).
-
-client_count(Node) ->
-    Clients = rpc:call(Node, supervisor, which_children, [riak_repl_client_sup]),
-    length(Clients).
-
-
-

--- a/tests/replication2_dirty.erl
+++ b/tests/replication2_dirty.erl
@@ -1,6 +1,5 @@
 -module(replication2_dirty).
 -export([confirm/0]).
--compile(export_all).
 -include_lib("eunit/include/eunit.hrl").
 
 -import(rt, [deploy_nodes/2,


### PR DESCRIPTION
... to replication2_dirty test

This is just a refactor of common repl2 kinds of functions into repl_util for common use between other replication tests. I'll use these in the new FS test as well. In addition, I've added some log_to_nodes() tracing in the replication2_dirty test to aid in debugging.
