### PR TITLE
verify_riak_object_reformat: use wait_until_capability

### DIFF
--- a/src/rt.erl
+++ b/src/rt.erl
@@ -37,6 +37,7 @@
          build_cluster/2,
          build_cluster/3,
          capability/2,
+         capability/3,
          check_singleton_node/1,
          claimant_according_to/1,
          clean_cluster/1,
@@ -110,6 +111,7 @@
          wait_until_all_members/1,
          wait_until_all_members/2,
          wait_until_capability/3,
+         wait_until_capability/4,
          wait_until_connected/1,
          wait_until_legacy_ringready/1,
          wait_until_owners_according_to/2,
@@ -631,10 +633,20 @@ capability(Node, all) ->
 capability(Node, Capability) ->
     rpc:call(Node, riak_core_capability, get, [Capability]).
 
+capability(Node, Capability, Default) ->
+    rpc:call(Node, riak_core_capability, get, [Capability, Default]).
+
 wait_until_capability(Node, Capability, Value) ->
     rt:wait_until(Node,
                   fun(_) ->
                           Value == capability(Node, Capability)
+                  end).
+
+wait_until_capability(Node, Capability, Value, Default) ->
+    rt:wait_until(Node,
+                  fun(_) ->
+                          Cap = capability(Node, Capability, Default),
+                          Value == Cap
                   end).
 
 wait_until_owners_according_to(Node, Nodes) ->

--- a/tests/verify_riak_object_reformat.erl
+++ b/tests/verify_riak_object_reformat.erl
@@ -28,39 +28,32 @@
 -export([confirm/0]).
 -include_lib("eunit/include/eunit.hrl").
 
+-define(N, 3).
+
 confirm() ->
     rt:update_app_config(all, [{riak_kv, [{object_format, v1}]}]),
-    N = 3,
     TestMetaData = riak_test_runner:metadata(),
     DowngradeVsn = proplists:get_value(upgrade_version, TestMetaData, previous),
-    Nodes = [Node1|_] = rt:build_cluster(N),
+    Nodes = [Node1|_] = rt:build_cluster(?N),
 
-    confirm_object_format(Nodes, v1),
+    [rt:wait_until_capability(N, {riak_kv, object_format}, v1, v0) || N <- Nodes],
 
     lager:info("Writing 100 keys in format v1 to ~p", [Node1]),
-    rt:systest_write(Node1, 100, N),
-    ?assertEqual([], rt:systest_read(Node1, 100, N)),
+    rt:systest_write(Node1, 100, ?N),
+    ?assertEqual([], rt:systest_read(Node1, 100, ?N)),
     lager:info("100 keys successfully written to ~p", [Node1]),
 
     %% TODO: introduce some handoff
     [begin
          lager:info("Reformatting objects and downgrading ~p", [Node]),
          run_reformat(Node, Node =:= Node1), %% wait for handoffs on one node, kill on rest
-         rt:wait_until_ring_converged(Nodes),
-         confirm_object_format(Nodes, v0),
+         [rt:wait_until_capability(N, {riak_kv, object_format}, v0, v0) || N <- Nodes],
          rt:upgrade(Node, DowngradeVsn), %% use upgrade to downgrade
          rt:wait_for_service(Node, riak_kv),
          lager:info("Ensuring keys still readable on ~p", [Node]),
-         ?assertEqual([], rt:systest_read(Node, 100, N))
+         ?assertEqual([], rt:systest_read(Node, 100, ?N))
      end || Node <- Nodes],
     ok.
-
-confirm_object_format(Nodes, Version) when is_list(Nodes) ->
-    [confirm_object_format(Node, Version) || Node <- Nodes];
-confirm_object_format(Node, Version) ->
-    ?assertEqual({Node, Version},
-                 {Node,
-                  rpc:call(Node, riak_core_capability, get, [{riak_kv, object_format}, v0])}).
 
 run_reformat(Node, KillHandoffs) ->
     {_Success, _Ignore, Error} = rpc:call(Node,


### PR DESCRIPTION
adds `rt:capability/3` and `rt:wait_until_capability/4` that can take default capability value (using `riak_core_capability:get/2`).
