### PR TITLE
gitignore emacs cruft, doc generation, java test jars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ riak_test
 out
 search-corpus/spam.0
 erl_crash.dump
+*~
+doc/
+!doc/overview.edoc
+*.jar


### PR DESCRIPTION
Without these extra ignores, `git status` quickly becomes a screen-filler. Any objections?
