### PR TITLE
Test 2i features added in 1.4.4

### DIFF
--- a/intercepts/riak_object_intercepts.erl
+++ b/intercepts/riak_object_intercepts.erl
@@ -1,0 +1,20 @@
+-module(riak_object_intercepts).
+-export([skippable_index_specs/1,
+         skippable_diff_index_specs/2]).
+-include("intercept.hrl").
+
+skippable_index_specs(Obj) ->
+    case app_helper:get_env(riak_kv, skip_index_specs, false) of
+        false ->
+            riak_object_orig:index_specs_orig(Obj);
+        true ->
+            []
+    end.
+
+skippable_diff_index_specs(Obj, OldObj) ->
+    case app_helper:get_env(riak_kv, skip_index_specs, false) of
+        false ->
+            riak_object_orig:diff_index_specs_orig(Obj, OldObj);
+        true ->
+            []
+    end.

--- a/src/rt.erl
+++ b/src/rt.erl
@@ -122,6 +122,7 @@
          wait_until/3,
          wait_until/2,
          wait_until/1,
+         wait_until_aae_trees_built/1,
          wait_until_all_members/1,
          wait_until_all_members/2,
          wait_until_capability/3,
@@ -752,6 +753,28 @@ wait_until_nodes_agree_about_ownership(Nodes) ->
     lager:info("Wait until nodes agree about ownership ~p", [Nodes]),
     Results = [ wait_until_owners_according_to(Node, Nodes) || Node <- Nodes ],
     ?assert(lists:all(fun(X) -> ok =:= X end, Results)).
+
+%% AAE support
+wait_until_aae_trees_built([AnyNode|_]=Nodes) ->
+    lager:info("Wait until AAE builds all partition trees across ~p", [Nodes]),
+    %% Wait until all nodes report no undefined trees
+    rt:wait_until(AnyNode,
+                  fun(_) ->
+                          Busy = lists:foldl(
+                                   fun(Node,Busy1) ->
+                                           %% will be false when all trees are built on Node
+                                           lists:keymember(undefined,
+                                                           2,
+                                                           rpc:call(Node,
+                                                                    riak_kv_entropy_info,
+                                                                    compute_tree_info,
+                                                                    []))
+                                               or Busy1
+                                   end,
+                                   false,
+                                   Nodes),
+                          not Busy
+                  end).
 
 %%%===================================================================
 %%% Ring Functions

--- a/tests/client_python_verify.erl
+++ b/tests/client_python_verify.erl
@@ -16,7 +16,8 @@ confirm() ->
     %% test requires allow_mult=false b/c of rt:systest_read
     rt:set_conf(all, [{"buckets.default.siblings", "off"}]),    
     {ok, TestCommand} = prereqs(),
-    Config = [{riak_search, [{enabled, true}]}],
+    Config = [{riak_kv, [{secondary_index_sort_default, true}]},
+              {riak_search, [{enabled, true}]}],
     [Node] = rt:deploy_nodes(1, Config),
     rt:wait_for_service(Node, riak_search),
 

