### PR TITLE
Change get_version in rt_cs_dev harness to return proper version

### DIFF
--- a/src/rt_cs_dev.erl
+++ b/src/rt_cs_dev.erl
@@ -446,7 +446,7 @@ set_backend(Backend) ->
     get_backends().
 
 get_version() ->
-    case file:read_file(relpath(current) ++ "/VERSION") of
+    case file:read_file(relpath(cs_current) ++ "/VERSION") of
         {error, enoent} -> unknown;
         {ok, Version} -> Version
     end.


### PR DESCRIPTION
Make the rt_cs_dev harness return the version of RiakCS to use instead of the
Riak version.
