### PR TITLE
Print the node logs when the test fails 

### DIFF
--- a/src/riak_test_runner.erl
+++ b/src/riak_test_runner.erl
@@ -96,7 +96,8 @@ execute(TestModule, TestMetaData) ->
             ErrorHeader = "================ " ++ atom_to_list(TestModule) ++ " failure stack trace =====================",
             ErrorFooter = [ $= || _X <- lists:seq(1,length(ErrorHeader))],
             Error = io_lib:format("~n~s~n~p~n~s~n", [ErrorHeader, Reason, ErrorFooter]),
-            lager:error(Error);
+            lager:error(Error),
+            cat_node_logs();
         _ -> meh
     end,
     {Status, Reason}.
@@ -119,3 +120,13 @@ check_prereqs(Module) ->
     [ lager:warning("~s prereq '~s' not installed.", [Module, P]) || {P, false} <- P2],
     GoodToGo = lists:all(fun({_, Present}) -> Present end, P2),
     ?assertEqual({all_prereqs_present, true}, {all_prereqs_present, GoodToGo}).
+
+cat_node_logs() ->
+    Files = rt:get_node_logs(),
+    lager:error("================ Printing node logs and crash dumps ================~n~n", []),
+    cat_node_logs(Files).
+
+cat_node_logs([]) -> ok;
+cat_node_logs([{Filename, Content}|Rest]) ->
+    lager:error("================ Log: ~s =====================~n~s~n~n", [Filename, Content]),
+    cat_node_logs(Rest).

--- a/src/rt.erl
+++ b/src/rt.erl
@@ -56,6 +56,7 @@
          download/1,
          enable_search_hook/2,
          get_deps/0,
+         get_node_logs/0,
          get_os_env/1,
          get_os_env/2,
          get_ring/1,
@@ -1165,3 +1166,8 @@ config_or_os_env(Config, Default) ->
 to_upper(S) -> lists:map(fun char_to_upper/1, S).
 char_to_upper(C) when C >= $a, C =< $z -> C bxor $\s;
 char_to_upper(C) -> C.
+
+%% @doc Downloads any extant log files from the harness's running
+%%   nodes.
+get_node_logs() ->
+    ?HARNESS:get_node_logs().

--- a/src/rtdev.erl
+++ b/src/rtdev.erl
@@ -475,3 +475,10 @@ devpaths() ->
 
 versions() ->
     proplists:get_keys(rt:config(rtdev_path)) -- [root].
+
+get_node_logs() ->
+    Root = proplists:get_value(root, ?PATH),
+    [ begin
+          {ok, Data} = file:read_file(Filename),
+          {Filename, Data}
+      end || Filename <- filelib:wildcard(Root ++ "/*/dev/dev*/log/*") ].


### PR DESCRIPTION
This should help with diagnosis of tests running on the builders that reset the devrel before we can get to the node logs. It also grabs crash dumps when present, assuming they were dumped into the node's log directory.
