### PR TITLE
Add post-giddyup webhooks

### DIFF
--- a/include/rt.hrl
+++ b/include/rt.hrl
@@ -1,0 +1,25 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-record(rt_webhook, {
+        name :: string(),
+        url :: string(),
+        headers=[] :: [{atom(), string()}]
+        }).


### PR DESCRIPTION
Each test result plus the related Giddy Up information is posted to each
webhook in the configuration. The first user is Bishop, so it can keep
track of tests as they happen and annoy the hell out of Engineering.
An example configuration:

``` erlang
    ,{webhooks, [
                [{name, "Bishop"},
                 {url, "http://basho-engbot.herokuapp.com/"}]
                ]}
```
