### PR TITLE
verify_dynamic_ring: siblings = off

### DIFF
--- a/tests/verify_dynamic_ring.erl
+++ b/tests/verify_dynamic_ring.erl
@@ -30,6 +30,8 @@
 -define(SHRUNK_SIZE, 8).
 
 confirm() ->
+    %% test requires allow_mult=false b/c of rt:systest_read
+    rt:set_conf(all, [{"buckets.default.siblings", "off"}]),
     rt:update_app_config(all, [{riak_core,
                                 [{ring_creation_size, ?START_SIZE}]}]),
     [ANode, AnotherNode, YetAnother, ReplacingNode] = AllNodes = rt:deploy_nodes(4),


### PR DESCRIPTION
test may fail because of recent default change + systest_read not supporting
siblings. Since I can't recreate it, and it doesn't matter for the test, turn
it off.

Example Failures:
1. http://giddyup.basho.com/#/projects/riak_ee/scorecards/54/54-712-verify_dynamic_ring-centos-6-64-bitcask/23135/artifacts/269380
1. http://giddyup.basho.com/#/projects/riak_ee/scorecards/54/54-612-verify_dynamic_ring-ubuntu-1004-64-bitcask/22859/artifacts/263031
1. http://giddyup.basho.com/#/projects/riak_ee/scorecards/54/54-652-verify_dynamic_ring-ubuntu-1204-64-bitcask/23046

cc/ @jaredmorrow 
