### PR TITLE
update riak_test_lager_backend for new msg tuple

### DIFF
--- a/src/riak_test_lager_backend.erl
+++ b/src/riak_test_lager_backend.erl
@@ -95,14 +95,15 @@ handle_event({log, Level, {Date, Time}, [LevelStr, Location, Message]}, %% lager
             [Time, " ", LevelStr, Message]
         end,
     {ok, State#state{log=[Log|Logs]}};
-handle_event({log, {lager_msg, Dest, _Meta, Level, Timestamp, Message}}, State) -> %% lager master
+handle_event({log, {lager_msg, Dest, _Meta, Level, DateTime, _Timestamp, Message}},
+             State) -> %% lager 2.0.0
     case lager_util:level_to_num(Level) of
         L when L =< State#state.level ->
-            handle_event({log, L, Timestamp, 
-                          [["[",atom_to_list(Level),"] "], " ", Message]}, 
+            handle_event({log, L, DateTime,
+                          [["[",atom_to_list(Level),"] "], " ", Message]},
                          State);
         L -> 
-            handle_event({log, Dest, L, Timestamp, 
+            handle_event({log, Dest, L, DateTime,
                           [["[",atom_to_list(Level),"] "], " ", Message]}, 
                          State)
     end;


### PR DESCRIPTION
The `riak_test_lager_backend` supports multiple versions of lager including lager 1.2.1/2.0.0. When support was added for the latter, the release was still a moving target (master was used). It seems the message structure has changed a bit.

This fixes this 1.4pre1 failure: http://giddyup.basho.com/#/projects/riak/scorecards/32/32-368-verify_busy_dist_port-centos-5-64/11327/artifacts/13721
