### PR TITLE
build-releases, now with 1.3 battle action

### DIFF
--- a/bin/rtdev-build-releases.sh
+++ b/bin/rtdev-build-releases.sh
@@ -115,3 +115,5 @@ build "riak-1.1.4" $R14B04 http://s3.amazonaws.com/downloads.basho.com/riak/1.1/
 echo
 build "riak-1.2.1" $R15B01 http://s3.amazonaws.com/downloads.basho.com/riak/1.2/1.2.1/riak-1.2.1.tar.gz
 echo
+build "riak-1.3.0" $R15B01 http://s3.amazonaws.com/downloads.basho.com/riak/1.3/1.3.0/riak-1.3.0.tar.gz
+echo


### PR DESCRIPTION
To Whom It May Concern, (Everyone)

Now that Riak 1.3 has left home, riak_test has come down with a case of empty nest syndrome. As developers begin writing cool new features for Riak and possibly (but not really, because 1.3 is perfect in every way!) fixing bugs in Riak 1.3, the idea of what 'previous' and 'legacy' versions are have become subjective to the task at hand. Sometimes (like in master), previous is now 1.3.0, whereas in the 1.3 branch, previous is still 1.2.1. 

How you choose to configure this is up you, but I am providing the option for you of now having Riaks 1.1.4, 1.2.1, (oxford comma'd) and 1.3.0 available in your test environment to choose from.

This has been in the works almost as long as riak_test has existed, which is why it was so easy to add. Get on board the progress train, or be left at the station.

Yours in testing,

--joe
