### PR TITLE
Fix another rt_config refactor victim

### DIFF
--- a/tests/verify_backup_restore.erl
+++ b/tests/verify_backup_restore.erl
@@ -37,7 +37,7 @@
 
 confirm() ->
     lager:info("Building cluster of ~p nodes", [?NUM_NODES]),
-    SpamDir = rt:config_or_os_env(spam_dir),
+    SpamDir = rt_config:config_or_os_env(spam_dir),
     Config = [{riak_search, [{enabled, true}]}],
     [Node0 | _RestNodes] = Nodes = rt:build_cluster(?NUM_NODES, Config),
     rt:enable_search_hook(Node0, ?SEARCH_BUCKET),


### PR DESCRIPTION
Fixing another failing test due to rt_config refactor. /cc @seancribbs 
Sorry, I should have grepped the code before I sent the other PR out. This seems to be the only other one with this same rt:config ->rt_config:config (yodawg) problem
