### PR TITLE
Use correct intercepts.

### DIFF
--- a/intercepts/riak_repl2_rtsink_conn_intercepts.erl
+++ b/intercepts/riak_repl2_rtsink_conn_intercepts.erl
@@ -1,5 +1,5 @@
 %% Intercepts functions for the riak_test in ../tests/repl_rt_heartbeat.erl
--module(riak_repl2_rtsink_intercepts).
+-module(riak_repl2_rtsink_conn_intercepts).
 -compile(export_all).
 -include("intercept.hrl").
 


### PR DESCRIPTION
Correct a typo which was causing the module to attempt to use intercepts
which do not exist.
