### PR TITLE
Improvements to Cluster Metadata Tests

### DIFF
--- a/intercepts/riak_core_broadcast_intercepts.erl
+++ b/intercepts/riak_core_broadcast_intercepts.erl
@@ -1,0 +1,9 @@
+-module(riak_core_broadcast_intercepts).
+-compile(export_all).
+-include("intercept.hrl").
+
+global_send(Msg, Peers) when is_list(Peers) ->
+    [global_send(Msg, P) || P <- Peers];
+global_send(Msg, P) ->
+    ?I_INFO("sending through proxy"),
+    gen_server:cast({global, cluster_meta_proxy_server}, {node(), riak_core_broadcast, P, Msg}).

--- a/src/rt.erl
+++ b/src/rt.erl
@@ -119,6 +119,7 @@
          wait_for_service/2,
          wait_for_control/1,
          wait_for_control/2,
+         wait_until/3,
          wait_until/2,
          wait_until/1,
          wait_until_all_members/1,

--- a/tests/cluster_meta_basic.erl
+++ b/tests/cluster_meta_basic.erl
@@ -19,17 +19,29 @@
 %% -------------------------------------------------------------------
 -module(cluster_meta_basic).
 -behavior(riak_test).
--export([confirm/0]).
+-export([confirm/0, object_count/2]).
 -include_lib("eunit/include/eunit.hrl").
 
 -define(PREFIX1, {a, b}).
+-define(PREFIX2, {fold, prefix}).
 -define(KEY1, key1).
+-define(KEY2, key2).
 -define(VAL1, val1).
 -define(VAL2, val2).
 
 confirm() ->
-    [N1 | _] = Nodes = rt:build_cluster(5),
+    Nodes = rt:build_cluster(5),
+    ok = test_fold_full_prefix(Nodes),
+    ok = test_metadata_conflicts(Nodes),
+    ok = test_writes_after_partial_cluster_failure(Nodes).
 
+
+%% 1. write a key and waits til it propogates around the cluster
+%% 2. stop the immediate eager peers of the node that performed the write
+%% 3. perform an update of the key from the same node and wait until it reaches all alive nodes
+%% 4. bring up stopped nodes and ensure that either lazily queued messages or anti-entropy repair
+%%    propogates key to all nodes in cluster
+test_writes_after_partial_cluster_failure([N1 | _]=Nodes) ->
     metadata_put(N1, ?PREFIX1, ?KEY1, ?VAL1),
     wait_until_metadata_value(Nodes, ?PREFIX1, ?KEY1, ?VAL1),
     print_tree(N1, Nodes),
@@ -47,19 +59,95 @@ confirm() ->
     wait_until_metadata_value(Nodes, ?PREFIX1, ?KEY1, ?VAL2),
     ok.
 
