### PR TITLE
Ensure we wait long enough for Riak Control to start.

### DIFF
--- a/src/rt.erl
+++ b/src/rt.erl
@@ -117,6 +117,8 @@
          wait_for_cluster_service/2,
          wait_for_cmd/1,
          wait_for_service/2,
+         wait_for_control/1,
+         wait_for_control/2,
          wait_until/2,
          wait_until/1,
          wait_until_all_members/1,
@@ -1299,3 +1301,58 @@ expect_in_log(Node, Pattern) ->
         _ ->
             false
     end.
+
+%% @doc Wait for Riak Control to start on a single node.
+%%
+%% Non-optimal check, because we're blocking for the gen_server to start
+%% to ensure that the routes have been added by the supervisor.
+%%
+wait_for_control(Vsn, Node) when is_atom(Node) ->
+    lager:info("Waiting for riak_control to start on node ~p.", [Node]),
+
+    %% Wait for the gen_server.
+    rt:wait_until(Node, fun(N) ->
+                case rpc:call(N,
+                              riak_control_session,
+                              get_version,
+                              []) of
+                    {ok, _} ->
+                        true;
+                    Error ->
+                        lager:info("Error was ~p.", [Error]),
+                        false
+                end
+        end),
+
+    GuiResource = case Vsn of
+        legacy ->
+            admin_gui;
+        _ ->
+            riak_control_wm_gui
+    end,
+
+    %% Wait for routes to be added by supervisor.
+    rt:wait_until(Node, fun(N) ->
+                case rpc:call(N,
+                              webmachine_router,
+                              get_routes,
+                              []) of
+                    {badrpc, Error} ->
+                        lager:info("Error was ~p.", [Error]),
+                        false;
+                    Routes ->
+                        case lists:keyfind(GuiResource, 2,
+                                           Routes) of
+                            false ->
+                                lager:info("Control routes not found yet: ~p ~p.", 
+                                           [Vsn, Routes]),
+                                false;
+                            _ ->
+                                true
+                        end
+                end
+        end).
+
+%% @doc Wait for Riak Control to start on a series of nodes.
+wait_for_control(VersionedNodes) when is_list(VersionedNodes) ->
+    [wait_for_control(Vsn, Node) || {Vsn, Node} <- VersionedNodes].

--- a/tests/riak_control.erl
+++ b/tests/riak_control.erl
@@ -69,7 +69,7 @@ verify_upgrade_fold({FromVsn, Node}, VersionedNodes0) ->
     rt:wait_for_service(Node, riak_kv),
 
     %% Wait for Riak Control to start.
-    wait_for_control(VersionedNodes0),
+    rt:wait_for_control(VersionedNodes0),
 
     %% Wait for Riak Control polling cycle.
     wait_for_control_cycle(Node),
@@ -182,29 +182,6 @@ wait_for_control_cycle(Node) when is_atom(Node) ->
                                      []),
                 Vsn =:= ExpectedVsn
         end).
-
-%% @doc Wait for Riak Control to start.
-%%
-%% Non-optimal check, because we're blocking for the gen_server to
-%% start to ensure that the routes have been added by the
-%% supervisor.
-wait_for_control(Node) when is_atom(Node) ->
-    lager:info("Waiting for riak_control to start on node ~p.", [Node]),
-
-    rt:wait_until(Node, fun(N) ->
-                case rpc:call(N,
-                              riak_control_session,
-                              get_version,
-                              []) of
-                    {ok, _} ->
-                        true;
-                    Error ->
-                        lager:info("Error was ~p.", [Error]),
-                        false
-                end
-        end);
-wait_for_control(VersionedNodes) when is_list(VersionedNodes) ->
-    [wait_for_control(Node) || {_, Node} <- VersionedNodes].
 
 %% @doc Validate partitions response.
 validate_partitions({current, _}, _ResponsePartitions, _VersionedNodes) ->


### PR DESCRIPTION
Wait until both the Riak Control gen_server has been registered, and the
webmachine routes have been added to the dispatcher to ensure that Riak
Control is able to service requests to prevent races between the test,
and application initialization.