--- a/tests/verify_2i_aae.erl
+++ b/tests/verify_2i_aae.erl
@@ -1,0 +1,189 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(verify_2i_aae).
+-behaviour(riak_test).
+-export([confirm/0]).
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("riakc/include/riakc.hrl").
+
+%% Make it multi-backend compatible.
+-define(BUCKETS, [<<"eleveldb1">>, <<"memory1">>]).
+-define(NUM_ITEMS, 1000).
+-define(NUM_DELETES, 100).
+-define(SCAN_BATCH_SIZE, 100).
+-define(N_VAL, 3).
+
+confirm() ->
+    Nodes =
+    [Node1] = rt:build_cluster(1,
+                               [{riak_kv,
+                                 [{anti_entropy_build_limit, {100, 1000}},
+                                  {anti_entropy_concurrency, 100},
+                                  {anti_entropy_tick, 1000}]}]),
+    rt:wait_until_aae_trees_built(Nodes),
+    rt_intercept:load_code(Node1),
+    rt_intercept:add(Node1,
+                     {riak_object,
+                      [{{index_specs, 1}, skippable_index_specs},
+                       {{diff_index_specs, 2}, skippable_diff_index_specs}]}),
+    lager:info("Installed intercepts to corrupt index specs on node ~p", [Node1]),
+    PBC = rt:pbc(Node1),
+    NumItems = ?NUM_ITEMS,
+    %%NumDelItems = NumItems div 10,
+    NumDel = ?NUM_DELETES,
+    pass = check_lost_objects(Node1, PBC, NumItems, NumDel),
+    pass = check_lost_indexes(Node1, PBC, NumItems),
+    pass = check_kill_repair(Node1),
+    lager:info("Et voila"),
+    riakc_pb_socket:stop(PBC),
+    pass.
+
+%% Write objects with a 2i index. Modify/delete the objects without updating
+%% the 2i index. Test that running 2i repair corrects the 2i indexes.
+check_lost_objects(Node1, PBC, NumItems, NumDel) ->
+    Index = {integer_index, "i"},
+    set_skip_index_specs(Node1, false),
+    lager:info("Putting ~p objects with indexes", [NumItems]),
+    [put_obj(PBC, Bucket, N, N+1, Index) || N <- lists:seq(1, NumItems),
+                                            Bucket <- ?BUCKETS],
+    %% Verify they are there.
+    ExpectedInitial = [{to_key(N+1), to_key(N)} || N <- lists:seq(1, NumItems)],
+    lager:info("Check objects are there as expected"),
+    [assert_range_query(PBC, Bucket, ExpectedInitial, Index, 1, NumItems+1)
+     || Bucket <- ?BUCKETS],
+    lager:info("Now mess index spec code and change values"),
+    set_skip_index_specs(Node1, true),
+    [put_obj(PBC, Bucket, N, N, Index) || N <- lists:seq(1, NumItems-NumDel),
+                                          Bucket <- ?BUCKETS],
+    DelRange = lists:seq(NumItems-NumDel+1, NumItems),
+    lager:info("Deleting ~b objects without updating indexes", [NumDel]),
+    [del_obj(PBC, Bucket, N) || N <- DelRange, Bucket <- ?BUCKETS],
+    DelKeys = [to_key(N) || N <- DelRange],
+    [rt:wait_until(fun() -> rt:pbc_really_deleted(PBC, Bucket, DelKeys) end)
+     || Bucket <- ?BUCKETS],
+    %% Verify they are damaged
+    lager:info("Verify change did not take, needs repair"),
+    [assert_range_query(PBC, Bucket, ExpectedInitial, Index, 1, NumItems+1)
+     || Bucket <- ?BUCKETS],
+    set_skip_index_specs(Node1, false),
+    run_2i_repair(Node1),
+    lager:info("Now verify that previous changes are visible after repair"),
+    ExpectedFinal = [{to_key(N), to_key(N)} || N <- lists:seq(1, NumItems-NumDel)],
+    [assert_range_query(PBC, Bucket, ExpectedFinal, Index, 1, NumItems+1)
+     || Bucket <- ?BUCKETS],
+    pass.
+
+%% Write objects without a 2i index. Test that running 2i repair will generate
+%% the missing indexes.
+check_lost_indexes(Node1, PBC, NumItems) ->
+    set_skip_index_specs(Node1, true),
+    Index = {integer_index, "ii"},
+    lager:info("Writing ~b objects without index", [NumItems]),
+    [put_obj(PBC, Bucket, N, N+1, Index) || Bucket <- ?BUCKETS,
+                                            N <- lists:seq(1, NumItems)],
+    lager:info("Verify that objects cannot be found via index"),
+    [assert_range_query(PBC, Bucket, [], Index, 1, NumItems+1)
+     || Bucket <- ?BUCKETS],
+    run_2i_repair(Node1),
+    lager:info("Check that objects can now be found via index"),
+    Expected = [{to_key(N+1), to_key(N)} || N <- lists:seq(1, NumItems)],
+    [assert_range_query(PBC, Bucket, Expected, Index, 1, NumItems+1)
+     || Bucket <- ?BUCKETS],
+    pass.
+
+check_kill_repair(Node1) ->
+    lager:info("Test that killing 2i repair works as desired"),
+    spawn(fun() ->
+                  timer:sleep(1500),
+                  rt:admin(Node1, ["repair-2i", "kill"])
+          end),
+    ExitStatus = run_2i_repair(Node1),
+    case ExitStatus of
+        normal ->
+            lager:info("Shucks. Repair finished before we could kill it");
+        killed ->
+            lager:info("Repair was forcibly killed");
+        user_request ->
+            lager:info("Repair exited gracefully, we should be able to "
+                       "trigger another repair immediately"),
+            normal = run_2i_repair(Node1)
+    end,
+    pass.
+
+run_2i_repair(Node1) ->
+    lager:info("Run 2i AAE repair"),
+    ?assertMatch({ok, _}, rt:admin(Node1, ["repair-2i"])),
+    RepairPid = rpc:call(Node1, erlang, whereis, [riak_kv_2i_aae]),
+    lager:info("Wait for repair process to finish"),
+    Mon = monitor(process, RepairPid),
+    MaxWaitTime = rt_config:get(rt_max_wait_time),
+    receive
+        {'DOWN', Mon, _, _, Status} ->
+            lager:info("Status: ~p", [Status]),
+            Status
+    after
+        MaxWaitTime ->
+            lager:error("Timed out (~pms) waiting for 2i AAE repair process", [MaxWaitTime]),
+            ?assertEqual(aae_2i_repair_complete, aae_2i_repair_timeout)
+    end.
+
+set_skip_index_specs(Node, Val) ->
+    ok = rpc:call(Node, application, set_env,
+                  [riak_kv, skip_index_specs, Val]).
+
+to_key(N) ->
+    list_to_binary(integer_to_list(N)).
+
+put_obj(PBC, Bucket, N, IN, Index) ->
+    K = to_key(N),
+    Obj =
+    case riakc_pb_socket:get(PBC, Bucket, K) of
+        {ok, ExistingObj} ->
+            ExistingObj;
+        _ ->
+            riakc_obj:new(Bucket, K, K)
+    end,
+    MD = riakc_obj:get_metadata(Obj),
+    MD2 = riakc_obj:set_secondary_index(MD, {Index, [IN]}),
+    Obj2 = riakc_obj:update_metadata(Obj, MD2),
+    riakc_pb_socket:put(PBC, Obj2, [{dw, ?N_VAL}]).
+
+del_obj(PBC, Bucket, N) ->
+    K = to_key(N),
+    case riakc_pb_socket:get(PBC, Bucket, K) of
+        {ok, ExistingObj} ->
+            ?assertMatch(ok, riakc_pb_socket:delete_obj(PBC, ExistingObj));
+        _ ->
+            ?assertMatch(ok, riakc_pb_socket:delete(PBC, Bucket, K))
+    end.
+
+
+assert_range_query(Pid, Bucket, Expected0, Index, StartValue, EndValue) ->
+    lager:info("Searching Index ~p/~p for ~p-~p", [Bucket, Index, StartValue, EndValue]),
+    {ok, ?INDEX_RESULTS{terms=Keys}} = riakc_pb_socket:get_index_range(Pid, Bucket, Index, StartValue, EndValue, [{return_terms, true}]),
+    Actual = case Keys of
+                 undefined ->
+                     [];
+                 _ ->
+                     lists:sort(Keys)
+             end,
+    Expected = lists:sort(Expected0),
+    ?assertEqual({Bucket, Expected}, {Bucket, Actual}),
+    lager:info("Yay! ~b (actual) == ~b (expected)", [length(Actual), length(Expected)]).

