### PR TITLE
Use riak_core_cluster_conn API to get connection status

### DIFF
--- a/tests/repl_util.erl
+++ b/tests/repl_util.erl
@@ -198,11 +198,11 @@ wait_for_connection(Node, Name) ->
                             [] ->
                                 false;
                             [Pid] ->
-                                Pid ! {self(), status},
-                                receive
-                                    {Pid, status, _} ->
+                                Status = riak_core_cluster_conn:status(Pid),
+                                case Status of
+                                    {Pid, status, {_, _, _, _}} ->
                                         true;
-                                    {Pid, connecting, _} ->
+                                    _ ->
                                         false
                                 end
                         end;


### PR DESCRIPTION
Use riak_core_cluster_conn API to get connection status instead of raw message
passing.

Please do not merge this until [this](https://github.com/basho/riak_repl/pull/498) riak_repl PR has been merged.
