### PR TITLE
Exercise 2i sort parameter

### DIFF
--- a/tests/secondary_index_tests.erl
+++ b/tests/secondary_index_tests.erl
@@ -178,13 +178,15 @@ put_an_object(Pid, N) ->
               ],
     put_an_object(Pid, Key, Data, Indexes).
 
-put_an_object(Pid, Key, Data, Indexes) ->
+put_an_object(Pid, Key, Data, Indexes) when is_list(Indexes) ->
     lager:info("Putting object ~p", [Key]),
     MetaData = dict:from_list([{<<"index">>, Indexes}]),
     Robj0 = riakc_obj:new(?BUCKET, Key),
     Robj1 = riakc_obj:update_value(Robj0, Data),
     Robj2 = riakc_obj:update_metadata(Robj1, MetaData),
-    riakc_pb_socket:put(Pid, Robj2).
+    riakc_pb_socket:put(Pid, Robj2);
+put_an_object(Pid, Key, IntIndex, BinIndex) when is_integer(IntIndex), is_binary(BinIndex) ->
+    put_an_object(Pid, Key, Key, [{"field1_bin", BinIndex},{"field2_int", IntIndex}]).
 
 int_to_key(N) ->
     case N < 100 of
@@ -293,7 +295,7 @@ start_http_stream(Ref) ->
     receive
         {http, {Ref, stream_start, Headers}} ->
             Boundary = get_boundary(proplists:get_value("content-type", Headers)),
-            http_stream_loop(Ref, orddict:new(), Boundary);
+            http_stream_loop(Ref, <<>>, Boundary);
         Other -> lager:error("Unexpected message ~p", [Other]),
                  {error, unknown_message}
     after 60000 ->
@@ -302,18 +304,19 @@ start_http_stream(Ref) ->
 
 http_stream_loop(Ref, Acc, {Boundary, BLen}=B) ->
     receive
+        {http, {Ref, stream, Chunk}} ->
+            http_stream_loop(Ref, <<Acc/binary,Chunk/binary>>, B);
         {http, {Ref, stream_end, _Headers}} ->
-            orddict:to_list(Acc);
-        {http, {Ref, stream, <<"\r\n--", Boundary:BLen/bytes, "\r\nContent-Type: application/json\r\n\r\n", Body/binary>>}} ->
-            ReverseBoundary = reverse_bin(<<"\r\n--", Boundary:BLen/binary, "--\r\n">>),
-            Message = get_message(ReverseBoundary, reverse_bin(Body)),
-            {struct, Result} = mochijson2:decode(Message),
-            Acc2 = lists:foldl(fun({K, V}, A) -> orddict:update(K, fun(Existing) -> Existing++V end, V, A) end,
-                               Acc,
-                               Result),
-            http_stream_loop(Ref, Acc2, B);
-        {http, {Ref, stream, <<"\r\n--", Boundary:BLen/bytes, "--\r\n">>}} ->
-            http_stream_loop(Ref, Acc, B);
+            Parts = binary:split(Acc,[
+                        <<"\r\n--", Boundary:BLen/bytes, "\r\nContent-Type: application/json\r\n\r\n">>,
+                        <<"\r\n--", Boundary:BLen/bytes,"--\r\n">>
+                        ], [global, trim]),
+            lists:foldl(fun(<<>>, Results) -> Results;
+                    (Part, Results) ->
+                        {struct, Result} = mochijson2:decode(Part),
+                        orddict:merge(fun(_K, V1, V2) -> V1 ++ V2 end,
+                                    Results, Result)
+                end, [], Parts);
         Other -> lager:error("Unexpected message ~p", [Other]),
                  {error, unknown_message}
     after 60000 ->
@@ -325,16 +328,4 @@ get_boundary("multipart/mixed;boundary=" ++ Boundary) ->
     {B, byte_size(B)};
 get_boundary(_) ->
     undefined.
-
-reverse_bin(Bin) ->
-    list_to_binary(lists:reverse(binary_to_list(Bin))).
-
-get_message(Boundary, Body) ->
-    BLen = byte_size(Boundary),
-    case Body of
-        <<Boundary:BLen/binary, Message/binary>> ->
-            reverse_bin(Message);
-        _ -> reverse_bin(Body)
-    end.
-
 

--- a/tests/verify_2i_returnterms.erl
+++ b/tests/verify_2i_returnterms.erl
@@ -47,9 +47,7 @@ confirm() ->
     ExpectedFooKeys = lists:sort([int_to_key(N) || N <- lists:seq(101, 200)]),
     assertEqual(RiakHttp, PBPid, ExpectedFooKeys, {<<"field1_bin">>, ?FOO}, ?Q_OPTS, keys),
 
