### PR TITLE
update verify_secondary_index_reformat for 1.4

### DIFF
--- a/tests/verify_secondary_index_reformat.erl
+++ b/tests/verify_secondary_index_reformat.erl
@@ -23,7 +23,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 confirm() ->
-    [Node] = rt:build_cluster([previous]),
+    [Node] = rt:build_cluster([legacy]),
     rt:wait_until_nodes_ready([Node]),
 
     check_fixed_index_statuses(Node, undefined),
@@ -63,7 +63,7 @@ confirm() ->
                                               1000000000000,
                                               TestIdxValue),
     lager:info("found keys: ~p", [Results]),
-    ?assertEqual([TestKey], Results),
+    ?assertEqual({keys, [TestKey]}, Results),
 
     check_fixed_index_statuses(Node, true),
 


### PR DESCRIPTION
- change to upgrade from legacy node. previous version node now supports
  correct index format
- adjust for change in `get_index` in pb client
