### PR TITLE
extend sink ack timeout, for slow test machines

### DIFF
--- a/tests/pipe_verify_sink_types.erl
+++ b/tests/pipe_verify_sink_types.erl
@@ -99,8 +99,8 @@ verify_fsm_timeout([RN|_]) ->
     Opts = [{log, sink},
             {trace, [error]},
             {sink, Sink},
-            %% a very short timeout, to fit eunit
-            {sink_type, {fsm, 0, 10}}],
+            %% a short timeout, to fit eunit
+            {sink_type, {fsm, 0, 1000}}],
     {ok, P} = rpc:call(RN, riak_pipe, exec, [Spec, Opts]),
     rpc:call(RN, riak_pipe, queue_work, [P, {sync, 1}]),
     rpc:call(RN, riak_pipe, queue_work, [P, {sync, 2}]),


### PR DESCRIPTION
In response to http://giddyup.basho.com/#/projects/riak_ee/scorecards/53/53-707-pipe_verify_sink_types-centos-6-64/21446

It seems like 10ms might be too short for some of our builders, so we can
get an additional timeout trace message, which breaks the log matching
later in this test. One second should be long enough for any VM, right?

The other option is to expect any number of log messages, and just find
the one we need. I'd like to avoid that for now, just in case the
intermittent failure we've seen is _not_ a simple additional timeout.
