### PR TITLE
Fix fallout from changing allow_mult to true

### DIFF
--- a/tests/bucket_types.erl
+++ b/tests/bucket_types.erl
@@ -44,8 +44,7 @@ confirm() ->
     ?assertEqual(<<"default">>, riakc_obj:bucket_type(O2)),
 
     %% write implicitly to the default bucket
-    riakc_pb_socket:put(PB, riakc_obj:new(<<"bucket">>,
-                                             <<"key">>, <<"newvalue">>)),
+    riakc_pb_socket:put(PB, riakc_obj:update_value(O1, <<"newvalue">>)),
  
     %% read from the default bucket explicitly
     {ok, O3} = riakc_pb_socket:get(PB, {<<"default">>, <<"bucket">>}, <<"key">>),

--- a/tests/http_security.erl
+++ b/tests/http_security.erl
@@ -109,7 +109,7 @@ confirm() ->
                         ]}
                                                ]),
 
-    ?assertEqual({error,{conn_failed,{error,{tls_alert,"unknown ca"}}}}, rhc:ping(C6)),
+    ?assertMatch({error,{conn_failed,{error,_}}}, rhc:ping(C6)),
 
     lager:info("verifying the peer certificate should work if the cert is valid"),
     %% verifying the peer certificate should work if the cert is valid


### PR DESCRIPTION
Also, tweak an error pattern match that seems highly OS/Openssl
dependant.

See also: basho/riak-erlang-http-client#25
