### PR TITLE
Add optional test list offsetting

### DIFF
--- a/src/riak_test_escript.erl
+++ b/src/riak_test_escript.erl
@@ -141,8 +141,8 @@ main(Args) ->
                     Tests0;
                 {Offset, Workers} ->
                     TestCount = length(Tests0),
-                    ActualOffset = ((TestCount div (Workers rem TestCount+1))
-                                    * Offset) rem TestCount+1,
+                    ActualOffset = ((TestCount div (Workers rem (TestCount+1)))
+                                    * Offset) rem (TestCount+1),
                     {TestA, TestB} = lists:split(ActualOffset, Tests0),
                     lager:info("Offsetting ~b tests by ~b (~b workers, ~b"
                                " offset)", [TestCount, ActualOffset, Workers,


### PR DESCRIPTION
This is useful if you have N workers you want to run the same test suite
against, but would prefer to stagger the start point each worker takes,
so you can get at each test run at least once as soon as possible. The
two required configuration parameters are offset and workers.

Offset is the _relative_ offset to start at, not an absolute number. So
example, if you have 6 workers, set the offset to 3 and have 20 tests to
run, that particular worker will start at test #9. The reason absolute
offsets are not used is that if the # of the tests to run changes, you
don't have to reconfigure anything. You'll only need to reconfigure once
the # of workers you're using to run the tests changes.

cc @jaredmorrow , @rzezeski and @seancribbs 
