### PR TITLE
Changes to loaded_upgrade test to improve reliability

### DIFF
--- a/src/rt_worker_sup.erl
+++ b/src/rt_worker_sup.erl
@@ -23,11 +23,11 @@
 -behavior(supervisor).
 
 %% Helper macro for declaring children of supervisor
--define(CHILD(Id, Mod, Node, Backend, Vsn), { 
-    list_to_atom(atom_to_list(Node) ++ "_loader_" ++ integer_to_list(Id)), 
-    {   Mod, 
-        start_link, 
-        [list_to_atom(atom_to_list(Node) ++ "_loader_" ++ integer_to_list(Id)), Node, Backend, Vsn]}, 
+-define(CHILD(Id, Mod, Node, Backend, Vsn, ReportPid), {
+    list_to_atom(atom_to_list(Node) ++ "_loader_" ++ integer_to_list(Id)),
+    {   Mod,
+        start_link,
+        [list_to_atom(atom_to_list(Node) ++ "_loader_" ++ integer_to_list(Id)), Node, Backend, Vsn, ReportPid]},
         permanent, 5000, worker, [Mod]}).
 
 -export([init/1]).
@@ -41,9 +41,10 @@ init(Props) ->
     Node = proplists:get_value(node, Props),
     Backend = proplists:get_value(backend, Props),
     Vsn = proplists:get_value(version, Props),
+    ReportPid = proplists:get_value(report_pid, Props),
 
     ChildSpecs = [
-        ?CHILD(Num, loaded_upgrade_worker_sup, Node, Backend, Vsn)
+        ?CHILD(Num, loaded_upgrade_worker_sup, Node, Backend, Vsn, ReportPid)
     || Num <- lists:seq(1, WorkersPerNode)],
 
     lager:info("Starting ~p workers to ~p", [WorkersPerNode, Node]),


### PR DESCRIPTION
- Wait for services after upgrading a node
- Remove hardcoded sleep call
- Reduce time between upgrades from 300 to 120 seconds
- Refactor worker functions to accept a report pid parameter instead
  of assuming a loaded_upgrade named process.
- Remove the mapreduce load. The results of the mapreduce queries
  during node shutdown are not predictable enough at this time to rely
  on for this test.

Regarding the removal of the mapreduce load, I believe I have identified an issue with riak_pipe + mapreduce that can lead to work being sent to nodes where KV is already in the process of shutting down. The queries still return successfully, but it leads to unpredictable results and makes it inappropriate to rely on for this test. I think this could be improved by changing `riak_pipe` to allow the service used determining which nodes are available during coverage planning to be configurable. Currently it is hard coded to `riak_pipe`, but `riak_pipe` may shutdown after `riak_kv` and I think `riak_kv` should really be the service of more interest to mapreduce. This needs more investigation so for now the answer is to remove the mapreduce load. 
