### PR TITLE
Exercise erlang http client 2i

### DIFF
--- a/tests/secondary_index_tests.erl
+++ b/tests/secondary_index_tests.erl
@@ -32,53 +32,72 @@ confirm() ->
     Nodes = rt:build_cluster(3),
     ?assertEqual(ok, rt:wait_until_nodes_ready(Nodes)),
     
-    Pid = rt:pbc(hd(Nodes)),
+    PBC = rt:pbc(hd(Nodes)),
+    HTTPC = rt:httpc(hd(Nodes)),
+    Clients = [{pb, PBC}, {http, HTTPC}],
     
-    [put_an_object(Pid, N) || N <- lists:seq(0, 20)],
+    [put_an_object(PBC, N) || N <- lists:seq(0, 20)],
     
-    assertExactQuery(Pid, [<<"obj5">>], <<"field1_bin">>, <<"val5">>),
-    assertExactQuery(Pid, [<<"obj5">>], <<"field2_int">>, <<"5">>),
-    assertRangeQuery(Pid, [<<"obj10">>, <<"obj11">>, <<"obj12">>], <<"field1_bin">>, <<"val10">>, <<"val12">>),
-    assertRangeQuery(Pid, [<<"obj10">>, <<"obj11">>, <<"obj12">>], <<"field2_int">>, 10, 12),
-    assertRangeQuery(Pid, [<<"obj10">>, <<"obj11">>, <<"obj12">>], <<"$key">>, <<"obj10">>, <<"obj12">>),
+    assertExactQuery(Clients, [<<"obj5">>], <<"field1_bin">>, <<"val5">>),
+    assertExactQuery(Clients, [<<"obj5">>], <<"field2_int">>, <<"5">>),
+    assertRangeQuery(Clients, [<<"obj10">>, <<"obj11">>, <<"obj12">>], <<"field1_bin">>, <<"val10">>, <<"val12">>),
+    assertRangeQuery(Clients, [<<"obj10">>, <<"obj11">>, <<"obj12">>], <<"field2_int">>, 10, 12),
+    assertRangeQuery(Clients, [<<"obj10">>, <<"obj11">>, <<"obj12">>], <<"$key">>, <<"obj10">>, <<"obj12">>),
 
     lager:info("Delete an object, verify deletion..."),
     ToDel = [<<"obj5">>, <<"obj11">>],
-    [?assertMatch(ok, riakc_pb_socket:delete(Pid, ?BUCKET, K)) || K <- ToDel],
+    [?assertMatch(ok, riakc_pb_socket:delete(PBC, ?BUCKET, K)) || K <- ToDel],
     lager:info("Make sure the tombstone is reaped..."),
-    ?assertMatch(ok, rt:wait_until(fun() -> rt:pbc_really_deleted(Pid, ?BUCKET, ToDel) end)),
+    ?assertMatch(ok, rt:wait_until(fun() -> rt:pbc_really_deleted(PBC, ?BUCKET, ToDel) end)),
     
-    assertExactQuery(Pid, [], <<"field1_bin">>, <<"val5">>),
-    assertExactQuery(Pid, [], <<"field2_int">>, <<"5">>),
-    assertRangeQuery(Pid, [<<"obj10">>, <<"obj12">>], <<"field1_bin">>, <<"val10">>, <<"val12">>),
-    assertRangeQuery(Pid, [<<"obj10">>, <<"obj12">>], <<"field2_int">>, 10, 12),
-    assertRangeQuery(Pid, [<<"obj10">>, <<"obj12">>], <<"$key">>, <<"obj10">>, <<"obj12">>),
+    assertExactQuery(Clients, [], <<"field1_bin">>, <<"val5">>),
+    assertExactQuery(Clients, [], <<"field2_int">>, <<"5">>),
+    assertRangeQuery(Clients, [<<"obj10">>, <<"obj12">>], <<"field1_bin">>, <<"val10">>, <<"val12">>),
+    assertRangeQuery(Clients, [<<"obj10">>, <<"obj12">>], <<"field2_int">>, 10, 12),
+    assertRangeQuery(Clients, [<<"obj10">>, <<"obj12">>], <<"$key">>, <<"obj10">>, <<"obj12">>),
 
     %% Verify the $key index, and riak_kv#367 regression
