### PR TITLE
Wait for 'cluster plan' to succeed (verify_staged_clustering)

### DIFF
--- a/tests/verify_staged_clustering.erl
+++ b/tests/verify_staged_clustering.erl
@@ -137,7 +137,14 @@ stage_force_replace(Node, Node1, Node2) ->
 
 print_staged(Node) ->
     %% rpc:call(Node, riak_core_console, print_staged, [[]]).
-    rt:admin(Node, ["cluster", "plan"]).
+    F = fun(_) ->
+                {ok, StdOut} = rt:admin(Node, ["cluster", "plan"]),
+                case StdOut of
+                    "Cannot" ++ _X -> false;
+                    _ -> true
+                end
+        end,
+    rt:wait_until(Node, F).
 
 commit_staged(Node) ->
     %% rpc:call(Node, riak_core_console, commit_staged, [[]]).


### PR DESCRIPTION
While running the `verify_staged_clustering` test on my local
workstation I hit a race when force replacing dev3 with dev2.  The
call to 'cluster plan' was happening before the ring had converged and
thus failing, but the test assumed the first call always succeeds.

This patch simply mimicks what a user might do and retry the 'cluster
plan' command over and over until it succeeds.
