### PR TITLE
Use python client version 2.0.1

### DIFF
--- a/tests/client_python_verify.erl
+++ b/tests/client_python_verify.erl
@@ -3,8 +3,7 @@
 -export([confirm/0]).
 -include_lib("eunit/include/eunit.hrl").
 
-%% @todo set this to 1.5.2 or greater, once that's released
--define(PYTHON_CLIENT_TAG, "1.5-stable").
+-define(PYTHON_CLIENT_TAG, "2.0.1").
 -define(PYTHON_CHECKOUT, filename:join([rt_config:get(rt_scratch_dir), "riak-python-client"])).
 -define(PYTHON_GIT_URL, "git://github.com/basho/riak-python-client.git").
 
@@ -64,10 +63,7 @@ prereqs() ->
     rt_local:stream_cmd(Cmd),
 
     lager:info("[PREREQ] Resetting python client to tag '~s'", [?PYTHON_CLIENT_TAG]),
-    %% @todo below is how to reset to a tag, use that when 1.5.2 is available
-    %%TagCmd = io_lib:format("git reset --hard ~s", [?PYTHON_CLIENT_TAG]),
-    rt_local:stream_cmd("git reset --hard", [{cd, ?PYTHON_CHECKOUT}]),
-    TagCmd = io_lib:format("git checkout -b ~s", [?PYTHON_CLIENT_TAG]),
+    TagCmd = io_lib:format("git reset --hard ~s", [?PYTHON_CLIENT_TAG]),
     rt_local:stream_cmd(TagCmd, [{cd, ?PYTHON_CHECKOUT}]),
 
     lager:info("[PREREQ] Installing an isolated environment with virtualenv in ~s", [?PYTHON_CHECKOUT]),


### PR DESCRIPTION
The python client test was still using 1.5.x even though the version 2.0.x includes Riak 1.4 features.

@jaredmorrow 
