### PR TITLE
Add test detecting source deadlock.

### DIFF
--- a/intercepts/riak_kv_index_hashtree_intercepts.erl
+++ b/intercepts/riak_kv_index_hashtree_intercepts.erl
@@ -4,6 +4,12 @@
 
 -define(M, riak_kv_index_hashtree_orig).
 
+%% @doc Perform a delayed compare, which delays the receipt of a
+%%      message.
+delayed_compare(_IndexN, _Remote, _AccFun, _TreePid) ->
+    timer:sleep(1000000),
+    [].
+
 %% @doc When attempting to get the lock on a hashtree, return the
 %%      not_built atom which means the tree has not been computed yet.
 not_built(_TreePid, _Type) ->


### PR DESCRIPTION
Add test which ensures that the AAE source worker doesn't deadlock when
waiting for responses from the process which is computing the hashtree
differences.

Unfortunately, this test uses timeouts because as the code currently
stands, I can't figure out a way to make it any cleaner.

Let me know how this looks and we can explore a 1.4 backport.
