### PR TITLE
Tweaked logic in get_backend to use node_package's latest chkconfig

### DIFF
--- a/src/rtdev.erl
+++ b/src/rtdev.erl
@@ -249,20 +249,15 @@ get_backend(AppConfig) ->
             Path = filename:join(lists:reverse(RPath)),
             %% Why chkconfig? It generates an app.config from cuttlefish
             %% without starting riak.
-            Output = hd(lists:reverse(string:tokens(
+            ConfigFileOutputLine = lists:last(string:tokens(
                 run_riak(list_to_integer(N), Path, "chkconfig"),
                 "\n"
-            ))),
+            )),
 
-            Files = lists:filter(
-                fun(PotentialFileName) ->
-                    case filename:extension(PotentialFileName) of
-                        ".config" -> true;
-                        _X ->
-                            false
-                    end  
-                end, 
-                string:tokens(Output, "\s")),             
+            %% ConfigFileOutputLine looks like this:
+            %% -config /path/to/app.config -args_file /path/to/vm.args
+            Files =[ Filename || Filename <- string:tokens(ConfigFileOutputLine, "\s"), 
+                                 ".config" == filename:extension(Filename) ],           
 
             hd(Files)
     end,


### PR DESCRIPTION
no longer assuming the name of the config file. Node_package now gives us an actual filename for free!
