### PR TITLE
Ajs overload handling

### DIFF
--- a/tests/overload.erl
+++ b/tests/overload.erl
@@ -236,7 +236,9 @@ remote_suspend_and_overload() ->
           end).
 
 overload(Pid) ->
-    [Pid ! hola || _ <- lists:seq(1, ?NUM_REQUESTS)].
+    %% The actual message doesn't matter. This one just has the least side
+    % effects.
+    [Pid ! {set_concurrency_limit, some_lock, 1} || _ <- lists:seq(1, ?NUM_REQUESTS)].
 
 suspend_vnode(Node, Idx) ->
     Pid = rpc:call(Node, ?MODULE, remote_suspend_vnode, [Idx], infinity),


### PR DESCRIPTION
Add coverage queries (list_keys and list_buckets) to the overload test to ensure they are getting responses. These changes require that the following two PRs to pass.

https://github.com/basho/riak_core/pull/513
https://github.com/basho/riak_kv/pull/822

Fixes: basho/riak_kv#753
