### PR TITLE
Replace naive URL encoding with ibrowse call

### DIFF
--- a/tests/secondary_index_tests.erl
+++ b/tests/secondary_index_tests.erl
@@ -187,9 +187,14 @@ opts_to_qstring([Opt|Rest], QString) ->
 opt_to_string(Sep, {Name, Value}) when is_integer(Value) ->
         io_lib:format(Sep++"~s=~p", [Name, Value]);
 opt_to_string(Sep, {Name, Value})->
-    io_lib:format(Sep++"~s=~s", [Name, Value]);
+    io_lib:format(Sep++"~s=~s", [Name, url_encode(Value)]);
 opt_to_string(Sep, Name) ->
     io_lib:format(Sep++"~s=~s", [Name, true]).
+
+url_encode(Val) when is_binary(Val) ->
+    url_encode(binary_to_list(Val));
+url_encode(Val) ->
+    ibrowse_lib:url_encode(Val).
 
 http_stream_loop(Ref, Acc) ->
     receive {http, {Ref, stream_end, _Headers}} ->


### PR DESCRIPTION
The verify_2i_limit tests was failing due to using the continuation code
in the URL without encoding.

http://giddyup.basho.com/#/projects/riak_ee/scorecards/43/43-948-verify_2i_limit-ubuntu-1004-64-memory/18152/artifacts/162041
