### PR TITLE
Assume integer.

### DIFF
--- a/tests/partition_repair.erl
+++ b/tests/partition_repair.erl
@@ -35,8 +35,8 @@ confirm() ->
     TestMetaData = riak_test_runner:metadata(),
     KVBackend = proplists:get_value(backend, TestMetaData),
 
-    NumNodes = list_to_integer(rt_config:config_or_os_env(num_nodes, "4")),
-    HOConcurrency = list_to_integer(rt_config:config_or_os_env(ho_concurrency, "2")),
+    NumNodes = rt_config:config_or_os_env(num_nodes, 4),
+    HOConcurrency = rt_config:config_or_os_env(ho_concurrency, 2),
     {_KVBackendMod, KVDataDir} = backend_mod_dir(KVBackend),
     Bucket = <<"scotts_spam">>,
 


### PR DESCRIPTION
All of the replication tests assume that num_nodes will be an integer,
not a list.  Fix partition repair to do similar.  Also, change
ho_concurrency to be a integer as well.
