### PR TITLE
update pipe handoff test for new fold req record

### DIFF
--- a/tests/pipe_verify_handoff.erl
+++ b/tests/pipe_verify_handoff.erl
@@ -163,7 +163,11 @@ confirm() ->
                                    P1MovedPrimaryToSecondary,
                                    P2MovedPrimaryToSecondary),
 
-    PFoldReqs = [X || riak_core_fold_req_v1=X <- PTraces],
+    PFoldReqs = [X || X <- PTraces,
+                      %% it would be really nice to import ?FOLD_REQ
+                      %% from riak_core_vnode.hrl
+                      (X == riak_core_fold_req_v1 orelse
+                       X == riak_core_fold_req_v2)],
     PArchives = [X || cmd_archive=X <- PTraces],
 
     %% number of active vnodes migrating from Primary to Secondary,


### PR DESCRIPTION
2.0 adds `riak_core_fold_req_v2`, so we need to watch for that record as well as `_v1`. It would be nice to be able to use `?FOLD_REQ` like the Riak code, but that would require pulling `riak_core` in as a dependency.
