### PR TITLE
Add test for corrupted data coming out of the backend

### DIFF
--- a/intercepts/riak_kv_bitcask_backend_intercepts.erl
+++ b/intercepts/riak_kv_bitcask_backend_intercepts.erl
@@ -1,0 +1,30 @@
+-module(riak_kv_bitcask_backend_intercepts).
+-compile(export_all).
+-include("intercept.hrl").
+
+-define(M, riak_kv_bitcask_backend_orig).
+
+corrupting_put(Bucket, Key, IndexSpecs, Val0, ModState) ->
+    Val = 
+        case random:uniform(20) of 
+            10 -> 
+                corrupt_binary(Val0);
+            _ -> Val0
+        end,
+    ?M:put_orig(Bucket, Key, IndexSpecs, Val, ModState).
+
+corrupting_get(Bucket, Key, ModState) ->
+    case ?M:get_orig(Bucket, Key, ModState) of
+        {ok, BinVal0, UpdModState} ->
+            BinVal =
+                case random:uniform(20) of 
+                    10 ->
+                        corrupt_binary(BinVal0);
+                    _ -> BinVal0
+                end,
+            {ok, BinVal, UpdModState};
+        Else -> Else
+    end.
+            
+corrupt_binary(O) ->
+    crypto:rand_bytes(byte_size(O)).

--- a/intercepts/riak_kv_eleveldb_backend_intercepts.erl
+++ b/intercepts/riak_kv_eleveldb_backend_intercepts.erl
@@ -1,0 +1,30 @@
+-module(riak_kv_eleveldb_backend_intercepts).
+-compile(export_all).
+-include("intercept.hrl").
+
+-define(M, riak_kv_eleveldb_backend_orig).
+
+corrupting_put(Bucket, Key, IndexSpecs, Val0, ModState) ->
+    Val = 
+        case random:uniform(20) of 
+            10 -> 
+                corrupt_binary(Val0);
+            _ -> Val0
+        end,
+    ?M:put_orig(Bucket, Key, IndexSpecs, Val, ModState).
+
+corrupting_get(Bucket, Key, ModState) ->
+    case ?M:get_orig(Bucket, Key, ModState) of
+        {ok, BinVal0, UpdModState} ->
+            BinVal =
+                case random:uniform(20) of 
+                    10 ->
+                        corrupt_binary(BinVal0);
+                    _ -> BinVal0
+                end,
+            {ok, BinVal, UpdModState};
+        Else -> Else
+    end.
+            
+corrupt_binary(O) ->
+    crypto:rand_bytes(byte_size(O)).

--- a/intercepts/riak_kv_vnode_intercepts.erl
+++ b/intercepts/riak_kv_vnode_intercepts.erl
@@ -77,3 +77,15 @@ error_do_put(Sender, BKey, RObj, ReqId, StartTime, Options, State) ->
                     ?M:do_put_orig(Sender, BKey, RObj, ReqId, StartTime, Options, State)
             end
     end.
+
+corrupting_handle_handoff_data(BinObj0, State) ->
+    BinObj =
+        case random:uniform(20) of
+            10 ->
+                corrupt_binary(BinObj0);
+            _ -> BinObj0
+        end,
+    ?M:handle_handoff_data_orig(BinObj, State).
+
+corrupt_binary(O) ->
+    crypto:rand_bytes(byte_size(O)).

--- a/tests/verify_corruption_filtering.erl
+++ b/tests/verify_corruption_filtering.erl
@@ -1,0 +1,121 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2012 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(verify_corruption_filtering).
+-behavior(riak_test).
+-export([confirm/0]).
+-include_lib("eunit/include/eunit.hrl").
+
+-import(rt, [build_cluster/1,
+             leave/1,
+             wait_until_unpingable/1,
+             status_of_according_to/2,
+             remove/2]).
+%% Test plan:
+%%   - build a 2-node cluster
+%%   - load values
+%%   - intercept the backend so that it sometimes returns 
+%%     bad data
+%%   - test puts, gets, folds, and handoff.
+
+
+
+
+confirm() ->
+    Nodes = build_cluster(2),
+    [Node1, Node2] = Nodes,
+    rt:wait_until_pingable(Node2),
+
+    load_cluster(Node1),
+   
+    lager:info("Cluster loaded"),
+
+    case rt:config(rt_backend, undefined) of 
+        riak_kv_eleveldb_backend ->
+            load_level_intercepts(Nodes);
+        _ ->
+            load_bitcask_intercepts(Nodes)
+    end,
+    
+    get_put_mix(Node1),
+
+    %% Have node2 leave
+    lager:info("Have ~p leave", [Node2]),
+    leave(Node2),
+    ?assertEqual(ok, wait_until_unpingable(Node2)),
+             
+    %% we'll never get here or timeout if this issue 
+    %% isn't fixed.
+    pass.
+
+get_put_mix(Node) ->
+    PB = rt:pbc(Node),
+    [begin
+         Key = random:uniform(1000),
+         case random:uniform(2) of
+             1 ->
+                 X = crypto:rand_bytes(512),
+                 riakc_pb_socket:put(PB, 
+                                     riakc_obj:new(<<"foo">>, <<Key>>,
+                                                   X));
+             2 ->
+                 case riakc_pb_socket:get(PB, <<"foo">>, <<Key>>) of
+                     {error, notfound} ->
+                         ok;
+                     {error, Reason} ->
+                         lager:error("got unexpected return: ~p",
+                                     [Reason]),
+                         throw(Reason);
+                     {ok, _O} -> ok;
+                     Else -> throw(Else)
+                 end
+         end
+     end 
+    || _ <- lists:seq(1, 2000)].
+
+load_cluster(Node) -> 
+    PB = rt:pbc(Node),
+    [riakc_pb_socket:put(PB, 
+                         riakc_obj:new(<<"foo">>, <<X>>,
+                                       <<X:4096>>))
+     || X <- lists:seq(1,1000)].
+
+load_level_intercepts(Nodes) ->
+    [begin
+         rt_intercept:add(Node, {riak_kv_eleveldb_backend,
+                                 [{{get, 3}, corrupting_get}]}),
+         rt_intercept:add(Node, {riak_kv_eleveldb_backend,
+                                 [{{put, 5}, corrupting_put}]}),
+         rt_intercept:add(Node, {riak_kv_vnode,
+                                 [{{handle_handoff_data, 2}, 
+                                 corrupting_handle_handoff_data}]})
+     end 
+     || Node <- Nodes].
+
+load_bitcask_intercepts(Nodes) ->
+    [begin
+         rt_intercept:add(Node, {riak_kv_bitcask_backend,
+                                 [{{get, 3}, corrupting_get}]}),
+         rt_intercept:add(Node, {riak_kv_bitcask_backend,
+                                 [{{put, 5}, corrupting_put}]}),
+         rt_intercept:add(Node, {riak_kv_vnode,
+                                 [{{handle_handoff_data, 2}, 
+                                   corrupting_handle_handoff_data}]})
+     end 
+     || Node <- Nodes].


### PR DESCRIPTION
intercepts gets and puts and handle_handoff_data calls and randomly corrupts the data coming out of or going into them.

Then tries to do gets and puts and forces handoff.

The test will never complete due to disconnection errors and the leave will time out.  Additionally the logs will be filled with crashes.

With proper filtering in place, you get discard messages, but no crashes, and the test completes.
