### PR TITLE
Cet aae refactor

### DIFF
--- a/tests/repl_aae_fullsync.erl
+++ b/tests/repl_aae_fullsync.erl
@@ -1,24 +1,19 @@
 %% @doc
 %% This module implements a riak_test to exercise the Active Anti-Entropy Fullsync replication.
-%% It sets up two clusters and starts a single fullsync worker for a single AAE tree.
+%% It sets up two clusters, runs a fullsync over all partitions, and verifies the missing keys
+%% were replicated to the sink cluster.
+
 -module(repl_aae_fullsync).
 -behavior(riak_test).
 -export([confirm/0]).
 -include_lib("eunit/include/eunit.hrl").
 
--import(rt, [deploy_nodes/2,
-             join/2,
-             log_to_nodes/2,
-             log_to_nodes/3,
-             wait_until_nodes_ready/1,
-             wait_until_no_pending_changes/1]).
-
 confirm() ->
-    NumNodes = rt_config:get(num_nodes, 6),
-    ClusterASize = rt_config:get(cluster_a_size, 3),
-
-    lager:info("Deploy ~p nodes", [NumNodes]),
-    Conf = [
+    NumNodesWanted = 6,         %% total number of nodes needed
+    ClusterASize = 3,           %% how many to allocate to cluster A
+    NumKeysAOnly = 10000,       %% how many keys on A that are missing on B
+    NumKeysBoth = 10000,        %% number of common keys on both A and B
+    Conf = [                    %% riak configuration
             {riak_kv,
                 [
                  %% Specify fast building of AAE trees
@@ -35,126 +30,31 @@ confirm() ->
              ]}
            ],
 
-    Nodes = deploy_nodes(NumNodes, Conf),
+    %% build clusters
+    {ANodes, BNodes} = repl_aae_fullsync_util:make_clusters(NumNodesWanted, ClusterASize, Conf),
 
-    {ANodes, BNodes} = lists:split(ClusterASize, Nodes),
-    lager:info("ANodes: ~p", [ANodes]),
-    lager:info("BNodes: ~p", [BNodes]),
-
-    lager:info("Build cluster A"),
-    repl_util:make_cluster(ANodes),
-
-    lager:info("Build cluster B"),
-    repl_util:make_cluster(BNodes),
-
-    aae_fs_test(ANodes, BNodes, false),
+    %% run test
+    aae_fs_test(NumKeysAOnly, NumKeysBoth, ANodes, BNodes),
     pass.
 
-aae_fs_test([AFirst|_] = ANodes, [BFirst|_] = BNodes, Connected) ->
-
-    AllNodes = ANodes ++ BNodes,
-    log_to_nodes(AllNodes, "Starting AAE Fullsync test"),
-
+aae_fs_test(NumKeysAOnly, NumKeysBoth, ANodes, BNodes) ->
+    %% populate them with data
     TestHash =  list_to_binary([io_lib:format("~2.16.0b", [X]) ||
                 <<X>> <= erlang:md5(term_to_binary(os:timestamp()))]),
     TestBucket = <<TestHash/binary, "-systest_a">>,
+    repl_aae_fullsync_util:prepare_cluster_data(TestBucket, NumKeysAOnly, NumKeysBoth, ANodes, BNodes),
 
-    case Connected of
-        false ->
-            %% clusters are not connected, connect them
-
-            repl_util:name_cluster(AFirst, "A"),
-            repl_util:name_cluster(BFirst, "B"),
-
-            %% we'll need to wait for cluster names before continuing
-            rt:wait_until_ring_converged(ANodes),
-            rt:wait_until_ring_converged(BNodes),
-
-            lager:info("waiting for leader to converge on cluster A"),
-            ?assertEqual(ok, repl_util:wait_until_leader_converge(ANodes)),
-            lager:info("waiting for leader to converge on cluster B"),
-            ?assertEqual(ok, repl_util:wait_until_leader_converge(BNodes)),
-
-            %% get the leader for the first cluster
-            LeaderA = rpc:call(AFirst, riak_core_cluster_mgr, get_leader, []),
-
-            {ok, {_IP, Port}} = rpc:call(BFirst, application, get_env,
-                [riak_core, cluster_mgr]),
-
-            lager:info("connect cluster A:~p to B on port ~p", [LeaderA, Port]),
-            repl_util:connect_cluster(LeaderA, "127.0.0.1", Port),
-            ?assertEqual(ok, repl_util:wait_for_connection(LeaderA, "B"));
-
-        _ ->
-            lager:info("clusters should already be connected"),
-            lager:info("waiting for leader to converge on cluster A"),
-            ?assertEqual(ok, repl_util:wait_until_leader_converge(ANodes)),
-            lager:info("waiting for leader to converge on cluster B"),
-            ?assertEqual(ok, repl_util:wait_until_leader_converge(BNodes)),
-            %% get the leader for the first cluster
-            LeaderA = rpc:call(AFirst, riak_core_cluster_mgr, get_leader, []),
-            lager:info("Leader on cluster A is ~p", [LeaderA]),
-            lager:info("BFirst on cluster B is ~p", [BFirst]),
-            {ok, {_IP, Port}} = rpc:call(BFirst, application, get_env,
-                [riak_core, cluster_mgr]),
-            lager:info("B is ~p with port ~p", [BFirst, Port])
-    end,
-
-    %% make sure we are connected
-    lager:info("Wait for cluster connection A:~p -> B:~p:~p", [LeaderA, BFirst, Port]),
-    ?assertEqual(ok, repl_util:wait_for_connection(LeaderA, "B")),
-
-    %%---------------------------------------------------
-    %% TEST: write data, NOT replicated by RT or fullsync
-    %% keys: 1..NumKeysAOnly
-    %%---------------------------------------------------
-    NumKeysAOnly = 10000,
-    lager:info("Writing ~p keys to A(~p)", [NumKeysAOnly, AFirst]),
-    ?assertEqual([], repl_util:do_write(AFirst, 1, NumKeysAOnly, TestBucket, 2)),
-
-    %% check that the keys we wrote initially aren't replicated yet, because
-    %% we've disabled fullsync_on_connect
-    lager:info("Check keys written before repl was connected are not present"),
-    Res2 = rt:systest_read(BFirst, 1, NumKeysAOnly, TestBucket, 2),
-    ?assertEqual(NumKeysAOnly, length(Res2)),
-
-    %%-----------------------------------------------
-    %% TEST: write data, replicated by RT
-    %% keys: NumKeysAOnly+1..NumKeysAOnly+NumKeysBoth
-    %%-----------------------------------------------
-    NumKeysBoth = 10000,
-
-    %% Enable and start Real-time replication
-    repl_util:enable_realtime(LeaderA, "B"),
-    rt:wait_until_ring_converged(ANodes),
-    repl_util:start_realtime(LeaderA, "B"),
-    rt:wait_until_ring_converged(ANodes),
-
-    log_to_nodes(AllNodes, "Write data to A, verify replication to B via realtime"),
-    %% write some data on A
-    lager:info("Writing ~p more keys to A(~p)", [NumKeysBoth, LeaderA]),
-    ?assertEqual([], repl_util:do_write(LeaderA,
-                                        NumKeysAOnly+1,
-                                        NumKeysAOnly+NumKeysBoth,
-                                        TestBucket, 2)),
-
-    %% verify data is replicated to B
-    lager:info("Verify: Reading ~p keys written to ~p from ~p", [NumKeysBoth, LeaderA, BFirst]),
-    ?assertEqual(0, repl_util:wait_for_reads(BFirst,
-                                             NumKeysAOnly+1,
-                                             NumKeysAOnly+NumKeysBoth,
-                                             TestBucket, 2)),
+    AFirst = hd(ANodes),
+    BFirst = hd(BNodes),
+    AllNodes = ANodes ++ BNodes,
+    LeaderA = rpc:call(AFirst, riak_core_cluster_mgr, get_leader, []),
 
     %%---------------------------------------------------------
     %% TEST: fullsync, check that non-RT'd keys get repl'd to B
     %% keys: 1..NumKeysAOnly
     %%---------------------------------------------------------
 
-    %% wait for the AAE trees to be built so that we don't get a not_built error
-    repl_util:wait_until_aae_trees_built(ANodes),
-    repl_util:wait_until_aae_trees_built(BNodes),
-
-    log_to_nodes(AllNodes, "Test fullsync from cluster A leader ~p to cluster B", [LeaderA]),
+    rt:log_to_nodes(AllNodes, "Test fullsync from cluster A leader ~p to cluster B", [LeaderA]),
     lager:info("Test fullsync from cluster A leader ~p to cluster B", [LeaderA]),
     repl_util:enable_fullsync(LeaderA, "B"),
     rt:wait_until_ring_converged(ANodes),
@@ -162,7 +62,7 @@ aae_fs_test([AFirst|_] = ANodes, [BFirst|_] = BNodes, Connected) ->
     lager:info("Fullsync completed in ~p seconds", [Time/1000/1000]),
 
     %% verify data is replicated to B
-    log_to_nodes(AllNodes, "Verify: Reading ~p keys repl'd from A(~p) to B(~p)",
+    rt:log_to_nodes(AllNodes, "Verify: Reading ~p keys repl'd from A(~p) to B(~p)",
                  [NumKeysAOnly, LeaderA, BFirst]),
     lager:info("Verify: Reading ~p keys repl'd from A(~p) to B(~p)",
                [NumKeysAOnly, LeaderA, BFirst]),

--- a/tests/repl_aae_fullsync_bench.erl
+++ b/tests/repl_aae_fullsync_bench.erl
@@ -11,8 +11,8 @@
 confirm() ->
     NumNodesWanted = 6,         %% total number of nodes needed
     ClusterASize = 3,           %% how many to allocate to cluster A
-    NumKeysAOnly = 100000,      %% how many keys on A that are missing on B
-    NumKeysBoth = 900000,       %% number of common keys on both A and B
+    NumKeysAOnly = 5000,        %% how many keys on A that are missing on B
+    NumKeysBoth = 45000,        %% number of common keys on both A and B
     Conf = [                    %% riak configuration
             {riak_kv,
                 [

--- a/tests/repl_aae_fullsync_custom_n.erl
+++ b/tests/repl_aae_fullsync_custom_n.erl
@@ -4,9 +4,9 @@
 %% were replicated to the sink cluster.
 %%
 %% Specically, this test sets a custom N-value on the test bucket on the source cluster, which
-%% is going to break the fullsync. We don't yet handle AAE fullsync when bucket N values differ
-%% between the two clusters. This test would like to pass someday, but not until we handle
-%% the "not_responsible" reply during the hashtree compare.
+%% is going to break the AAE fullsync. We don't yet handle AAE fullsync when bucket N values differ
+%% between the two clusters. "not_responsible" is returned reply during the hashtree compare and
+%% the fullsync source module should restart the connection using the keylist strategy.
 
 -module(repl_aae_fullsync_custom_n).
 -behavior(riak_test).
@@ -72,10 +72,8 @@ aae_fs_test(NumKeysAOnly, NumKeysBoth, ANodes, BNodes) ->
     repl_util:enable_fullsync(LeaderA, "B"),
     rt:wait_until_ring_converged(ANodes),
 
-    %% This is not expected to complete until we fix the issue with handling "not_responsible"
-    %% in the AAE exchange protocol.
+    %% Start fullsync and wait for it to finish.
     {Time,_} = timer:tc(repl_util,start_and_wait_until_fullsync_complete,[LeaderA]),
-
     lager:info("Fullsync completed in ~p seconds", [Time/1000/1000]),
 
     %% verify data is replicated to B

--- a/tests/repl_aae_fullsync_util.erl
+++ b/tests/repl_aae_fullsync_util.erl
@@ -1,0 +1,109 @@
+%% @doc
+%% This module implements a riak_test to exercise the Active Anti-Entropy Fullsync replication.
+%% It sets up two clusters and starts a single fullsync worker for a single AAE tree.
+-module(repl_aae_fullsync_util).
+-export([make_clusters/3,
+        prepare_cluster_data/5]).
+-include_lib("eunit/include/eunit.hrl").
+
+-import(rt, [deploy_nodes/2,
+             join/2,
+             log_to_nodes/2,
+             log_to_nodes/3,
+             wait_until_nodes_ready/1,
+             wait_until_no_pending_changes/1]).
+
+make_clusters(NumNodesWanted, ClusterSize, Conf) ->
+    NumNodes = rt_config:get(num_nodes, NumNodesWanted),
+    ClusterASize = rt_config:get(cluster_a_size, ClusterSize),
+    lager:info("Deploy ~p nodes", [NumNodes]),
+    Nodes = deploy_nodes(NumNodes, Conf),
+
+    {ANodes, BNodes} = lists:split(ClusterASize, Nodes),
+    lager:info("ANodes: ~p", [ANodes]),
+    lager:info("BNodes: ~p", [BNodes]),
+
+    lager:info("Build cluster A"),
+    repl_util:make_cluster(ANodes),
+
+    lager:info("Build cluster B"),
+    repl_util:make_cluster(BNodes),
+    {ANodes, BNodes}.
+
+prepare_cluster_data(TestBucket, NumKeysAOnly, NumKeysBoth, [AFirst|_] = ANodes, [BFirst|_] = BNodes) ->
+    AllNodes = ANodes ++ BNodes,
+    log_to_nodes(AllNodes, "Starting AAE Fullsync test"),
+
+    %% clusters are not connected, connect them
+
+    repl_util:name_cluster(AFirst, "A"),
+    repl_util:name_cluster(BFirst, "B"),
+
+    %% we'll need to wait for cluster names before continuing
+    rt:wait_until_ring_converged(ANodes),
+    rt:wait_until_ring_converged(BNodes),
+
+    lager:info("waiting for leader to converge on cluster A"),
+    ?assertEqual(ok, repl_util:wait_until_leader_converge(ANodes)),
+    lager:info("waiting for leader to converge on cluster B"),
+    ?assertEqual(ok, repl_util:wait_until_leader_converge(BNodes)),
+
+    %% get the leader for the first cluster
+    LeaderA = rpc:call(AFirst, riak_core_cluster_mgr, get_leader, []),
+
+    {ok, {_IP, Port}} = rpc:call(BFirst, application, get_env,
+                                 [riak_core, cluster_mgr]),
+
+    lager:info("connect cluster A:~p to B on port ~p", [LeaderA, Port]),
+    repl_util:connect_cluster(LeaderA, "127.0.0.1", Port),
+    ?assertEqual(ok, repl_util:wait_for_connection(LeaderA, "B")),
+
+    %% make sure we are connected
+    lager:info("Wait for cluster connection A:~p -> B:~p:~p", [LeaderA, BFirst, Port]),
+    ?assertEqual(ok, repl_util:wait_for_connection(LeaderA, "B")),
+
+    %%---------------------------------------------------
+    %% TEST: write data, NOT replicated by RT or fullsync
+    %% keys: 1..NumKeysAOnly
+    %%---------------------------------------------------
+
+    lager:info("Writing ~p keys to A(~p)", [NumKeysAOnly, AFirst]),
+    ?assertEqual([], repl_util:do_write(AFirst, 1, NumKeysAOnly, TestBucket, 2)),
+
+    %% check that the keys we wrote initially aren't replicated yet, because
+    %% we've disabled fullsync_on_connect
+    lager:info("Check keys written before repl was connected are not present"),
+    Res2 = rt:systest_read(BFirst, 1, NumKeysAOnly, TestBucket, 2),
+    ?assertEqual(NumKeysAOnly, length(Res2)),
+
+    %%-----------------------------------------------
+    %% TEST: write data, replicated by RT
+    %% keys: NumKeysAOnly+1..NumKeysAOnly+NumKeysBoth
+    %%-----------------------------------------------
+    %% Enable and start Real-time replication
+    repl_util:enable_realtime(LeaderA, "B"),
+    rt:wait_until_ring_converged(ANodes),
+    repl_util:start_realtime(LeaderA, "B"),
+    rt:wait_until_ring_converged(ANodes),
+
+    log_to_nodes(AllNodes, "Write data to A, verify replication to B via realtime"),
+    %% write some data on A
+    lager:info("Writing ~p more keys to A(~p)", [NumKeysBoth, LeaderA]),
+    ?assertEqual([], repl_util:do_write(LeaderA,
+                                        NumKeysAOnly+1,
+                                        NumKeysAOnly+NumKeysBoth,
+                                        TestBucket, 2)),
+
+    %% verify data is replicated to B
+    lager:info("Verify: Reading ~p keys written to ~p from ~p", [NumKeysBoth, LeaderA, BFirst]),
+    ?assertEqual(0, repl_util:wait_for_reads(BFirst,
+                                             NumKeysAOnly+1,
+                                             NumKeysAOnly+NumKeysBoth,
+                                             TestBucket, 2)),
+
+    %% wait for the AAE trees to be built so that we don't get a not_built error
+    repl_util:wait_until_aae_trees_built(ANodes),
+    repl_util:wait_until_aae_trees_built(BNodes),
+
+    ok.
+


### PR DESCRIPTION
Refactor AAE fullsync tests so they share a common module.
Write a test for custom bucket n_val so that source and sink have differing values, which should now pass.

Works with riak_repl PR: https://github.com/basho/riak_repl/pull/291
