### PR TITLE
Fix verify_commit_hooks test to expect 404 instead of 201

### DIFF
--- a/tests/verify_commit_hooks.erl
+++ b/tests/verify_commit_hooks.erl
@@ -57,7 +57,9 @@ confirm() ->
                  rt:httpc_write(HTTP, <<"failkey">>, <<"fail">>, <<"value">>)),
 
     lager:info("Checking fix for BZ1244 - riak_kv_wm_object makes call to riak_client:get/3 with invalid type for key"),
-    ?assertMatch({error, {ok, "201", _, _}},
+    %% riak_kv_wm_object:ensure_doc will return {error, not_found}, leading to 404.
+    %% see https://github.com/basho/riak_kv/pull/237 for details of the fix.
+    ?assertMatch({error, {ok, "404", _, _}},
                  rt:httpc_write(HTTP, <<"bz1244bucket">>, undefined, <<"value">>)),
 
     lager:info("Checking that postcommit fires."),


### PR DESCRIPTION
The verify_commit_hooks test was failing for the pre4 milestone.
This change fixes the test to expect a 404 (NOT FOUND) instead of a 201 (CREATED).
- Justification: riak_kv_wm_object:ensure_doc(Bucket,undefined) will return {error, undefined}, which will lead to a 404.
- See original fix to ensure_doc here: https://github.com/basho/riak_kv/pull/237
- http://developer.yahoo.com/social/rest_api_guide/http-response-codes.html
  Note description for 404; it's a legit response for both GET, POST, PUT, and DELETE. This test is issuing a PUT, so a 404 is one of the reasonable choices.