--- a/tests/verify_2i_mixed_cluster.erl
+++ b/tests/verify_2i_mixed_cluster.erl
@@ -1,0 +1,75 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2012 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(verify_2i_mixed_cluster).
+-behavior(riak_test).
+-export([confirm/0]).
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("riakc/include/riakc.hrl").
+
+-import(secondary_index_tests, [put_an_object/2]).
+-define(BUCKET, <<"2ibucket">>).
+
+confirm() ->
+    TestMetaData = riak_test_runner:metadata(),
+    OldVsn = proplists:get_value(upgrade_version, TestMetaData, previous),
+    Nodes =
+    [CurrentNode, OldNode1, _] =
+    rt:build_cluster([{current,
+                               [{riak_kv, [{anti_entropy, {off, []}}]}]},
+                              OldVsn, OldVsn]),
+    ?assertEqual(ok, rt:wait_until_nodes_ready(Nodes)),
+    
+    PBC1 = rt:pbc(CurrentNode),
+    PBC2 = rt:pbc(OldNode1),
+    HTTPC1 = rt:httpc(CurrentNode),
+
+    Clients = [{pb, PBC1}, {pb, PBC2}, {http, HTTPC1}],
+    
+    [put_an_object(PBC1, N) || N <- lists:seq(0, 20)],
+    
+    K = fun secondary_index_tests:int_to_key/1,
+
+    assertExactQuery(Clients, [K(5)], <<"field1_bin">>, <<"val5">>),
+    assertExactQuery(Clients, [K(5)], <<"field2_int">>, 5),
+    assertExactQuery(Clients, [K(N) || N <- lists:seq(5, 9)], <<"field3_int">>, 5),
+    assertRangeQuery(Clients, [K(N) || N <- lists:seq(10, 18)], <<"field1_bin">>, <<"val10">>, <<"val18">>),
+    assertRangeQuery(Clients, [K(N) || N <- lists:seq(10, 19)], <<"field2_int">>, 10, 19),
+    assertRangeQuery(Clients, [K(N) || N <- lists:seq(10, 17)], <<"$key">>, <<"obj10">>, <<"obj17">>),
+
+    lager:info("Delete an object, verify deletion..."),
+    ToDel = [<<"obj05">>, <<"obj11">>],
+    [?assertMatch(ok, riakc_pb_socket:delete(PBC1, ?BUCKET, KD)) || KD <- ToDel],
+    lager:info("Make sure the tombstone is reaped..."),
+    ?assertMatch(ok, rt:wait_until(fun() -> rt:pbc_really_deleted(PBC1, ?BUCKET, ToDel) end)),
+    
+    assertExactQuery(Clients, [], <<"field1_bin">>, <<"val5">>),
+    assertExactQuery(Clients, [], <<"field2_int">>, 5),
+    assertExactQuery(Clients, [K(N) || N <- lists:seq(6, 9)], <<"field3_int">>, 5),
+    assertRangeQuery(Clients, [K(N) || N <- lists:seq(10, 18), N /= 11], <<"field1_bin">>, <<"val10">>, <<"val18">>),
+    assertRangeQuery(Clients, [K(N) || N <- lists:seq(10, 19), N /= 11], <<"field2_int">>, 10, 19),
+    assertRangeQuery(Clients, [K(N) || N <- lists:seq(10, 17), N /= 11], <<"$key">>, <<"obj10">>, <<"obj17">>),
+
+    pass.
+
+assertExactQuery(C, K, F, V) ->
+    secondary_index_tests:assertExactQuery(C, K, F, V, {false, false}).
+
+assertRangeQuery(C, K, F, V1, V2) ->
+    secondary_index_tests:assertRangeQuery(C, K, F, V1, V2, undefined, {false, false}).

