### PR TITLE
Remove any specific 1.2.1 code.

### DIFF
--- a/tests/verify_capabilities.erl
+++ b/tests/verify_capabilities.erl
@@ -216,19 +216,19 @@ confirm() ->
     [rt:update_app_config(Node, Override(legacy, proxy)) || Node <- Nodes],
 
     lager:info("Verify vnode_routing == legacy"),
-    ?assertEqual(legacy, rt:capability(CNode, {riak_core, vnode_routing})),
+    assert_capability(CNode, {riak_core, vnode_routing}, legacy),
 
     lager:info("Override: (use: proxy), (prefer: legacy)"),
     [rt:update_app_config(Node, Override(proxy, legacy)) || Node <- Nodes],
 
     lager:info("Verify vnode_routing == proxy"),
-    ?assertEqual(proxy, rt:capability(CNode, {riak_core, vnode_routing})),
+    assert_capability(CNode, {riak_core, vnode_routing}, proxy),
 
     lager:info("Override: (prefer: legacy)"),
     [rt:update_app_config(Node, Override(undefined, legacy)) || Node <- Nodes],
 
     lager:info("Verify vnode_routing == legacy"),
-    ?assertEqual(legacy, rt:capability(CNode, {riak_core, vnode_routing})),
+    assert_capability(CNode, {riak_core, vnode_routing}, legacy),
 
     [rt:stop(Node) || Node <- Nodes],
     pass.


### PR DESCRIPTION
Unfortunately, this drastically reduces the value of the test because is
no longer verfies a "liveness" property of capabilities; it doesn't
verify that things will negotiate to the newer version.  However,
leaving the remainder of this test in place verifies two things: a.)
"safety", things do not regress to a earlier capability, and that the
override capabilities work as designed.
