### PR TITLE
Explicitly set siblings to off

### DIFF
--- a/tests/verify_api_timeouts.erl
+++ b/tests/verify_api_timeouts.erl
@@ -8,6 +8,8 @@
 -define(NUM_KEYS, 1000).
 
 confirm() ->
+    %% test requires allow_mult=false b/c of rt:systest_read
+    rt:set_conf(all, [{"buckets.default.siblings", "off"}]),    
     [Node] = rt:build_cluster(1),
     rt:wait_until_pingable(Node),
     


### PR DESCRIPTION
As a bandaid after on became the default. We should later update this
test to work with siblings on.

This test needs https://github.com/basho/riak-erlang-client/pull/125 to completely pass, as it also uncovered a problem in the riak erlang client related to bucket types.
