### PR TITLE
Fix partition repair stuck on vnode cmd

### DIFF
--- a/tests/partition_repair.erl
+++ b/tests/partition_repair.erl
@@ -257,7 +257,7 @@ get_data(Service, {Partition, Node}) ->
     Data = riak_core_vnode_master:sync_command({Partition, Node},
                                                Req,
                                                VMaster,
-                                               infinity),
+                                               rt_config:get(rt_max_wait_time)),
     Data.
 
 stash_data(Service, {Partition, Node}) ->


### PR DESCRIPTION
Changing from infinity (that's too long) to configure max waiting time.
This does not resolve other issues with the test that are still being
investigated: lots of data not found on first riak_kv vnode repaired in
some testers. But does prevent it from completely blocking riak_test
which happened on many machines.
