### PR TITLE
Re-instate the deleted key so it appears for list-buckets later

### DIFF
--- a/tests/http_security.erl
+++ b/tests/http_security.erl
@@ -171,6 +171,9 @@ confirm() ->
     ?assertMatch({error, notfound}, rhc:get(C7, <<"hello">>,
                                                      <<"world">>)),
 
+    %% write it back for list_buckets later
+    ?assertEqual(ok, rhc:put(C7, Object)),
+
     %% slam the door in the user's face
     lager:info("Revoking get/put/delete, checking that get/put/delete are disallowed"),
     ok = rpc:call(Node, riak_core_console, revoke,


### PR DESCRIPTION
Without this patch, the delete done on line 167 leaves behind a tombstone and the later list_buckets call is in a race with the tombstone being GCed. On slower machines the tombstone GCs before we call list buckets and on faster ones it does not.