--- a/tests/verify_2i_returnterms.erl
+++ b/tests/verify_2i_returnterms.erl
@@ -47,9 +47,7 @@ confirm() ->
     ExpectedFooKeys = lists:sort([int_to_key(N) || N <- lists:seq(101, 200)]),
     assertEqual(RiakHttp, PBPid, ExpectedFooKeys, {<<"field1_bin">>, ?FOO}, ?Q_OPTS, keys),
 
-    %% Note: not sorted by key, but by value (the int index)
-    %% Should return "val, key" pairs
-    ExpectedRangeResults = [{list_to_binary(integer_to_list(N)), int_to_key(N)} || N <- lists:seq(1, 100)],
+    ExpectedRangeResults = lists:sort([{list_to_binary(integer_to_list(N)), int_to_key(N)} || N <- lists:seq(1, 100)]),
     assertEqual(RiakHttp, PBPid, ExpectedRangeResults, {<<"field2_int">>, "1", "100"}, ?Q_OPTS, results),
 
     riakc_pb_socket:stop(PBPid),
@@ -63,8 +61,8 @@ assertEqual(Http, PB, Expected, Query, Opts, ResultKey) ->
     HTTPRes = http_query(Http, Query, Opts),
     HTTPResults0 = proplists:get_value(atom_to_binary(ResultKey, latin1), HTTPRes, []),
     HTTPResults = decode_http_results(ResultKey, HTTPResults0),
