### PR TITLE
Fixes to replication2 for 2.0: allow_mult=false for mutator; rhc fix

### DIFF
--- a/tests/replication2.erl
+++ b/tests/replication2.erl
@@ -11,6 +11,10 @@
              wait_until_no_pending_changes/1]).
 
 confirm() ->
+
+    %% test requires allow_mult=false
+    rt:set_conf(all, [{"buckets.default.siblings", "off"}]), 
+
     NumNodes = rt_config:get(num_nodes, 6),
     ClusterASize = rt_config:get(cluster_a_size, 3),
 
@@ -33,6 +37,7 @@ confirm() ->
     ],
 
     Nodes = deploy_nodes(NumNodes, Conf),
+ 
 
     {ANodes, BNodes} = lists:split(ClusterASize, Nodes),
     lager:info("ANodes: ~p", [ANodes]),
@@ -541,7 +546,7 @@ http_write_during_shutdown(Target, BSecond, TestBucket) ->
     lager:info("got ~p write failures to ~p", [length(WriteErrors), Target]),
     timer:sleep(3000),
     lager:info("checking number of read failures on secondary cluster node, ~p", [BSecond]),
-    [{_IP, Port2},_] = rt:connection_info(BSecond),
+    [{_, {IP, Port2}},_] = rt:connection_info(BSecond),
     C2 = rhc:create("127.0.0.1", Port2, "riak", []),
     ReadErrors = http_read(C2, 12000, 22000, TestBucket, 2),
     lager:info("got ~p read failures from ~p", [length(ReadErrors), BSecond]),
@@ -653,3 +658,4 @@ collect_results(Workers, Acc) ->
         {'DOWN', _, _, Pid, _Reason} ->
             collect_results(lists:keydelete(Pid, 1, Workers), Acc)
     end.
+


### PR DESCRIPTION
Get the test passing with 2 small fixes after these crashes:

Mutator:
================ replication2 failure stack trace =====================
{{badmatch,[{{dict,5,16,16,8,80,48,
                   {[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]},
                   {{[],[],[],[],
                     [[cluster_of_record,65],
                      [mutators_applied,riak_repl_reduced]],
                     [],[],[],[],[],
                     [[<<"X-Riak-VTag">>,49,56,48,120,83,112,53,109,69,74,74,
                       48,81,108,99,103,112,115,82,74,86,70]],
                     [[<<"index">>]],
                     [],
                     [[<<"X-Riak-Last-Modified">>|{1384,471557,44502}]],
                     [],[]}}},
             <<0,0,3,132>>},
            {{dict,5,16,16,8,80,48,
                   {[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]},
                   {{[],[],[],[],
                     [[cluster_of_record,65],
                      [mutators_applied,riak_repl_reduced]],
                     [],[],[],[],[],
                     [[<<"X-Riak-VTag">>,49,77,106,107,69,52,66,83,102,73,83,
                       80,116,87,68,57,104,82,75,69,74,57]],
                     [[<<"index">>]],
                     [],
                     [[<<"X-Riak-Last-Modified">>|{1384,471562,248058}]],
                     [],[]}}},
             <<0,0,3,132>>}]},
 [{riak_object,get_value,1,[{file,"src/riak_object.erl"},{line,355}]},
  {rt,'-systest_read/5-fun-0-',5,[{file,"src/rt.erl"},{line,942}]},
  {lists,foldl,3,[{file,"lists.erl"},{line,1197}]}
## rhc:

19:15:13.196 [warning] replication2 failed: {function_clause,[{rhc,create,["127.0.0.1",{"127.0.0.1",10058},"riak",[]],[{file,"src/rhc.erl"},{line,84}]},{replication2,http_write_during_shutdown,3,[{file,"tests/replication2.erl"},{line,550}]},{replication2,replication,3,[{file,"tests/replication2.erl"},{line,460}]},{replication2,confirm,0,[{file,"tests/replication2.erl"},{line,52}]}]}
19:15:13.196 [error] Error in process <0.127.0> on node 'riak_test@127.0.0.1' with exit value: {function_clause,[{rhc,create,["127.0.0.1",{"127.0.0.1",10058},"riak",[]],[{file,"src/rhc.erl"},{line,<wbr>84}]},{replication2,http_write_during_shutdown,3,[{file,"tests/replication2.erl"},{line,550}]},{replication2,replication,3,[{file,"t...
