### PR TITLE
Test for fullsync's successful_exists status item

### DIFF
--- a/tests/replication2.erl
+++ b/tests/replication2.erl
@@ -135,6 +135,11 @@ replication([AFirst|_] = ANodes, [BFirst|_] = BNodes, Connected) ->
             log_to_nodes(AllNodes, "Test fullsync with leader ~p", [LeaderA]),
             repl_util:start_and_wait_until_fullsync_complete(LeaderA),
 
+            %% check that the number of successful FS source exists matches the number of partitions
+            NumExits = repl_util:get_fs_coord_status_item(LeaderA, "B", successful_exits),
+            NumPartitions = repl_util:num_partitions(LeaderA),
+            ?assertEqual(NumPartitions, NumExits),
+
             lager:info("Check keys written before repl was connected are present"),
             ?assertEqual(0, repl_util:wait_for_reads(BFirst, 1, 200, TestBucket, 2));
         _ ->


### PR DESCRIPTION
- After a fullsync, make sure that the numner of successful exists equals the number of partitions, since each partition should have one successful fullsync source process exit.
- We could extend this test to handle the parts of replication2 that have down nodes in the future.
- Added a utility function to get the number of partitions from a node, plus a function to get fullsync status items.
- Test passes with changes from branch cet-successful-exists-fix

Requires PR https://github.com/basho/riak_repl/pull/310
