### PR TITLE
Upgrade to lager 2.0 and remove some lager 2.0 API abuse

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -8,7 +8,7 @@
            warnings_as_errors, {parse_transform, lager_transform}]}.
 
 {deps, [
-        {lager, ".*", {git, "git://github.com/basho/lager", {tag, "1.2.2"}}},
+        {lager, ".*", {git, "git://github.com/basho/lager", {tag, "2.0.0"}}},
         {getopt, ".*", {git, "git://github.com/jcomellas/getopt", {tag, "v0.4"}}},
         {meck, ".*", {git, "git://github.com/eproxus/meck"}},
         {mapred_verify, ".*", {git, "git://github.com/basho/mapred_verify"}},
@@ -17,7 +17,7 @@
         {kvc, "1.3.0", {git, "https://github.com/etrepum/kvc", {tag, "v1.3.0"}}}
        ]}.
 
-{escript_incl_apps, [lager, getopt, riakhttpc, riakc, ibrowse, mochiweb, kvc]}.
+{escript_incl_apps, [goldrush, lager, getopt, riakhttpc, riakc, ibrowse, mochiweb, kvc]}.
 {escript_emu_args, "%%! -escript main riak_test_escript +K true +P 10000 -env ERL_MAX_PORTS 10000\n"}.
 {plugin_dir, "src"}.
 {plugins, [rebar_riak_test_plugin]}.

--- a/src/riak_test_lager_backend.erl
+++ b/src/riak_test_lager_backend.erl
@@ -53,17 +53,13 @@ get_logs() ->
 %% @private
 %% @doc Initializes the event handler
 init(Level) when is_atom(Level) ->
-    case lists:member(Level, ?LEVELS) of
-        true ->
-            {ok, #state{level=lager_util:level_to_num(Level), verbose=false}};
-        _ ->
-            {error, bad_log_level}
-    end;
+    init([Level, false]);
 init([Level, Verbose]) ->
-    case lists:member(Level, ?LEVELS) of
-        true ->
-            {ok, #state{level=lager_util:level_to_num(Level), verbose=Verbose}};
-        _ ->
+    try parse_level(Level) of
+        Lvl ->
+            {ok, #state{level=Lvl, verbose=Verbose}}
+    catch
+        _:_ ->
             {error, bad_log_level}
     end.
 
@@ -95,17 +91,29 @@ handle_event({log, Level, {Date, Time}, [LevelStr, Location, Message]}, %% lager
             [Time, " ", LevelStr, Message]
         end,
     {ok, State#state{log=[Log|Logs]}};
-handle_event({log, {lager_msg, Dest, _Meta, Level, DateTime, _Timestamp, Message}},
-             State) -> %% lager 2.0.0
-    case lager_util:level_to_num(Level) of
-        L when L =< State#state.level ->
-            handle_event({log, L, DateTime,
-                          [["[",atom_to_list(Level),"] "], " ", Message]},
-                         State);
-        L -> 
-            handle_event({log, Dest, L, DateTime,
-                          [["[",atom_to_list(Level),"] "], " ", Message]}, 
-                         State)
+handle_event({log, Msg},
+  #state{level=Level, verbose=Verbose, log = Logs} = State) -> %% lager 2.0.0
+    case lager_util:is_loggable(Msg, Level, ?MODULE) of
+        true ->
+            {Date, Time} = lager_msg:datetime(Msg),
+            LevelStr = atom_to_list(lager_msg:severity(Msg)),
+            Message = lager_msg:message(Msg),
+            Log = case Verbose of
+                true ->
+                    Location = lager_default_formatter:format(Msg, [
+                                {pid, ""},
+                                {module, [
+                                        {pid, ["@"], ""},
+                                        module,
+                                        {function, [":", function], ""},
+                                        {line, [":",line], ""}], ""}]),
+                    [Date, " ", Time, " ", LevelStr, Location, Message];
+                _ ->
+                    [Time, " ", LevelStr, Message]
+            end,
+            {ok, State#state{log=[Log|Logs]}};
+        false ->
+            {ok, State}
     end;
 handle_event(Event, State) ->
     {ok, State#state{log = [Event|State#state.log]}}.
@@ -116,10 +124,11 @@ handle_event(Event, State) ->
 handle_call(get_loglevel, #state{level=Level} = State) ->
     {ok, Level, State};
 handle_call({set_loglevel, Level}, State) ->
-    case lists:member(Level, ?LEVELS) of
-        true ->
-            {ok, ok, State#state{level=lager_util:level_to_num(Level)}};
-        _ ->
+    try parse_level(Level) of
+        Lvl ->
+            {ok, ok, State#state{level=Lvl}}
+    catch
+        _:_ ->
             {ok, {error, bad_log_level}, State}
     end;
 handle_call(get_logs, #state{log = Logs} = State) ->
@@ -143,6 +152,16 @@ code_change(_OldVsn, State, _Extra) ->
 %% @doc gen_event callback, does nothing.
 terminate(_Reason, #state{log=Logs}) ->
     {ok, lists:reverse(Logs)}.
+
+parse_level(Level) ->
+    try lager_util:config_to_mask(Level) of
+        Res ->
+            Res
+    catch
+        error:undef ->
+            %% must be lager < 2.0
+            lager_util:level_to_num(Level)
+    end.
 
 -ifdef(TEST).
 


### PR DESCRIPTION
Riak, EE and CS all use lager 2.0 now, riak_test should too.

cc @rzezeski 
