### PR TITLE
Fix install_on_absence moved from rt->rt_local

### DIFF
--- a/tests/client_ruby_verify.erl
+++ b/tests/client_ruby_verify.erl
@@ -52,7 +52,7 @@ prereqs() ->
     RubyVersion = os:cmd("ruby -v"),
     ?assert(rt:str(RubyVersion, "1.9.") orelse rt:str(RubyVersion, "1.8.7")),
 
-    rt:install_on_absence("bundle", "gem install bundler --no-rdoc --no-ri"),
+    rt_local:install_on_absence("bundle", "gem install bundler --no-rdoc --no-ri"),
     ok.
 
 


### PR DESCRIPTION
A very small fix after the rt->rt_local refactoring. The test now runs, but it doesn't pass for me, yo. Pythong and Java seem fine.
