### PR TITLE
Fix legacy PB connections

### DIFF
--- a/src/rt.erl
+++ b/src/rt.erl
@@ -579,7 +579,7 @@ wait_until_transfers_complete([Node0|_]) ->
 wait_for_service(Node, Services) when is_list(Services) ->
     F = fun(N) ->
                 CurrServices = rpc:call(N, riak_core_node_watcher, services, [N]),
-                lists:all(fun(Service) -> lists:member(Service, CurrServices) end, Services) 
+                lists:all(fun(Service) -> lists:member(Service, CurrServices) end, Services)
         end,
     ?assertEqual(ok, wait_until(Node, F)),
     ok;


### PR DESCRIPTION
1.1.x doesn't have riak_api.
