### PR TITLE
Move the timing of the runnable test check to earlier in test run

### DIFF
--- a/src/riak_test_runner.erl
+++ b/src/riak_test_runner.erl
@@ -18,7 +18,7 @@
 %%
 %% -------------------------------------------------------------------
 
-%% @doc riak_test_runner runs a riak_test module's run/0 function. 
+%% @doc riak_test_runner runs a riak_test module's run/0 function.
 -module(riak_test_runner).
 -export([confirm/3, metadata/0]).
 -include_lib("eunit/include/eunit.hrl").
@@ -27,12 +27,12 @@
 %% @doc fetches test metadata from spawned test process
 metadata() ->
     riak_test ! metadata,
-    receive 
-        {metadata, TestMeta} -> TestMeta 
+    receive
+        {metadata, TestMeta} -> TestMeta
     end.
 
 -spec(confirm(integer(), atom(), [{atom(), term()}]) -> [tuple()]).
-%% @doc Runs a module's run/0 function after setting up a log capturing backend for lager. 
+%% @doc Runs a module's run/0 function after setting up a log capturing backend for lager.
 %%      It then cleans up that backend and returns the logs as part of the return proplist.
 confirm(TestModule, Outdir, TestMetaData) ->
     start_lager_backend(TestModule, Outdir),
@@ -40,23 +40,15 @@ confirm(TestModule, Outdir, TestMetaData) ->
 
     check_prereqs(TestModule),
 
-    %% Check for api compatibility
-    {Status, Reason, Backend} = case erlang:function_exported(TestModule, confirm, 0) of
-        true ->
-            lager:notice("Running Test ~s", [TestModule]), 
-            SetBackend = rt:set_backend(proplists:get_value(backend, TestMetaData)),
-            {S, R} = execute(TestModule, TestMetaData),
-            {S, R, SetBackend};
-        _ ->
-            lager:info("~s is not a runnable test", [TestModule]),
-            {not_a_runnable_test, undefined, undefined}
-    end,
-    
+    lager:notice("Running Test ~s", [TestModule]),
+    Backend = rt:set_backend(proplists:get_value(backend, TestMetaData)),
+    {Status, Reason} = execute(TestModule, TestMetaData),
+
     lager:notice("~s Test Run Complete", [TestModule]),
     {ok, Log} = stop_lager_backend(),
     Logs = iolist_to_binary(lists:foldr(fun(L, Acc) -> [L ++ "\n" | Acc] end, [], Log)),
-    
-    
+
+
     RetList = [{test, TestModule}, {status, Status}, {log, Logs}, {backend, Backend} | proplists:delete(backend, TestMetaData)],
     case Status of
         fail -> RetList ++ [{reason, iolist_to_binary(io_lib:format("~p", [Reason]))}];
@@ -66,7 +58,7 @@ confirm(TestModule, Outdir, TestMetaData) ->
 start_lager_backend(TestModule, Outdir) ->
     case Outdir of
         undefined -> ok;
-        _ -> 
+        _ ->
             gen_event:add_handler(lager_event, lager_file_backend, {Outdir ++ "/" ++ atom_to_list(TestModule) ++ ".dat_test_output", debug, 10485760, "$D0", 1}),
             lager:set_loglevel(lager_file_backend, debug)
     end,
@@ -83,7 +75,7 @@ execute(TestModule, TestMetaData) ->
     GroupLeader = group_leader(),
     NewGroupLeader = riak_test_group_leader:new_group_leader(self()),
     group_leader(NewGroupLeader, self()),
-    
+
     {0, UName} = rt:cmd("uname -a"),
     lager:info("Test Runner `uname -a` : ~s", [UName]),
 


### PR DESCRIPTION
Check if potential test modules are compatatible with the `riak_test` API as part of the determination of which tests to run in the `riak_test:main` function instead of doing the check in the `riak_test_runner` module. This speeds up execution of test runs by avoiding the penalty of attempting to stop all nodes for modules that are not actually runnable tests.

This is especially helpful in situations where the test involves nodes other than just riak nodes. _e.g._ riak_ee or riak_cs tests
