### PR TITLE
retry proxy_get test if custom options fail

### DIFF
--- a/tests/replication2_pg.erl
+++ b/tests/replication2_pg.erl
@@ -249,8 +249,10 @@ test_basic_pg(Mode, SSL) ->
             riakc_obj:get_value(PGResult3Value);
         {error, notfound} ->
             RetryOptions = [{n_val, 1}],
-            {ok, PGResult4Value} = riak_repl_pb_api:get(PidC,Bucket,KeyA,CidA,RetryOptions),
-            riakc_obj:get_value(PGResult4Value);
+            case riak_repl_pb_api:get(PidC,Bucket,KeyA,CidA,RetryOptions) of
+                {ok, PGResult4Value} -> riakc_obj:get_value(PGResult4Value);
+                UnknownResult -> UnknownResult
+            end;
         UnknownResult ->
             %% welp, we might have been expecting a notfound, but we got
             %% something else.


### PR DESCRIPTION
see http://giddyup.basho.com/#/projects/riak_ee/scorecards/38/38-1088-replication2_pg:test_basic_pg_mode_mixed_ssl-freebsd-9-64/15727/artifacts/105785