+%% 1. write several keys to a prefix, fold over them accumulating a list
+%% 2. ensure list of keys and values match those written to prefix
+test_fold_full_prefix([N1 | _]=Nodes) ->
+    rt:load_modules_on_nodes([?MODULE], Nodes),
+    lager:info("testing prefix (~p) fold on ~p", [?PREFIX2, N1]),
+    KeysAndVals = [{I, I} || I <- lists:seq(1, 10)],
+    [metadata_put(N1, ?PREFIX2, K, V) || {K, V} <- KeysAndVals],
+    %% we don't use a resolver but shouldn't have conflicts either, so assume that in
+    %% head of fold function
+    FoldRes = [{K, V} || {K, [V]} <- metadata_to_list(N1, ?PREFIX2)],
+    SortedRes = lists:ukeysort(1, FoldRes),
+    ?assertEqual(KeysAndVals, SortedRes),
+    ok.
+
+test_metadata_conflicts([N1, N2 | _]=Nodes) ->
+    rt:load_modules_on_nodes([?MODULE], Nodes),
+    lager:info("testing conflicting writes to a key"),
+    write_conflicting(N1, N2, ?PREFIX1, ?KEY2, ?VAL1, ?VAL2),
+
+    %% assert that we still have siblings since write_conflicting uses allow_put=false
+    lager:info("checking object count after resolve on get w/o put"),
+    ?assertEqual(2, rpc:call(N1, ?MODULE, object_count, [?PREFIX1, ?KEY2])),
+    ?assertEqual(2, rpc:call(N2, ?MODULE, object_count, [?PREFIX1, ?KEY2])),
+
+    %% iterate over the values and ensure we can resolve w/o doing a put
+    ?assertEqual([{?KEY2, lists:usort([?VAL1, ?VAL2])}],
+                 metadata_to_list(N1, ?PREFIX1, [{allow_put, false}])),
+    ?assertEqual([{?KEY2, lists:usort([?VAL1, ?VAL2])}],
+                 metadata_to_list(N2, ?PREFIX1, [{allow_put, false}])),
+    lager:info("checking object count after resolve on itr_key_values w/o put"),
+    ?assertEqual(2, rpc:call(N1, ?MODULE, object_count, [?PREFIX1, ?KEY2])),
+    ?assertEqual(2, rpc:call(N2, ?MODULE, object_count, [?PREFIX1, ?KEY2])),
+
+    %% assert that we no longer have siblings when allow_put=true
+    lager:info("checking object count afger resolve on get w/ put"),
+    wait_until_metadata_value([N1, N2], ?PREFIX1, ?KEY2,
+                              [{resolver, fun list_resolver/2}],
+                              lists:usort([?VAL1, ?VAL2])),
+    ?assertEqual(1, rpc:call(N1, ?MODULE, object_count, [?PREFIX1, ?KEY2])),
+    ?assertEqual(1, rpc:call(N2, ?MODULE, object_count, [?PREFIX1, ?KEY2])),
+    ok.
+
+write_conflicting(N1, N2, Prefix, Key, Val1, Val2) ->
+    rpc:call(N1, riak_core_metadata_manager, put, [{Prefix, Key}, undefined, Val1]),
+    rpc:call(N2, riak_core_metadata_manager, put, [{Prefix, Key}, undefined, Val2]),
+    wait_until_metadata_value([N1, N2], Prefix, Key,
+                              [{resolver, fun list_resolver/2},
+                               {allow_put, false}],
+                              lists:usort([Val1, Val2])).
+
+
+object_count(Prefix, Key) ->
+    Obj = riak_core_metadata_manager:get({Prefix, Key}),
+    case Obj of
+        undefined -> 0;
+        _ -> riak_core_metadata_object:value_count(Obj)
+    end.
+
+
+list_resolver(X1, X2) when is_list(X2) andalso is_list(X1) ->
+    lists:usort(X1 ++ X2);
+list_resolver(X1, X2) when is_list(X2) ->
+    lists:usort([X1 | X2]);
+list_resolver(X1, X2) when is_list(X1) ->
+    lists:usort(X1 ++ [X2]);
+list_resolver(X1, X2) ->
+    lists:usort([X1, X2]).
+
+metadata_to_list(Node, FullPrefix) ->
+    metadata_to_list(Node, FullPrefix, []).
+
+metadata_to_list(Node, FullPrefix, Opts) ->
+    rpc:call(Node, riak_core_metadata, to_list, [FullPrefix, Opts]).
+
 metadata_put(Node, Prefix, Key, FunOrVal) ->
     ok = rpc:call(Node, riak_core_metadata, put, [Prefix, Key, FunOrVal]).
 
-metadata_get(Node, Prefix, Key) ->
-    rpc:call(Node, riak_core_metadata, get, [Prefix, Key]).
+metadata_get(Node, Prefix, Key, Opts) ->
+    rpc:call(Node, riak_core_metadata, get, [Prefix, Key, Opts]).
 
-wait_until_metadata_value(Nodes, Prefix, Key, Val) when is_list(Nodes) ->
-    [wait_until_metadata_value(Node, Prefix, Key, Val) || Node <- Nodes];
-wait_until_metadata_value(Node, Prefix, Key, Val) ->
+wait_until_metadata_value(Nodes, Prefix, Key, Val) ->
+    wait_until_metadata_value(Nodes, Prefix, Key, [], Val).
+
+wait_until_metadata_value(Nodes, Prefix, Key, Opts, Val) when is_list(Nodes) ->
+    [wait_until_metadata_value(Node, Prefix, Key, Opts, Val) || Node <- Nodes];
+wait_until_metadata_value(Node, Prefix, Key, Opts, Val) ->
     lager:info("wait until {~p, ~p} equals ~p on ~p", [Prefix, Key, Val, Node]),
     F = fun() ->