-    ?assertEqual(Expected, PBKeys),
-    ?assertEqual(Expected, HTTPResults).
+    ?assertEqual(Expected, lists:sort(PBKeys)),
+    ?assertEqual(Expected, lists:sort(HTTPResults)).
 
 decode_http_results(keys, Keys) ->
     Keys;

--- a/tests/verify_2i_stream.erl
+++ b/tests/verify_2i_stream.erl
@@ -54,14 +54,15 @@ confirm() ->
 
 %% Check the PB result against our expectations
 %% and the non-streamed HTTP
-assertEqual(Http, PB, Expected, Query) ->
+assertEqual(Http, PB, Expected0, Query) ->
     {ok, PBRes} = stream_pb(PB, Query),
     PBKeys = proplists:get_value(keys, PBRes, []),
     HTTPRes = http_query(Http, Query),
     StreamHTTPRes = http_stream(Http, Query, []),
     HTTPKeys = proplists:get_value(<<"keys">>, HTTPRes, []),
     StreamHttpKeys = proplists:get_value(<<"keys">>, StreamHTTPRes, []),
-    ?assertEqual(Expected, PBKeys),
-    ?assertEqual(Expected, HTTPKeys),
-    ?assertEqual(Expected, StreamHttpKeys).
+    Expected = lists:sort(Expected0),
+    ?assertEqual(Expected, lists:sort(PBKeys)),
+    ?assertEqual(Expected, lists:sort(HTTPKeys)),
+    ?assertEqual(Expected, lists:sort(StreamHttpKeys)).
 

--- a/tests/verify_2i_timeout.erl
+++ b/tests/verify_2i_timeout.erl
@@ -45,7 +45,7 @@ confirm() ->
 
     %% Override app.config
     {ok, Res} =  stream_pb(PBPid, Query, [{timeout, 5000}]),
-    ?assertEqual(ExpectedKeys, proplists:get_value(keys, Res, [])),
+    ?assertEqual(ExpectedKeys, lists:sort(proplists:get_value(keys, Res, []))),
 
     {ok, {{_, ErrCode, _}, _, Body}} = httpc:request(url("~s/buckets/~s/index/~s/~s~s",
                                                      [Http, ?BUCKET, <<"$bucket">>, ?BUCKET, []])),
@@ -54,7 +54,7 @@ confirm() ->
     ?assertMatch({match, _}, re:run(Body, "request timed out|{error,timeout}")), %% shows the app.config timeout
 
     HttpRes = http_query(Http, Query, [{timeout, 5000}]),
-    ?assertEqual(ExpectedKeys, proplists:get_value(<<"keys">>, HttpRes, [])),
+    ?assertEqual(ExpectedKeys, lists:sort(proplists:get_value(<<"keys">>, HttpRes, []))),
 
     stream_http(Http, Query, ExpectedKeys),
 
@@ -65,5 +65,5 @@ stream_http(Http, Query, ExpectedKeys) ->
      Res = http_stream(Http, Query, []),
      ?assert(lists:member({<<"error">>,<<"timeout">>}, Res)),
      Res2 = http_stream(Http, Query, [{timeout, 5000}]),
-     ?assertEqual(ExpectedKeys, proplists:get_value(<<"keys">>, Res2, [])).
+     ?assertEqual(ExpectedKeys, lists:sort(proplists:get_value(<<"keys">>, Res2, []))).
 


### PR DESCRIPTION
- 2i AAE test
- term_regex 2i filter tests
- pagination sort tests
- add mixed cluster 2i test

_NOTE_ mixed cluster tests currently fail on the develop branch. We'll need to make sure verify_2i_mixed_cluster is OK once that's fixed.