-    assertRangeQuery(Pid, [<<"obj6">>], <<"$key">>, <<"obj6">>, <<"obj6">>),
-    assertRangeQuery(Pid, [<<"obj6">>, <<"obj7">>], <<"$key">>, <<"obj6">>, <<"obj7">>),
+    assertRangeQuery(Clients, [<<"obj6">>], <<"$key">>, <<"obj6">>, <<"obj6">>),
+    assertRangeQuery(Clients, [<<"obj6">>, <<"obj7">>], <<"$key">>, <<"obj6">>, <<"obj7">>),
 
     %% Verify bignum sort order in sext -- eleveldb only (riak_kv#499)
     TestIdxVal = 1362400142028,
-    put_an_object(Pid, TestIdxVal),
-    assertRangeQuery(Pid,
+    put_an_object(PBC, TestIdxVal),
+    assertRangeQuery(Clients,
                      [<<"obj1362400142028">>],
                      <<"field2_int">>,
                      1000000000000,
                      TestIdxVal),
     pass.
 
-assertExactQuery(Pid, Expected, Index, Value) -> 
+assertExactQuery(Clients, Expected, Index, Value) when is_list(Clients) ->
+    [assertExactQuery(C, Expected, Index, Value) || C <- Clients];
+assertExactQuery({ClientType, Client}, Expected, Index, Value) -> 
     lager:info("Searching Index ~p for ~p", [Index, Value]),
-    {ok, ?INDEX_RESULTS{keys=Results}} = riakc_pb_socket:get_index(Pid, ?BUCKET, Index, Value),
+    {ok, ?INDEX_RESULTS{keys=Results}} = case ClientType of
+        pb ->
+             riakc_pb_socket:get_index(Client, ?BUCKET, Index, Value);
+        http ->
+            rhc:get_index(Client, ?BUCKET, Index, Value)
+    end,
+            
+            
     ActualKeys = lists:sort(Results),
     lager:info("Expected: ~p", [Expected]),
     lager:info("Actual  : ~p", [ActualKeys]),
     ?assertEqual(Expected, ActualKeys). 
 
-assertRangeQuery(Pid, Expected, Index, StartValue, EndValue) ->
-    lager:info("Searching Index ~p for ~p-~p", [Index, StartValue, EndValue]),
-    {ok, ?INDEX_RESULTS{keys=Results}} = riakc_pb_socket:get_index(Pid, ?BUCKET, Index, StartValue, EndValue),
+assertRangeQuery(Clients, Expected, Index, StartValue, EndValue) when is_list(Clients) ->
+    [assertRangeQuery(C, Expected, Index, StartValue, EndValue) || C <- Clients];
+assertRangeQuery({ClientType, Client}, Expected, Index, StartValue, EndValue) ->
+    lager:info("Searching Index ~p for ~p-~p with ~p client",
+               [Index, StartValue, EndValue, ClientType]),
+    {ok, ?INDEX_RESULTS{keys=Results}} = case ClientType of
+        pb ->
+            riakc_pb_socket:get_index(Client, ?BUCKET, Index, StartValue, EndValue);
+        http ->
+            rhc:get_index(Client,  ?BUCKET, Index, {StartValue, EndValue})
+    end,
     ActualKeys = lists:sort(Results),
     lager:info("Expected: ~p", [Expected]),
     lager:info("Actual  : ~p", [ActualKeys]),

--- a/tests/verify_2i_limit.erl
+++ b/tests/verify_2i_limit.erl
@@ -23,7 +23,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("riakc/include/riakc.hrl").
 -import(secondary_index_tests, [put_an_object/2, put_an_object/4, int_to_key/1,
-                                stream_pb/3, http_query/3, pb_query/3, http_stream/3]).
+                                stream_pb/3, http_query/3, pb_query/3]).
 -define(BUCKET, <<"2ibucket">>).
 -define(FOO, <<"foo">>).
 -define(MAX_RESULTS, 50).
@@ -34,7 +34,8 @@ confirm() ->
     Nodes = rt:build_cluster(3),
     ?assertEqual(ok, (rt:wait_until_nodes_ready(Nodes))),
 
-    RiakHttp = rt:http_url(hd(Nodes)),
+    RiakHttp = rt:httpc(hd(Nodes)),
+    HttpUrl = rt:http_url(hd(Nodes)),
     PBPid = rt:pbc(hd(Nodes)),
 
     [put_an_object(PBPid, N) || N <- lists:seq(0, 100)],
@@ -52,13 +53,21 @@ confirm() ->
     ?assertEqual(Rest, proplists:get_value(keys, PBKeys2, [])),
 
     %% HTTP
-    HttpRes = http_stream(RiakHttp, Q, [{max_results, ?MAX_RESULTS}]),
-    ?assertEqual(FirstHalf, proplists:get_value(<<"keys">>, HttpRes, [])),
-    HttpContinuation = proplists:get_value(<<"continuation">>, HttpRes),
+    HttpRes = rhc:get_index(RiakHttp, ?BUCKET, <<"$key">>,
+                            {int_to_key(0), int_to_key(999)},
+                           [{max_results, ?MAX_RESULTS}]),
+    ?assertMatch({ok, ?INDEX_RESULTS{}}, HttpRes),
+    {ok, ?INDEX_RESULTS{keys=HttpResKeys,
+                        continuation=HttpContinuation}} = HttpRes, 
+    ?assertEqual(FirstHalf, HttpResKeys),
     ?assertEqual(PBContinuation, HttpContinuation),
 
-    HttpRes2 = http_query(RiakHttp, Q, [{continuation, HttpContinuation}]),
-    ?assertEqual(Rest, proplists:get_value(<<"keys">>, HttpRes2, [])),
+    HttpRes2 = rhc:get_index(RiakHttp, ?BUCKET, <<"$key">>,
+                             {int_to_key(0), int_to_key(999)},
+                             [{continuation, HttpContinuation}]),
+    ?assertMatch({ok, ?INDEX_RESULTS{}}, HttpRes2),
+    {ok, ?INDEX_RESULTS{keys=HttpRes2Keys}} = HttpRes2,
+    ?assertEqual(Rest, HttpRes2Keys),
 
     %% Multiple indexes for single key
     O1 = riakc_obj:new(?BUCKET, <<"bob">>, <<"1">>),
@@ -84,7 +93,7 @@ confirm() ->
 
     [put_an_object(PBPid, int_to_key(N), 1000, <<"myval">>) || N <- lists:seq(0, 100)],
 
-    [ verify_eq_pag(PBPid, RiakHttp, EqualsQuery, FirstHalf, Rest) ||
+    [ verify_eq_pag(PBPid, HttpUrl, EqualsQuery, FirstHalf, Rest) ||
         EqualsQuery <- [{"field1_bin", <<"myval">>},
                         {"field2_int", 1000},
                         {"$bucket", ?BUCKET}]],


### PR DESCRIPTION
These are some changes to the 2i tests to exercise new 2i support in the erlang http client and take advantage of its HTTP streaming support specially. The tests have their own implementation of http streams fetching that is a bit of a maintenance headache.

More changes are needed. I'm planning on adding non-streaming support for 2i operations to the client and use that instead in the tests, among other things.

/cc @seancribbs @russelldb 