-    %% Note: not sorted by key, but by value (the int index)
-    %% Should return "val, key" pairs
-    ExpectedRangeResults = [{list_to_binary(integer_to_list(N)), int_to_key(N)} || N <- lists:seq(1, 100)],
+    ExpectedRangeResults = lists:sort([{list_to_binary(integer_to_list(N)), int_to_key(N)} || N <- lists:seq(1, 100)]),
     assertEqual(RiakHttp, PBPid, ExpectedRangeResults, {<<"field2_int">>, "1", "100"}, ?Q_OPTS, results),
 
     riakc_pb_socket:stop(PBPid),
@@ -63,8 +61,8 @@ assertEqual(Http, PB, Expected, Query, Opts, ResultKey) ->
     HTTPRes = http_query(Http, Query, Opts),
     HTTPResults0 = proplists:get_value(atom_to_binary(ResultKey, latin1), HTTPRes, []),
     HTTPResults = decode_http_results(ResultKey, HTTPResults0),
-    ?assertEqual(Expected, PBKeys),
-    ?assertEqual(Expected, HTTPResults).
+    ?assertEqual(Expected, lists:sort(PBKeys)),
+    ?assertEqual(Expected, lists:sort(HTTPResults)).
 
 decode_http_results(keys, Keys) ->
     Keys;

--- a/tests/verify_2i_stream.erl
+++ b/tests/verify_2i_stream.erl
@@ -54,14 +54,15 @@ confirm() ->
 
 %% Check the PB result against our expectations
 %% and the non-streamed HTTP
-assertEqual(Http, PB, Expected, Query) ->
+assertEqual(Http, PB, Expected0, Query) ->
     {ok, PBRes} = stream_pb(PB, Query),
     PBKeys = proplists:get_value(keys, PBRes, []),
     HTTPRes = http_query(Http, Query),
     StreamHTTPRes = http_stream(Http, Query, []),
     HTTPKeys = proplists:get_value(<<"keys">>, HTTPRes, []),
     StreamHttpKeys = proplists:get_value(<<"keys">>, StreamHTTPRes, []),
-    ?assertEqual(Expected, PBKeys),
-    ?assertEqual(Expected, HTTPKeys),
-    ?assertEqual(Expected, StreamHttpKeys).
+    Expected = lists:sort(Expected0),
+    ?assertEqual(Expected, lists:sort(PBKeys)),
+    ?assertEqual(Expected, lists:sort(HTTPKeys)),
+    ?assertEqual(Expected, lists:sort(StreamHttpKeys)).
 

--- a/tests/verify_2i_timeout.erl
+++ b/tests/verify_2i_timeout.erl
@@ -45,7 +45,7 @@ confirm() ->
 
     %% Override app.config
     {ok, Res} =  stream_pb(PBPid, Query, [{timeout, 5000}]),
-    ?assertEqual(ExpectedKeys, proplists:get_value(keys, Res, [])),
+    ?assertEqual(ExpectedKeys, lists:sort(proplists:get_value(keys, Res, []))),
 
     {ok, {{_, ErrCode, _}, _, Body}} = httpc:request(url("~s/buckets/~s/index/~s/~s~s",
                                                      [Http, ?BUCKET, <<"$bucket">>, ?BUCKET, []])),
@@ -54,7 +54,7 @@ confirm() ->
     ?assertMatch({match, _}, re:run(Body, "request timed out|{error,timeout}")), %% shows the app.config timeout
 
     HttpRes = http_query(Http, Query, [{timeout, 5000}]),
-    ?assertEqual(ExpectedKeys, proplists:get_value(<<"keys">>, HttpRes, [])),
+    ?assertEqual(ExpectedKeys, lists:sort(proplists:get_value(<<"keys">>, HttpRes, []))),
 
     stream_http(Http, Query, ExpectedKeys),
 
@@ -65,5 +65,5 @@ stream_http(Http, Query, ExpectedKeys) ->
      Res = http_stream(Http, Query, []),
      ?assert(lists:member({<<"error">>,<<"timeout">>}, Res)),
      Res2 = http_stream(Http, Query, [{timeout, 5000}]),
-     ?assertEqual(ExpectedKeys, proplists:get_value(<<"keys">>, Res2, [])).
+     ?assertEqual(ExpectedKeys, lists:sort(proplists:get_value(<<"keys">>, Res2, []))).
 


### PR DESCRIPTION
The default when sort is off is undefined, but this test at least tries
to verify that results are sorted when it's set or defaults to true.
Notice that sort order is not key, but rather <2i term that matched>/key

/cc @russelldb This is the rebase/merged/reworked for 1.4 version of the test needed for the 1.4.4 release. Did you have to tweak other tests during the review? Anyway, I will be trying all other 2i riak_tests in the 1.4 branch to see what else might need an update/sync with 2.0

This needs an update to the HTTP client to pass: https://github.com/basho/riak-erlang-http-client/pull/29
