### PR TITLE
Add a log/test.log that mirrors the console output

### DIFF
--- a/src/riak_test_escript.erl
+++ b/src/riak_test_escript.erl
@@ -107,7 +107,9 @@ main(Args) ->
             notice
     end,
 
-    application:set_env(lager, handlers, [{lager_console_backend, ConsoleLagerLevel}]),
+    application:set_env(lager, handlers, [{lager_console_backend, ConsoleLagerLevel},
+                                         {lager_file_backend, [{file, "log/test.log"},
+                                                               {level, ConsoleLagerLevel}]}]),
     lager:start(),
 
     %% Report


### PR DESCRIPTION
This is extremely handy when debugging riak_test issues, since the
actual test logs can omit messages between tests and also be hard to
reassemble.

cc @joedevivo 
