### PR TITLE
Add SSL to each proxy_get test

### DIFF
--- a/tests/replication2_pg.erl
+++ b/tests/replication2_pg.erl
@@ -393,7 +393,7 @@ test_pg_proxy(SSL) ->
 
 %% connect source + sink clusters, pg bidirectionally
 test_bidirectional_pg() ->
-    test_bidirectional_pg().
+    test_bidirectional_pg(false).
 
 test_bidirectional_pg(SSL) ->
     banner("test_bidirectional_pg", SSL),


### PR DESCRIPTION
All tests can be run with:

./riak_test -c foo -t replication2_pg:test_basic_pg_mode_repl13,
etc

-t replication2_pg:test_basic_pg_mode_mixed,
-t replication2_pg:test_12_pg_mode_repl12,
-t replication2_pg:test_12_pg_mode_repl_mixed,
-t replication2_pg:test_mixed_pg,
-t replication2_pg:test_multiple_sink_pg,
-t replication2_pg:test_bidirectional_pg,
-t replication2_pg:test_pg_proxy,

-t replication2_pg:test_basic_pg_mode_repl13_ssl,
-t replication2_pg:test_basic_pg_mode_mixed_ssl,
-t replication2_pg:test_12_pg_mode_repl12_ssl,
-t replication2_pg:test_12_pg_mode_repl_mixed_ssl,
-t replication2_pg:test_mixed_pg_ssl,
-t replication2_pg:test_multiple_sink_pg_ssl,
-t replication2_pg:test_bidirectional_pg_ssl,
-t replication2_pg:test_pg_proxy_ssl

heads up to @seancribbs, I'll submit a Giddyup issue if these additional SSL tests are +1'd and merged.
