### PR TITLE
Fix rt_cascading.

### DIFF
--- a/tests/rt_cascading.erl
+++ b/tests/rt_cascading.erl
@@ -20,6 +20,9 @@
 % cluster_mgr port = 10006 + 10n where n is devN
 
 confirm() ->
+    %% test requires allow_mult=false b/c of rt:systest_read
+    rt:set_conf(all, [{"buckets.default.siblings", "off"}]),
+
     case eunit:test(?MODULE, [verbose]) of
         ok ->
             pass;


### PR DESCRIPTION
Set allow_mult=false, as this test relies on systest_read.
