### PR TITLE
Update lager test for new config format

### DIFF
--- a/tests/verify_riak_lager.erl
+++ b/tests/verify_riak_lager.erl
@@ -40,7 +40,8 @@ confirm() ->
     
     {ok, LagerHandlers} = rt:rpc_get_env(Node, [{lager, handlers}]),
     
-    Files = [element(1, Backend) || Backend <- proplists:get_value(lager_file_backend, LagerHandlers)],
+    Files = [proplists:get_value(file, Config) || {Backend, Config} <- LagerHandlers,
+                                    Backend == lager_file_backend ],
     
     lager:info("Checking for files: ~p", [Files]),
     [?assert(rpc:call(Node, filelib, is_file, [File])) || File <- Files],


### PR DESCRIPTION
Test was assuming old-style lager config, but cuttlefish generates the
'new' style config, so the test broke.
