### PR TITLE
Wait until shutdown for at least 5mins

### DIFF
--- a/src/rt.erl
+++ b/src/rt.erl
@@ -599,7 +599,7 @@ wait_until_unpingable(Node) ->
     %% riak has stopped. Riak stop should only take about 5 minutes before its timeouts kill
     %% the process. This wait should at least wait that long.
     Delay = rt_config:get(rt_retry_delay),
-    Retry = 360000 div Delay,
+    Retry = lists:max([360000, rt_config:get(rt_max_wait_time)]) div Delay,
     ?assertEqual(ok, wait_until(Node, F, Retry, Delay, TimeoutFun)),
     ok.
 


### PR DESCRIPTION
Before, the timeout was kind of hardcoded to 5 mins. The intention is
that it should follow the general wait timeout, but not be _under_ 5
minutes. This should fix that.
