### PR TITLE
Add test to ensure modified objects replicate.

### DIFF
--- a/tests/repl_aae_fullsync.erl
+++ b/tests/repl_aae_fullsync.erl
@@ -386,7 +386,7 @@ difference_test() ->
     %% Read key from after fullsync.
     {ok, O2} = riakc_pb_socket:get(BPBC, <<"foo">>, <<"bar">>,
                                   [{timeout, 4000}]),
-    ?assertEqual([<<"baz">>, <<"baz2">>], lists:sort(riakc_obj:get_values(O2))),
+    ?assertEqual(<<"baz2">>, riakc_obj:get_value(O2)),
 
     rt:clean_cluster(Nodes),
 


### PR DESCRIPTION
Ensure that objects, when modified, actually replicate correctly to the
sink cluster.
