### PR TITLE
Ensure we re-connect to the proper sink leader.

### DIFF
--- a/intercepts/riak_repl2_leader_intercepts.erl
+++ b/intercepts/riak_repl2_leader_intercepts.erl
@@ -1,0 +1,19 @@
+-module(riak_repl2_leader_intercepts).
+-compile(export_all).
+-include("intercept.hrl").
+
+-define(M, riak_repl2_leader_orig).
+
+set_leader_node3(LocalPid, LeaderNode, LeaderPid) ->
+    io:format("Intercept triggered on node ~p with ~p ~p ~p",
+              [node(), LocalPid, LeaderNode, LeaderPid]),
+    ?I_INFO("Intercept triggered on node ~p with ~p ~p ~p",
+            [node(), LocalPid, LeaderNode, LeaderPid]),
+    ?M:set_leader_orig(LocalPid, 'dev3@127.0.0.1', undefined).
+
+set_leader_node4(LocalPid, LeaderNode, LeaderPid) ->
+    io:format("Intercept triggered on node ~p with ~p ~p ~p",
+              [node(), LocalPid, LeaderNode, LeaderPid]),
+    ?I_INFO("Intercept triggered on node ~p with ~p ~p ~p",
+            [node(), LocalPid, LeaderNode, LeaderPid]),
+    ?M:set_leader_orig(LocalPid, 'dev4@127.0.0.1', undefined).


### PR DESCRIPTION
Ensures that when the same node becomes re-elected, we reconnect to all
clusters that may have been not connected.

The only weirdness here is that the proxy_get may return not_found, if I 
haven't verified it's been written to the source node and potentially performed
read repair for missing replicas before issuing the proxy_get.  
