### PR TITLE
Add test to ensure modified objects replicate.

### DIFF
--- a/tests/repl_aae_fullsync.erl
+++ b/tests/repl_aae_fullsync.erl
@@ -39,6 +39,7 @@
         ]).
 
 confirm() ->
+    difference_test(),
     simple_test(),
     bidirectional_test(),
     dual_test(),
@@ -295,6 +296,98 @@ bidirectional_test() ->
     validate_completed_fullsync(LeaderB, AFirst, "A", ?NUM_KEYS + 1, ?NUM_KEYS + ?NUM_KEYS),
 
     %% Clean.
+    rt:clean_cluster(Nodes),
+
+    pass.
+
+difference_test() ->
+    %% Deploy 6 nodes.
+    Nodes = deploy_nodes(6, ?CONF(5)),
+
+    %% Break up the 6 nodes into three clustes.
+    {ANodes, BNodes} = lists:split(3, Nodes),
+
+    lager:info("ANodes: ~p", [ANodes]),
+    lager:info("BNodes: ~p", [BNodes]),
+
+    lager:info("Building two clusters."),
+    [repl_util:make_cluster(N) || N <- [ANodes, BNodes]],
+
+    AFirst = hd(ANodes),
+    BFirst = hd(BNodes),
+
+    lager:info("Naming clusters."),
+    repl_util:name_cluster(AFirst, "A"),
+    repl_util:name_cluster(BFirst, "B"),
+
+    lager:info("Waiting for convergence."),
+    rt:wait_until_ring_converged(ANodes),
+    rt:wait_until_ring_converged(BNodes),
+
+    lager:info("Waiting for transfers to complete."),
+    rt:wait_until_transfers_complete(ANodes),
+    rt:wait_until_transfers_complete(BNodes),
+
+    lager:info("Get leaders."),
+    LeaderA = get_leader(AFirst),
+    LeaderB = get_leader(BFirst),
+
+    lager:info("Finding connection manager ports."),
+    BPort = get_port(LeaderB),
+
+    lager:info("Connecting cluster A to B"),
+    connect_cluster(LeaderA, BPort, "B"),
+
+    %% Get PBC connections.
+    APBC = rt:pbc(LeaderA),
+    BPBC = rt:pbc(LeaderB),
+
+    %% Write key.
+    ok = riakc_pb_socket:put(APBC,
+                             riakc_obj:new(<<"foo">>, <<"bar">>,
+                                           <<"baz">>),
+                             [{timeout, 4000}]),
+
+    %% Wait for trees to compute.
+    repl_util:wait_until_aae_trees_built(ANodes),
+    repl_util:wait_until_aae_trees_built(BNodes),
+
+    lager:info("Test fullsync from cluster A leader ~p to cluster B",
+               [LeaderA]),
+    repl_util:enable_fullsync(LeaderA, "B"),
+    rt:wait_until_ring_converged(ANodes),
+
+    %% Flush AAE trees to disk.
+    perform_sacrifice(AFirst),
+
+    %% Wait for fullsync.
+    {Time1, _} = timer:tc(repl_util,
+                         start_and_wait_until_fullsync_complete,
+                         [LeaderA, "B"]),
+    lager:info("Fullsync completed in ~p seconds", [Time1/1000/1000]),
+
+    %% Read key from after fullsync.
+    {ok, O1} = riakc_pb_socket:get(BPBC, <<"foo">>, <<"bar">>,
+                                  [{timeout, 4000}]),
+    ?assertEqual(<<"baz">>, riakc_obj:get_value(O1)),
+
+    %% Put, generate sibling.
+    ok = riakc_pb_socket:put(APBC,
+                             riakc_obj:new(<<"foo">>, <<"bar">>,
+                                           <<"baz2">>),
+                             [{timeout, 4000}]),
+
+    %% Wait for fullsync.
+    {Time2, _} = timer:tc(repl_util,
+                         start_and_wait_until_fullsync_complete,
+                         [LeaderA, "B"]),
+    lager:info("Fullsync completed in ~p seconds", [Time2/1000/1000]),
+
+    %% Read key from after fullsync.
+    {ok, O2} = riakc_pb_socket:get(BPBC, <<"foo">>, <<"bar">>,
+                                  [{timeout, 4000}]),
+    ?assertEqual([<<"baz">>, <<"baz2">>], lists:sort(riakc_obj:get_values(O2))),
+
     rt:clean_cluster(Nodes),
 
     pass.


### PR DESCRIPTION
Ensure that objects, when modified, actually replicate correctly to the
sink cluster.

If this looks good, I'll backport the test to Riak 1.4.
