### PR TITLE
Test that link walking and erlang mapreduce with untrusted modules is not allowed

### DIFF
--- a/tests/pb_security.erl
+++ b/tests/pb_security.erl
@@ -56,7 +56,10 @@ confirm() ->
                     ]},
             {riak_core, [
                          {security, true}
-                        ]}
+                        ]},
+            {riak_search, [
+                           {enabled, true}
+                          ]}
            ],
 
     MD = riak_test_runner:metadata(),
@@ -740,6 +743,9 @@ group_test(Node, Port, CertDir) ->
     ?assertMatch({error, notfound}, (riakc_pb_socket:get(PB, {<<"mytype2">>,
                                                               <<"hello">>},
                                                           <<"world">>))),
+
+    lager:info("riak search should not be running with security enabled"),
+    ?assertEqual({error, <<"Unknown message code.">>}, riakc_pb_socket:search(PB, <<"index">>, <<"foo:bar">>)),
 
     riakc_pb_socket:stop(PB),
     ok.


### PR DESCRIPTION
See also basho/riak_kv#756
