### PR TITLE
The test as written relies on the sorted 2i

### DIFF
--- a/tests/client_python_verify.erl
+++ b/tests/client_python_verify.erl
@@ -14,7 +14,8 @@
 
 confirm() ->
     {ok, TestCommand} = prereqs(),
-    Config = [{riak_search, [{enabled, true}]}],
+    Config = [{riak_kv, [{secondary_index_sort_default, true}]},
+              {riak_search, [{enabled, true}]}],
     [Node] = rt:deploy_nodes(1, Config),
     rt:wait_for_service(Node, riak_search),
 


### PR DESCRIPTION
This change configures the nodes to mimic the sorted 2i results as they
were in the 1.4 series before 1.4.4 made it optional.
