### PR TITLE
Treat users and groups as distinct concepts

### DIFF
--- a/tests/pb_security.erl
+++ b/tests/pb_security.erl
@@ -49,6 +49,9 @@ confirm() ->
     lager:info("Deploy some nodes"),
     PrivDir = rt:priv_dir(),
     Conf = [
+            {riak_core, [
+                    {default_bucket_props, [{allow_mult, true}]}
+                    ]},
             {riak_api, [
                     {certfile, filename:join([CertDir,"site3.basho.com/cert.pem"])},
                     {keyfile, filename:join([CertDir, "site3.basho.com/key.pem"])},


### PR DESCRIPTION
To make it easier to reason about and document the new security behavior, this PR splits roles into users and groups.
- Users (but not groups) can be given authentication information (sources).
- Groups (but not users) can be used to cascade privileges to other groups and users.

Where the code does not or cannot distinguish between users and groups, I continue to refer to roles, but the user interface is constrained to users and groups.

There are 3 projects impacted by this change, all with the same branch name (`jrd-security-role-bifurcation`):
- riak
- riak_core
- riak_test

All should be merged at the same time. I will be filing PRs for each.

/cc @Vagabond

(riak_test note: currently `http_security` test does not reference groups, so no fixes are required.)
