### PR TITLE
add deps to edts lib dirs

### DIFF
--- a/.edts
+++ b/.edts
@@ -1,1 +1,2 @@
 :node-sname "rt"
+:lib-dirs "deps"


### PR DESCRIPTION
so it doesn't show xref errors when using lager for example