-                %% TODO: need to not resolve or else we can have ambiguities
-                Val =:= metadata_get(Node, Prefix, Key)
+                Val =:= metadata_get(Node, Prefix, Key, Opts)
         end,
     ?assertEqual(ok, rt:wait_until(F)),
     ok.

--- a/tests/cluster_meta_proxy_server.erl
+++ b/tests/cluster_meta_proxy_server.erl
@@ -1,0 +1,123 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(cluster_meta_proxy_server).
+
+-compile(export_all).
+
+-behaviour(gen_server).
+
+%% API
+-export([start_link/0, history/0, is_empty/1]).
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+	 terminate/2, code_change/3]).
+
+-record(state, {history :: [any()],
+                last_msg_ts :: non_neg_integer()}).
+
+-define(SERVER, ?MODULE).
+
+start_link() ->
+  gen_server:start_link({global, ?SERVER}, ?MODULE, [], []).
+
+history() ->
+    gen_server:call({global, ?SERVER}, history, infinity).
+
+is_empty(ThresholdSecs) ->
+    gen_server:call({global, ?SERVER}, {is_empty, ThresholdSecs}, infinity).
+
+init([]) ->
+  {ok, #state{history = []}}.
+
+handle_call({is_empty, ThresholdSecs}, _From, State=#state{last_msg_ts=LastMsgTs}) ->
+    Now = moment(),
+    Reply = case process_info(self(), message_queue_len) of
+                {message_queue_len, 0} when (Now - LastMsgTs) > ThresholdSecs ->
+                    true;
+                {message_queue_len, _} ->
+                    false
+            end,
+    {reply, Reply, State};
+handle_call(history, _From, State=#state{history=History}) ->
+    {reply, lists:reverse(History), State}.
+
+handle_cast({From, Server, To, Msg}, State) ->
+%  {Keep, State1} = keep_msg(node_name(From), node_name(To), State),
+    State1 = add_to_history({From, To, Msg}, State),
+    gen_server:cast({Server, To}, Msg),
+%     true -> event_logger:event({dropped, node_name(From), node_name(To), Msg}) end,
+    {noreply, State1};
+handle_cast(_Msg, State) ->
+  {noreply, State}.
+
+%%--------------------------------------------------------------------
+%% Function: handle_info(Info, State) -> {noreply, State} |
+%%                                       {noreply, State, Timeout} |
+%%                                       {stop, Reason, State}
+%% Description: Handling all non call/cast messages
+%%--------------------------------------------------------------------
+handle_info(_Info, State) ->
+  {noreply, State}.
+
+%%--------------------------------------------------------------------
+%% Function: terminate(Reason, State) -> void()
+%% Description: This function is called by a gen_server when it is about to
+%% terminate. It should be the opposite of Module:init/1 and do any necessary
+%% cleaning up. When it returns, the gen_server terminates with Reason.
+%% The return value is ignored.
+%%--------------------------------------------------------------------
+terminate(_Reason, _State) ->
+  ok.
+
+%%--------------------------------------------------------------------
+%% Func: code_change(OldVsn, State, Extra) -> {ok, NewState}
+%% Description: Convert process state when code is changed
+%%--------------------------------------------------------------------
+code_change(_OldVsn, State, _Extra) ->
+  {ok, State}.
+
+%%--------------------------------------------------------------------
+%%% Internal functions
+%%--------------------------------------------------------------------
+
+add_to_history(Entry, State=#state{history=History}) ->
+    State#state{history=[Entry | History], last_msg_ts = moment()}.
+
+moment() ->
+    calendar:datetime_to_gregorian_seconds(calendar:universal_time()).
+
+
+%% keep_msg(From, To, State) ->
+%%   Key = {From, To},
+%%   Cfg = State#state.config,
+%%   {Keep, Cfg1} =
+%%     case proplists:get_value(Key, Cfg, []) of
+%%       []             -> {true,  Cfg};
+%%       [{keep, N}|Xs] -> {true,  store(Key, [{keep, N - 1} || N > 1] ++ Xs, Cfg)};
+%%       [{drop, N}|Xs] -> {false, store(Key, [{drop, N - 1} || N > 1] ++ Xs, Cfg)}
+%%     end,
+%%   {Keep, State#state{ config = Cfg1 }}.
+
+%% store(Key, [], Cfg) -> lists:keydelete(Key, 1, Cfg);
+%% store(Key, Xs, Cfg) -> lists:keystore(Key, 1, Cfg, {Key, Xs}).
+
+%% node_name(Node) ->
+%%   list_to_atom(hd(string:tokens(atom_to_list(Node),"@"))).

--- a/tests/cluster_meta_rmr.erl
+++ b/tests/cluster_meta_rmr.erl
@@ -1,0 +1,226 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(cluster_meta_rmr).
+-behavior(riak_test).
+-export([confirm/0]).
+
+-define(CM_PREFIX, {test, cm}).
+
+confirm() ->
+    rt:set_conf(all, [{"ring_size", "128"}]),
+    Seed = erlang:now(),
+    lager:info("SEED: ~p", [Seed]),
+    random:seed(Seed),
+%    run([10,20,40], 10, 50, 10).
+    run([5], 1, 5, 1).
+
+run(NumNodes, SuperRounds, NumRounds, StableRounds) when is_list(NumNodes) ->
+    [begin
+         [begin
+              lager:info("starting super round ~p: ~p nodes ~p total rounds ~p stable rounds",
+                         [S, N, NumRounds, StableRounds]),
+              run(N, NumRounds, StableRounds)
+          end || S <- lists:seq(1, SuperRounds)]
+     end || N <- NumNodes].
+
+run(NumNodes, NumRounds, StableRounds) ->
+    {ok, Pid} = cluster_meta_proxy_server:start_link(),
+    unlink(Pid),
+    AllNodes = setup_nodes(NumNodes),
+    %% ensures any gossip messages being proxied during initial cluster setup
+    %% are drained before we proceed
+%    wait_until_no_messages(),
+%    {ok, R} = rpc:call(hd(AllNodes), riak_core_ring_manager, get_my_ring, []),
+%    Nodes = riak_core_ring:active_members(R),
+%    lager:info("GOSSIP TREE: ~p", [riak_core_util:build_tree(2, Nodes, [cycles])]),
+    lager:info("running ~p broadcast rounds on nodes: ~p", [NumRounds, AllNodes]),
+    DownNodes = run_rounds(NumRounds, StableRounds, fun broadcast/2, fun wait_until_broadcast_consistent/2, AllNodes, []),
+%    lager:info("running ~p gossip rounds on nodes: ~p", [NumRounds, AllNodes]),
+%    run_rounds(NumRounds, fun gossip/2, fun wait_until_gossip_consistent/2, AllNodes),
+    calc_stuff(AllNodes, NumNodes, NumRounds),
+    exit(Pid, kill),
+    %% start all the down nodes so we can clean them :(
+    [rt:start(Node) || Node <- DownNodes],
+    rt:clean_cluster(AllNodes).
+
+setup_nodes(NumNodes) ->
+    Nodes = rt:build_cluster(NumNodes),
+    [begin
+         ok = rpc:call(Node, application, set_env, [riak_core, broadcast_exchange_timer, 4294967295]),
+         ok = rpc:call(Node, application, set_env, [riak_core, gossip_limit, {10000000, 4294967295}]),
+         rt_intercept:add(Node, {riak_core_broadcast, [{{send,2}, global_send}]})
+     end || Node <- Nodes],
+    Nodes.
+
+run_rounds(0, _, _, _, _, DownNodes) ->
+    DownNodes;
+run_rounds(_, _, _, _, [_SenderNode], DownNodes) ->
+    lager:info("ran out of nodes to shut down"),
+    DownNodes;
+run_rounds(Round, 0, SendFun, ConsistentFun, [SenderNode | OtherNodes]=UpNodes, DownNodes) ->
+    lager:info("round ~p (unstable): starting", [Round]),
+    %% get down nodes too just so it prints nicer, debug_get_tree handles them being down
+    Tree = rpc:call(SenderNode, riak_core_broadcast, debug_get_tree, [SenderNode, UpNodes ++ DownNodes]),
+    lager:info("round ~p (unstable): tree before sending ~p", [Round, Tree]),
+    {FailedNode, RemainingNodes} = fail_node(Round, OtherNodes),
+    NewUpNodes = [SenderNode | RemainingNodes],
+    SendFun(SenderNode, Round),
+    lager:info("round: ~p (unstable): waiting until updates have reached all running nodes", [Round]),
+    try ConsistentFun(NewUpNodes, Round) of
+        _ ->
+            run_rounds(Round - 1, 0, SendFun, ConsistentFun, NewUpNodes, [FailedNode | DownNodes])
+    catch
+        _:_ ->
+            NumDown = length([FailedNode | DownNodes]),
+            NumUp = length(NewUpNodes),
+            Total = NumDown + NumUp,
+            lager:error("round ~p (unstable): consistency check failed w/ ~p down ~p up, total ~p",
+                        [Round, NumDown, NumUp, Total]),
+            [FailedNode | DownNodes]
+    end;
+run_rounds(Round, StableRound, SendFun, ConsistentFun, [SenderNode | _]=UpNodes, DownNodes) ->
+    lager:info("round ~p (stable): starting", [Round]),
+    SendFun(SenderNode, Round),
+    lager:info("round ~p (stable): waiting until there are no messages left", [Round]),
+    wait_until_no_messages(),
+    lager:info("round ~p (stable): waiting until updates have reached all running nodes", [Round]),
+    ConsistentFun(UpNodes, Round),
+    run_rounds(Round - 1, StableRound - 1, SendFun, ConsistentFun, UpNodes, DownNodes).
+
+fail_node(Round, OtherNodes) ->
+    Failed = lists:nth(random:uniform(length(OtherNodes)), OtherNodes),
+    lager:info("round: ~p (unstable): shutting down ~p", [Round, Failed]),
+    rt:stop(Failed),
+    {Failed, lists:delete(Failed, OtherNodes)}.
+
+calc_stuff(AllNodes, NumNodes, NumRounds) ->
+    History = cluster_meta_proxy_server:history(),
+    %% GossipHistory = [{From, To, element(2, riak_core_ring:get_meta(round, R))} ||
+    %%                     {From, To, {reconcile_ring, R}} <- History, riak_core_ring:get_meta(round, R) =/= undefined],
+    %% lager:info("GOSSIP HISTORY:"),
+    %% [lager:info("~p", [X]) || X <- GossipHistory],
+    ResultsDict = calc_stuff(AllNodes, History),
+    ResultsList = lists:reverse(orddict:to_list(ResultsDict)),
+    ResultsFileName = io_lib:format("results-~p.csv", [NumNodes]),
+    {ok, ResultsFile} = file:open(ResultsFileName, [write]),
+    io:format(ResultsFile, "round,broadcastrmr,gossiprmr,broadcastldh,gossipldh~n", []),
+    [io:format(ResultsFile, "~p,~p,~p,~p,~p~n", [abs(Round - NumRounds), BRMR, GRMR, BLDH, GLDH])
+     || {{round, Round}, {{BRMR, GRMR}, {BLDH, GLDH}}} <- ResultsList],
+    lager:info("NumNodes: ~p NumRounds: ~p RESULTS: ~p", [NumNodes, NumRounds, ResultsList]).
+
+calc_stuff(AllNodes, History) ->
+    CountDict = lists:foldl(fun process_message/2, orddict:new(), History),
+    RMRN = length(AllNodes) - 1,
+    orddict:fold(fun(TestRound, Info, AccDict) ->
+                         {BroadcastCount, BroadcastLDH} = proplists:get_value(broadcast, Info),
+                         {GossipCount, GossipLDH} = proplists:get_value(gossip, Info, {0, 0}),
+                         BroadcastRMR = (BroadcastCount / RMRN) - 1,
+                         GossipRMR = (GossipCount / RMRN) - 1,
+                         %% add 1 to LDHs since rounds are zero based
+                         orddict:store(TestRound, {{BroadcastRMR, GossipRMR}, {BroadcastLDH+1, GossipLDH+1}}, AccDict)
+                 end, orddict:new(), CountDict).
+
+
+process_message({_From, _To,
+                 {broadcast, {{?CM_PREFIX, {round, TestRound}}, _Ctx}, _Payload, _Mod, BCastRound, _Root, _From}},
+                ResultsDict) ->
+    case orddict:find({round, TestRound}, ResultsDict) of
+        error ->
+            orddict:store({round, TestRound}, [{broadcast, {1, BCastRound}}], ResultsDict);
+        {ok, Info} ->
+            {CurrentCount, LastBCastRound} = proplists:get_value(broadcast, Info, {1, BCastRound}),
+            NewInfo = lists:keystore(broadcast, 1, Info, {broadcast, {CurrentCount+1, max(LastBCastRound, BCastRound)}}),
+            orddict:store({round, TestRound}, NewInfo, ResultsDict)
+    end;
+%process_message({_From, _To,
+%                 {reconcile_ring, OutRing}}, {CountDict, LDHDict}) ->
+%    CountDict1 = case riak_core_ring:get_meta(round, OutRing) of
+%                     undefined -> CountDict; %% not a gossip message we sent (e.g. owneship change building cluster)
+%                     {ok, Round} -> orddict:update_counter({gossip, Round}, 1, CountDict)
+%                 end,
+%    {CountDict1, LDHDict};
+process_message({_From, _To,
+                 {reconcile_ring, GossipRound, OutRing}}, ResultsDict) ->
+    case riak_core_ring:get_meta(round, OutRing) of
+        undefined -> ResultsDict;
+        {ok, TestRound} ->
+        case orddict:find({round, TestRound}, ResultsDict) of
+            error ->
+                orddict:store({round, TestRound}, [{gossip, {1, GossipRound}}], ResultsDict);
+            {ok, Info} ->
+                {CurrentCount, LastGossipRound} = proplists:get_value(gossip, Info, {1, GossipRound}),
+                NewInfo = lists:keystore(gossip, 1, Info, {gossip, {CurrentCount+1, max(LastGossipRound, GossipRound)}}),
+                orddict:store({round, TestRound}, NewInfo, ResultsDict)
+        end
+    end;
+process_message(_Msg, Acc) ->
+    Acc.
+
+broadcast(SenderNode, Round) ->
+    %% TODO: don't use metadata manager?
+    Key = mk_key(Round),
+    Value = mk_value(Round),
+    ok = rpc:call(SenderNode, riak_core_metadata, put, [?CM_PREFIX, Key, Value]).
+
+%gossip(SenderNode, Round) ->
+%    Value = mk_value(Round),
+%    {ok, _} = rpc:call(SenderNode, riak_core_ring, update_round, [Value]).
+
+wait_until_no_messages() ->
+    F = fun() ->
+                cluster_meta_proxy_server:is_empty(5)
+        end,
+    ok = rt:wait_until(F).
+
+wait_until_broadcast_consistent(Nodes, Round) ->
+    Key = mk_key(Round),
+    Value = mk_value(Round),
+    wait_until_metadata_value(Nodes,Key, Value).
+
+wait_until_metadata_value(Nodes, Key, Val) when is_list(Nodes) ->
+    [wait_until_metadata_value(Node, Key, Val) || Node <- Nodes];
+wait_until_metadata_value(Node, Key, Val) ->
+    F = fun() ->
+                %% no need to resolve b/c we use a single sender
+                Val =:= metadata_get(Node, Key)
+        end,
+    ok = rt:wait_until(F, 10, 500).
+
+metadata_get(Node, Key) ->
+    rpc:call(Node, riak_core_metadata, get, [?CM_PREFIX, Key]).
+
+%wait_until_gossip_consistent(Nodes, Round) ->
+%    Value = mk_value(Round),
+%    wait_until_bucket_value(Nodes, Value).
+
+%wait_until_bucket_value(Nodes, Val) when is_list(Nodes) ->
+%    [wait_until_bucket_value(Node, Val) || Node <- Nodes];
+%wait_until_bucket_value(Node, Val) ->
+%    F = fun() ->
+%                {ok, Ring} = rpc:call(Node, riak_core_ring_manager, get_my_ring, []),
+%                {ok, Val} =:= riak_core_ring:get_meta(round, Ring)
+%        end,
+%    ok = rt:wait_until(F).
+
+mk_key(Round) ->
+    {round, Round}.
+
+mk_value(Round) ->
+    Round.


### PR DESCRIPTION
The changes to `cluster_meta_basic` increase some coverage of this sanity check test. `cluster_meta_rmr` is a test not destined for a giddyup suite but I think is useful to have in the ~~develop~~ master branch. It can be run against a `riak_core` cluster to measure certain properties of cluster meta. It is admittedly a bit impractical for some to run, because any useful measurements require at least 10 to 40 nodes. To make sure it is runnable, i have commented out the requirement of such a high node-count and instead defaulted it to use the standard five node devrel so a reviewer can try and run it. In addition, running this test at higher node counts requires working around the `nothing_planned` issue. No workaround for that issue provided as part of this PR. 

The changes to `cluster_meta_basic` require https://github.com/basho/riak_core/pull/457

Partially addresses https://github.com/basho/riak_core/issues/373
