### PR TITLE
Make rt:pmap use spawn_link

### DIFF
--- a/src/rt.erl
+++ b/src/rt.erl
@@ -1126,7 +1126,7 @@ pmap(F, L) ->
     Parent = self(),
     lists:foldl(
       fun(X, N) ->
-              spawn(fun() ->
+              spawn_link(fun() ->
                             Parent ! {pmap, N, F(X)}
                     end),
               N+1


### PR DESCRIPTION
Without a link, if the worker crashes, riak_test will hang forever
waiting for the worker to send its response message.

cc @jtuple @jaredmorrow 
