### PR TITLE
Migrate riak_kv's mapred_test suite

### DIFF
--- a/tests/mapred_basic_compat.erl
+++ b/tests/mapred_basic_compat.erl
@@ -40,7 +40,7 @@
 -define(LINK_BUCKET, <<"link bucket">>).
 
 confirm() ->
-    Nodes = rt:build_cluster(1),
+    Nodes = rt:build_cluster(3),
 
     load_test_data(Nodes),
     rt:load_modules_on_nodes([?MODULE], Nodes),

--- a/tests/mapred_buffer_prereduce.erl
+++ b/tests/mapred_buffer_prereduce.erl
@@ -35,7 +35,7 @@
 -define(NUM_INTS, 1000).
 
 confirm() ->
-    Nodes = rt:build_cluster(1),
+    Nodes = rt:build_cluster(3),
 
     load_test_data(Nodes),
     

--- a/tests/mapred_dead_pipe.erl
+++ b/tests/mapred_dead_pipe.erl
@@ -43,7 +43,7 @@
                       }">>).
 
 confirm() ->
-    Nodes = rt:build_cluster(1),
+    Nodes = rt:build_cluster(3),
 
     %% to pick up fake_builder/1
     rt:load_modules_on_nodes([?MODULE], Nodes),

--- a/tests/mapred_javascript.erl
+++ b/tests/mapred_javascript.erl
@@ -43,7 +43,7 @@
                       }">>).
 
 confirm() ->
-    Nodes = rt:build_cluster(1),
+    Nodes = rt:build_cluster(3),
 
     load_test_data(Nodes),
     

--- a/tests/mapred_notfound_failover.erl
+++ b/tests/mapred_notfound_failover.erl
@@ -40,7 +40,7 @@ confirm() ->
     %% notfound by killing a vnode
     rt:set_backend(memory),
 
-    Nodes = rt:build_cluster(1),
+    Nodes = rt:build_cluster(3),
 
     %% for our custom reduce phase
     rt:load_modules_on_nodes([?MODULE], Nodes),
@@ -84,9 +84,10 @@ replica_notfound(Node, {HashMod, HashFun},
     %% to the kvget pipe fitting return an error (because it's the
     %% memory backend), so it will have to look at another kv vnode
     Hash = rpc:call(Node, HashMod, HashFun, [{MissingBucket, MissingKey}]),
-    [{{PrimaryIndex, _},_}] =
+    [{{PrimaryIndex, PrimaryNode},_}] =
         rpc:call(Node, riak_core_apl, get_primary_apl, [Hash, 1, riak_kv]),
-    {ok, VnodePid} = rpc:call(Node, riak_core_vnode_manager,get_vnode_pid,
+    {ok, VnodePid} = rpc:call(PrimaryNode,
+                              riak_core_vnode_manager, get_vnode_pid,
                               [PrimaryIndex, riak_kv_vnode]),
     exit(VnodePid, kill).
 


### PR DESCRIPTION
The mapred_test eunit suite had a fragile setup stage that frequently caused the automated builders to fail. It should be more stable here.

The suite has also been broken into several independent tests, to make it possible to run each major piece individually.

Some of these tests would benefit from code in #143. They have been marked with TODOs to be fixed once that PR merges.
