### PR TITLE
init ~/rt/riak even if releases aren't built

### DIFF
--- a/bin/rtdev-setup-releases.sh
+++ b/bin/rtdev-setup-releases.sh
@@ -15,19 +15,31 @@ echo " - Creating $RT_DEST_DIR"
 
 rm -rf $RT_DEST_DIR
 mkdir -p $RT_DEST_DIR
-for rel in */dev; do
-    vsn=$(dirname "$rel")
-    echo " - Initializing $RT_DEST_DIR/$vsn"
-    mkdir -p "$RT_DEST_DIR/$vsn"
-    cp -p -P -R "$rel" "$RT_DEST_DIR/$vsn"
-done
+
+count=$(ls */dev 2> /dev/null | wc -l)
+if [ "$count" -ne "0" ]
+then
+    for rel in */dev; do
+        vsn=$(dirname "$rel")
+        echo " - Initializing $RT_DEST_DIR/$vsn"
+        mkdir -p "$RT_DEST_DIR/$vsn"
+        cp -p -P -R "$rel" "$RT_DEST_DIR/$vsn"
+    done
+else
+    # This is useful when only testing with 'current'
+    # The repo still needs to be initialized for current
+    # and we don't want to bomb out if */dev doesn't exist
+    touch $RT_DEST_DIR/.current_init
+    echo "No devdirs found. Not copying any releases."
+fi
+
 cd $RT_DEST_DIR
-echo " - Creating the git repository"
-git init > /dev/null 2>&1
+git init 
 
 ## Some versions of git and/or OS require these fields
 git config user.name "Riak Test"
 git config user.email "dev@basho.com"
 
 git add .
-git commit -a -m "riak_test init" > /dev/null 2>&1
+git commit -a -m "riak_test init" > /dev/null
+echo " - Successfully completed initial git commit of $RT_DEST_DIR"


### PR DESCRIPTION
This change allows initialization of ~/rt/riak to proceed even if
releases aren't built, or if you run this script outside of your
test-releases directory. It will report this to the user however.

This is useful if you only want to run riak tests against current. New
users of riak test and people working on bugs on crazy branches will
especially want this since they likely do not want to take the time to
build multiple releases that may not even be relevant to the bug.
