### PR TITLE
Remove riaknostic node connection check

### DIFF
--- a/tests/riaknostic_rt.erl
+++ b/tests/riaknostic_rt.erl
@@ -40,7 +40,6 @@ confirm() ->
     check_riaknostic_usage(Node1),
     check_riaknostic_command_list(Node1),
     check_riaknostic_log_levels(Node1),
-    check_riaknostic_conn_failure(Node1),
 
     %% Done!
     lager:info("Test riaknostic: PASS"),
@@ -107,11 +106,3 @@ check_riaknostic_log_levels(Node) ->
     ?assert(rt:str(RiaknosticOut, "[debug]")),
     ok.
 
-%% Check that a connection failure message is output if node is stopped
-check_riaknostic_conn_failure(Node) ->
-    %% Check node conn failure when stopped
-    lager:info("**  Riaknostic warns of node connection failure when stopped"),
-    rt:stop_and_wait(Node),
-    {ok, RiaknosticOut} = rt:admin(Node, ["diag"]),
-    ?assert(rt:str(RiaknosticOut, "[warning] Could not connect")),
-    ok.


### PR DESCRIPTION
Riaknostic used to be a separate app, but it is now embedded with Riak,
so it doesn't make sense to check for tool output if the node is down,
as that mean riaknostic is not available either.
