### PR TITLE
tidy up group_leaders, so they don't loops forever

### DIFF
--- a/src/riak_test_group_leader.erl
+++ b/src/riak_test_group_leader.erl
@@ -19,7 +19,7 @@
 %% -------------------------------------------------------------------
 -module(riak_test_group_leader).
 
--export([new_group_leader/1, group_leader_loop/1]).
+-export([new_group_leader/1, group_leader_loop/1, tidy_up/1]).
 
 % @doc spawns the new group leader
 new_group_leader(Runner) ->
@@ -34,10 +34,18 @@ group_leader_loop(Runner) ->
         io_request(From, ReplyAs, Req),
         process_flag(priority, P),
         group_leader_loop(Runner);
+    stab ->
+        kthxbye;
     _ ->
         %% discard any other messages
         group_leader_loop(Runner)
     end.
+
+% @doc closes group leader down
+tidy_up(FormerGroupLeader) ->
+    GroupLeaderToMurder = group_leader(),
+    group_leader(FormerGroupLeader, self()),
+    GroupLeaderToMurder ! stab.
 
 %% Processes an io_request and sends a reply
 io_request(From, ReplyAs, Req) ->

--- a/src/riak_test_runner.erl
+++ b/src/riak_test_runner.erl
@@ -80,7 +80,7 @@ stop_lager_backend() ->
 %% does some group_leader swapping, in the style of EUnit.
 execute(TestModule, TestMetaData) ->
     process_flag(trap_exit, true),
-    GroupLeader = group_leader(),
+    OldGroupLeader = group_leader(),
     NewGroupLeader = riak_test_group_leader:new_group_leader(self()),
     group_leader(NewGroupLeader, self()),
 
@@ -90,7 +90,7 @@ execute(TestModule, TestMetaData) ->
     Pid = spawn_link(TestModule, confirm, []),
 
     {Status, Reason} = rec_loop(Pid, TestModule, TestMetaData),
-    group_leader(GroupLeader, self()),
+    riak_test_group_leader:tidy_up(OldGroupLeader),
     case Status of
         fail ->
             ErrorHeader = "================ " ++ atom_to_list(TestModule) ++ " failure stack trace =====================",


### PR DESCRIPTION
group_leaders keep running, even after they've outlived their usefulness.
