### PR TITLE
Use 1.4 branches of erlang clients

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -12,8 +12,8 @@
         {getopt, ".*", {git, "git://github.com/jcomellas/getopt", {tag, "v0.4"}}},
         {meck, ".*", {git, "git://github.com/eproxus/meck"}},
         {mapred_verify, ".*", {git, "git://github.com/basho/mapred_verify"}},
-        {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client",{tag,"1.4.1"}}},
-        {riakhttpc, ".*", {git, "git://github.com/basho/riak-erlang-http-client"}},
+        {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {branch, "1.4"}}},
+        {riakhttpc, ".*", {git, "git://github.com/basho/riak-erlang-http-client", {branch, "1.4"}}},
         {kvc, "1.3.0", {git, "https://github.com/etrepum/kvc", {tag, "v1.3.0"}}}
        ]}.
 


### PR DESCRIPTION
@jaredmorrow @cmeiklejohn These are the rebar changes to make sure riak_test in riak/1.4 points to the right clients, riak_pb, protobuffs, etc. I tested manually by doing a fresh riak_test clone, get-deps and running the riak/1.4 2i tests.
