### PR TITLE
Add ability to upgrade and update app cfg

### DIFF
--- a/src/rt.erl
+++ b/src/rt.erl
@@ -107,6 +107,7 @@
          teardown/0,
          update_app_config/2,
          upgrade/2,
+         upgrade/3,
          versions/0,
          wait_for_cluster_service/2,
          wait_for_cmd/1,
@@ -268,9 +269,14 @@ stop_and_wait(Node) ->
     stop(Node),
     ?assertEqual(ok, wait_until_unpingable(Node)).
 
-%% @doc Upgrade a Riak `Node' to a specific version
+%% @doc Upgrade a Riak `Node' to the specified `NewVersion'.
 upgrade(Node, NewVersion) ->
     ?HARNESS:upgrade(Node, NewVersion).
+
+%% @doc Upgrade a Riak `Node' to the specified `NewVersion' and update
+%% the config based on entries in `Config'.
+upgrade(Node, NewVersion, Config) ->
+    ?HARNESS:upgrade(Node, NewVersion, Config).
 
 %% @doc Upgrade a Riak node to a specific version using the alternate
 %%      leave/upgrade/rejoin approach

--- a/src/rtdev.erl
+++ b/src/rtdev.erl
@@ -113,6 +113,9 @@ relpath(_, _) ->
     throw("Version requested but only one path provided").
 
 upgrade(Node, NewVersion) ->
+    upgrade(Node, NewVersion, same).
+
+upgrade(Node, NewVersion, Config) ->
     N = node_id(Node),
     Version = node_version(N),
     lager:info("Upgrading ~p : ~p -> ~p", [Node, Version, NewVersion]),
@@ -135,6 +138,10 @@ upgrade(Node, NewVersion) ->
     end || Cmd <- Commands],
     VersionMap = orddict:store(N, NewVersion, rt_config:get(rt_versions)),
     rt_config:set(rt_versions, VersionMap),
+    case Config of
+	same -> ok;
+	_ -> update_app_config(Node, Config)
+    end,
     start(Node),
     rt:wait_until_pingable(Node),
     ok.


### PR DESCRIPTION
Add the ability to upgrade node and update its app.config in one go.
This is useful when testing upgrade path on Yokozuna where the old
app.config should be copied over but modifications should also be made
before restarting the node.
