### PR TITLE
Update PB get index call

### DIFF
--- a/tests/verify_secondary_index_reformat.erl
+++ b/tests/verify_secondary_index_reformat.erl
@@ -21,6 +21,7 @@
 -behaviour(riak_test).
 -export([confirm/0]).
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("riakc/include/riakc.hrl").
 
 confirm() ->
     [Node] = rt:build_cluster([legacy]),
@@ -57,13 +58,13 @@ confirm() ->
     {3, 0, 0} = rpc:call(Node, riak_kv_util, fix_incorrect_index_entries, []),
 
     Client1 = rt:pbc(Node),
-    {ok, Results} = riakc_pb_socket:get_index(Client1,
-                                              TestBucket,
-                                              TestIndex,
-                                              1000000000000,
-                                              TestIdxValue),
-    lager:info("found keys: ~p", [Results]),
-    ?assertEqual({keys, [TestKey]}, Results),
+    Results = riakc_pb_socket:get_index(Client1, TestBucket,
+                                        TestIndex, 1000000000000,
+                                        TestIdxValue),
+    ?assertMatch({ok, #index_results_v1{}}, Results),
+    {ok, ?INDEX_RESULTS{keys=ResultKeys}} = Results,
+    lager:info("found keys: ~p", [ResultKeys]),
+    ?assertEqual([TestKey], ResultKeys),
 
     check_fixed_index_statuses(Node, true),
 


### PR DESCRIPTION
Updated to use newer index results record like the other 2i tests. It
was failing before this as it was using the old tuple result format.

http://giddyup.basho.com/#/projects/riak_ee/scorecards/43/43-571-verify_secondary_index_reformat-ubuntu-1004-64-eleveldb/18223/artifacts/163436

/cc @rzezeski 
