### PR TITLE
JMX test now checks for JMX failure taking down the whole node

### DIFF
--- a/tests/jmx_verify.erl
+++ b/tests/jmx_verify.erl
@@ -26,6 +26,9 @@
 
 %% You should have curl installed locally to do this.
 confirm() ->
+
+    test_supervision(),
+
     JMXPort = 41111,
     Config = [{riak_jmx, [{enabled, true}, {port, JMXPort}]}],
     Nodes = rt:deploy_nodes(1, Config),
@@ -101,6 +104,19 @@ confirm() ->
                             {<<"read_repairs">>, 1}]),
     pass.
 
+test_supervision() ->
+    JMXPort = 80,
+    Config = [{riak_jmx, [{enabled, true}, {port, JMXPort}]}],
+    [Node|[]] = rt:deploy_nodes(1, Config),
+    timer:sleep(20000),
+    case net_adm:ping(Node) of
+        pang ->
+            lager:error("riak_jmx crash able to crash riak node"),
+            ?assertEqual("riak_jmx crash able to crash riak node", true);
+        _ ->
+            rt:stop(Node)
+    end.
+ 
 verify_inc(Prev, Props, Keys) ->
     [begin
          Old = proplists:get_value(Key, Prev, 0),


### PR DESCRIPTION
This test will take a node down if it doesn't have basho/riak_jmx#14, so it's a good thing that PR exists.
