### PR TITLE
Fix race checking logs for busy dist port

### DIFF
--- a/tests/verify_busy_dist_port.erl
+++ b/tests/verify_busy_dist_port.erl
@@ -75,19 +75,28 @@ confirm() ->
                         [])
     end,
 
-    Logs = rpc:call(Node1, riak_test_lager_backend, get_logs, []),
-    Success = try re:run(Logs, "monitor busy_dist_port .*#Port", []) of
-                  {match, _} ->
-                      lager:info("found busy_dist_port message in log", []),
-                      true;
-                  nomatch -> 
-                      lager:error("busy_dist_port message not found in log", []),
-                      false
-              catch
-                  Err:Reason ->
-                      lager:error("busy_dist_port re:run failed w/ ~p: ~p", [Err, Reason]),
-                      false
-              end,
+    lager:info("Verifying busy_dist_port message ended up in the log"),
+    CheckLogFun = fun(Node) ->
+            Logs = rpc:call(Node, riak_test_lager_backend, get_logs, []),
+            try case re:run(Logs, "monitor busy_dist_port .*#Port", []) of
+                    {match, _} -> true;
+                    nomatch    -> false
+                end
+            catch
+                Err:Reason ->
+                    lager:error("busy_dist_port re:run failed w/ ~p: ~p", [Err, Reason]),
+                    false
+            end
+    end,
+
+    Success = case rt:wait_until(Node1, CheckLogFun) of
+        ok ->
+            lager:info("found busy_dist_port message in log", []),
+            true;
+        _ ->
+            lager:error("busy_dist_port message not found in log", []),
+            false
+    end,
 
     lager:info("continuing node 2 (~p) pid ~s", [Node2, OsPid]),
     %% NOTE: this call must be executed on the OS running Node2 in order to unpause it


### PR DESCRIPTION
The test detects the busy dist port event, and immediately fetches the
logs and parses them looking for it in the output. But it's failing
because the message appears an instant after the logs are fetched.
This changes it so it will retry a few times as we do with most things.
