### PR TITLE
Test for RTQ mailbox overload handling

### DIFF
--- a/intercepts/riak_repl2_rtq_intercepts.erl
+++ b/intercepts/riak_repl2_rtq_intercepts.erl
@@ -12,7 +12,7 @@ slow_trim_q(State) ->
     %% This hideousness is necessary in order to have this intercept sleep only 
     %% on the first iteration. With hope, it causes the message queue of the
     %% RTQ to spike enough to initiate overload handling, then subsequently
-    %% allow the queue to drain, overload flipped off, and the writes to complete.
+    %% allows the queue to drain, overload to flip off, and the writes to complete.
     case get(hosed) of 
     	undefined ->
     	    put(hosed, true);

--- a/tests/repl_rt_overload.erl
+++ b/tests/repl_rt_overload.erl
@@ -5,7 +5,7 @@
 %% -------------------------------------------------------------------
 -module(repl_rt_overload).
 -behaviour(riak_test).
--export([confirm/0, check_size/1, slow_write_calls/1, slow_trim_q/1]).
+-export([confirm/0, check_size/1, slow_trim_q/1]).
 -include_lib("eunit/include/eunit.hrl").
 
 -define(RTSINK_MAX_WORKERS, 1).
@@ -166,11 +166,11 @@ load_intercepts(Node) ->
     rt_intercept:load_code(Node).
 
 %% @doc Slow down handle_info (write calls)
-slow_write_calls(Node) ->
-    %% disable forwarding of the heartbeat function call
-    lager:info("Slowing down sink do_write calls on ~p", [Node]),
-    rt_intercept:add(Node, {riak_repl2_rtsink_conn,
-                            [{{handle_info, 2}, slow_handle_info}]}).
+% slow_write_calls(Node) ->
+%     %% disable forwarding of the heartbeat function call
+%   lager:info("Slowing down sink do_write calls on ~p", [Node]),
+%    rt_intercept:add(Node, {riak_repl2_rtsink_conn,
+%                            [{{handle_info, 2}, slow_handle_info}]}).
 
 slow_trim_q(Node) ->
     lager:info("Slowing down trim_q calls on ~p", [Node]),


### PR DESCRIPTION
#### Related PR

https://github.com/basho/riak_repl/pull/372
#### Description

This test attempts to force overload handling to turn on both by configuring the sink with few resources (max_workers, max_pending = 1), and by introducing a run-once intercept on trim_q/1 on the source RTQ that introduces a long sleep. This gives time for the mailbox on the source RTQ to start to back up with traffic running, initiate overload handling, and drop some push messages. On subsequent calls to the intercept, no sleep is done, so the backlog should drain.

Reads from the sink should reflect the drops. The test checks to make sure there are _some_ drops (it does not do exact accounting), and displays the message_queue size on the source while the test is running, for visual inspection.
