### PR TITLE
make sure http stats are refreshed

### DIFF
--- a/tests/verify_snmp.erl
+++ b/tests/verify_snmp.erl
@@ -62,6 +62,14 @@ confirm() ->
     rt:systest_write(Node1, 10),
     rt:systest_read(Node1, 10),
 
+    lager:info("Waiting for HTTP Stats to be non-zero"),
+    ?assertEqual(ok, 
+                 rt:wait_until(Node1, fun(N) -> 
+                    Stats = get_stats(N),
+                    proplists:get_value(<<"vnode_gets">>, Stats) =/= 0
+                 end)),
+
+
     verify_eq(OIDPairs, Node1),
     pass.
 


### PR DESCRIPTION
more stable than a timer.

as an alternative to https://github.com/basho/riak_test/pull/257
