### PR TITLE
Fix backup/restore test with siblings enabled

### DIFF
--- a/tests/verify_backup_restore.erl
+++ b/tests/verify_backup_restore.erl
@@ -264,7 +264,13 @@ delete_some(PBC, Props) ->
     Keys = [KFun(N) || N <- lists:seq(Start, End)],
     F =
         fun(K, Acc) ->
-            case riakc_pb_socket:delete(PBC, Bucket, K) of
+            DRes = case riakc_pb_socket:get(PBC, Bucket, K) of
+                {ok, DObj} ->
+                    riakc_pb_socket:delete_obj(PBC, DObj);
+                _ ->
+                    riakc_pb_socket:delete(PBC, Bucket, K)
+            end,
+            case DRes of
                 ok -> Acc;
                 _ -> [{error, {could_not_delete, K}} | Acc]
             end


### PR DESCRIPTION
With siblings now enabled by default, this test produced them and failed
because of it.
- Internal search buckets do not tolerate siblings. Search queries
  crash. So siblings was disabled in that bucket only
- Change write functions to use PB client and perform read before
  write.
