### PR TITLE
Faster wait_for_cmd that preserves order

### DIFF
--- a/src/rtdev.erl
+++ b/src/rtdev.erl
@@ -499,9 +499,6 @@ wait_for_cmd(Port) ->
     rt:wait_until(node(),
                   fun(_) ->
                           receive
-                              {Port, Msg={data, _}} ->
-                                  self() ! {Port, Msg},
-                                  false;
                               {Port, Msg={exit_status, _}} ->
                                   catch port_close(Port),
                                   self() ! {Port, Msg},


### PR DESCRIPTION
Remove the receive clause for port data.  This can cause
`wait_for_cmd` to needlessly loop through all stdout msgs before
getting to the port exit.  By just doing selective recv on the exit
msg Erlang will implicit use the "save queue" and place the data msgs
back on the mailbox in the original order of arrival.  In fact, the
previous method could rearrange the stdout ordering.
