### PR TITLE
Add basic riak_ensemble tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,10 @@ clean:
 distclean: clean
 	@rm -rf riak_test deps
 
+quickbuild:
+	./rebar skip_deps=true compile
+	./rebar escriptize
+
 ##################
 # Dialyzer targets
 ##################

--- a/tests/ensemble_basic.erl
+++ b/tests/ensemble_basic.erl
@@ -1,0 +1,31 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2013-2014 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(ensemble_basic).
+-export([confirm/0]).
+-include_lib("eunit/include/eunit.hrl").
+
+confirm() ->
+    NumNodes = 5,
+    NVal = 5,
+    Config = ensemble_util:fast_config(NVal),
+    lager:info("Building cluster and waiting for ensemble to stablize"),
+    ensemble_util:build_cluster(NumNodes, Config, NVal),
+    pass.

--- a/tests/ensemble_basic2.erl
+++ b/tests/ensemble_basic2.erl
@@ -1,0 +1,36 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2013-2014 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(ensemble_basic2).
+-export([confirm/0]).
+-include_lib("eunit/include/eunit.hrl").
+
+confirm() ->
+    NumNodes = 5,
+    NVal = 5,
+    Config = ensemble_util:fast_config(NVal),
+    lager:info("Building cluster and waiting for ensemble to stablize"),
+    Nodes = ensemble_util:build_cluster(NumNodes, Config, NVal),
+    Node = hd(Nodes),
+    Ensembles = ensemble_util:ensembles(Node),
+    lager:info("Killing all ensemble leaders"),
+    ok = ensemble_util:kill_leaders(Node, Ensembles),
+    ensemble_util:wait_until_stable(Node, NVal),
+    pass.

--- a/tests/ensemble_basic3.erl
+++ b/tests/ensemble_basic3.erl
@@ -1,0 +1,100 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2013-2014 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(ensemble_basic3).
+-export([confirm/0]).
+-include_lib("eunit/include/eunit.hrl").
+
+confirm() ->
+    NumNodes = 5,
+    NVal = 5,
+    Quorum = NVal div 2 + 1,
+    Config = ensemble_util:fast_config(NVal),
+    lager:info("Building cluster and waiting for ensemble to stablize"),
+    Nodes = ensemble_util:build_cluster(NumNodes, Config, NVal),
+    vnode_util:load(Nodes),
+    Node = hd(Nodes),
+    Ensembles = ensemble_util:ensembles(Node),
+    lager:info("Killing all ensemble leaders"),
+    ok = ensemble_util:kill_leaders(Node, Ensembles),
+    ensemble_util:wait_until_stable(Node, NVal),
+
+    lager:info("Creating/activating 'strong' bucket type"),
+    rt:create_and_activate_bucket_type(Node, <<"strong">>,
+                                       [{consistent, true}, {n_val, NVal}]),
+    ensemble_util:wait_until_stable(Node, NVal),
+    Bucket = {<<"strong">>, <<"test">>},
+    Keys = [<<N:64/integer>> || N <- lists:seq(1,1000)],
+
+    Key1 = hd(Keys),
+    DocIdx = rpc:call(Node, riak_core_util, chash_std_keyfun, [{Bucket, Key1}]),
+    PL = rpc:call(Node, riak_core_apl, get_primary_apl, [DocIdx, NVal, riak_kv]),
+    All = [VN || {VN, _} <- PL],
+    Other = [VN || {VN={_, Owner}, _} <- PL,
+                   Owner =/= Node],
+
+    Minority = NVal - Quorum,
+    PartitionedVN = lists:sublist(Other, Minority),
+    Partitioned = [VNode || {_, VNode} <- PartitionedVN],
+    MajorityVN = All -- PartitionedVN,
+
+    PBC = rt:pbc(Node),
+
+    lager:info("Partitioning quorum minority: ~p", [Partitioned]),
+    Part = rt:partition(Nodes -- Partitioned, Partitioned),
+    ensemble_util:wait_until_stable(Node, Quorum),
+
+    lager:info("Writing ~p consistent keys", [1000]),
+    [ok = rt:pbc_write(PBC, Bucket, Key, Key) || Key <- Keys],
+
+    lager:info("Read keys to verify they exist"),
+    [rt:pbc_read(PBC, Bucket, Key) || Key <- Keys],
+
+    lager:info("Healing partition"),
+    rt:heal(Part),
+
+    lager:info("Suspending majority vnodes"),
+    L = [begin
+             lager:info("Suspending vnode: ~p", [VIdx]),
+             Pid = vnode_util:suspend_vnode(VNode, VIdx),
+             {VN, Pid}
+         end || VN={VIdx, VNode} <- MajorityVN],
+    L2 = orddict:from_list(L),
+
+    lager:info("Sleeping for 5s"),
+    timer:sleep(5000),
+
+    lists:foldl(fun({VN={VIdx, VNode}, Pid}, Suspended) ->
+                        lager:info("Resuming vnode: ~p", [VIdx]),
+                        vnode_util:resume_vnode(Pid),
+                        ensemble_util:wait_until_stable(Node, Quorum),
+                        lager:info("Re-reading keys"),
+                        [rt:pbc_read(PBC, Bucket, Key) || Key <- Keys],
+                        lager:info("Suspending vnode: ~p", [VIdx]),
+                        Pid2 = vnode_util:suspend_vnode(VNode, VIdx),
+                        orddict:store(VN, Pid2, Suspended)
+                end, L2, L2),
+
+    lager:info("Resuming all vnodes"),
+    [vnode_util:resume_vnode(Pid) || {_, Pid} <- L2],
+    ensemble_util:wait_until_stable(Node, NVal),
+    lager:info("Re-reading keys"),
+    [rt:pbc_read(PBC, Bucket, Key) || Key <- Keys],
+    pass.

--- a/tests/ensemble_util.erl
+++ b/tests/ensemble_util.erl
@@ -1,0 +1,131 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2013-2014 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(ensemble_util).
+-compile(export_all).
+
+-include_lib("eunit/include/eunit.hrl").
+
+build_cluster(Num, Config, NVal) ->
+    Nodes = rt:deploy_nodes(Num, Config),
+    Node = hd(Nodes),
+    ok = rpc:call(Node, riak_ensemble_manager, enable, []),
+    ensemble_util:wait_until_stable(Node, NVal),
+    rt:join_cluster(Nodes),
+    ensemble_util:wait_until_cluster(Nodes),
+    ensemble_util:wait_for_membership(Node),
+    ensemble_util:wait_until_stable(Node, NVal),
+    Nodes.
+
+fast_config(NVal) ->
+    fast_config(NVal, 16).
+
+fast_config(NVal, RingSize) ->
+    [{riak_kv, [{anti_entropy_build_limit, {100, 1000}},
+                {anti_entropy_concurrency, 100},
+                {anti_entropy_tick, 100},
+                {anti_entropy, {on, []}},
+                {anti_entropy_timeout, 5000},
+                {storage_backend, riak_kv_memory_backend}]},
+     {riak_core, [{default_bucket_props, [{n_val, NVal}]},
+                  {vnode_management_timer, 1000},
+                  {ring_creation_size, RingSize},
+                  {enable_consensus, true}]}].
+
+ensembles(Node) ->
+    rpc:call(Node, riak_kv_ensembles, ensembles, []).
+
+get_leader_pid(Node, Ensemble) ->
+    rpc:call(Node, riak_ensemble_manager, get_leader_pid, [Ensemble]).
+
+kill_leader(Node, Ensemble) ->
+    case get_leader_pid(Node, Ensemble) of
+        undefined ->
+            ok;
+        Pid ->
+            exit(Pid, kill),
+            ok
+    end.
+
+kill_leaders(Node, Ensembles) ->
+    _ = [kill_leader(Node, Ensemble) || Ensemble <- Ensembles],
+    ok.
+
+wait_until_cluster(Nodes) ->
+    lager:info("Waiting until riak_ensemble cluster includes all nodes"),
+    Node = hd(Nodes),
+    F = fun() ->
+                case rpc:call(Node, riak_ensemble_manager, cluster, []) of
+                    Nodes ->
+                        true;
+                    _ ->
+                        false
+                end
+        end,
+    ?assertEqual(ok, rt:wait_until(F)),
+    lager:info("....cluster ready"),
+    ok.
+
+wait_until_stable(Node, Count) ->
+    lager:info("Waiting until all ensembles are stable"),
+    Ensembles = rpc:call(Node, riak_kv_ensembles, ensembles, []),
+    wait_until_quorum(Node, root),
+    [wait_until_quorum(Node, Ensemble) || Ensemble <- Ensembles],
+    [wait_until_quorum_count(Node, Ensemble, Count) || Ensemble <- Ensembles],
+    lager:info("....all stable"),
+    ok.
+
+wait_until_quorum(Node, Ensemble) ->
+    F = fun() ->
+                case rpc:call(Node, riak_ensemble_manager, check_quorum, [Ensemble, 500]) of
+                    true ->
+                        true;
+                    false ->
+                        lager:info("Not ready: ~p", [Ensemble]),
+                        false
+                end
+        end,
+    ?assertEqual(ok, rt:wait_until(F)).
+
+wait_until_quorum_count(Node, Ensemble, Want) ->
+    F = fun() ->
+                case rpc:call(Node, riak_ensemble_manager, count_quorum, [Ensemble, 1500]) of
+                    Count when Count >= Want ->
+                        true;
+                    Count ->
+                        lager:info("Count: ~p :: ~p < ~p", [Ensemble, Count, Want]),
+                        false
+                end
+        end,
+    ?assertEqual(ok, rt:wait_until(F)).
+
+wait_for_membership(Node) ->
+    lager:info("Waiting until ensemble membership matches ring ownership"),
+    F = fun() ->
+                case rpc:call(Node, riak_kv_ensembles, check_membership, []) of
+                    Results when is_list(Results) ->
+                        [] =:= [x || false <- Results];
+                    _ ->
+                        false
+                end
+        end,
+    ?assertEqual(ok, rt:wait_until(F)),
+    lager:info("....ownership matches"),
+    ok.

--- a/tests/vnode_util.erl
+++ b/tests/vnode_util.erl
@@ -1,0 +1,47 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2013-2014 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(vnode_util).
+-compile(export_all).
+
+load(Nodes) ->
+    rt:load_modules_on_nodes([?MODULE], Nodes),
+    ok.
+
+suspend_vnode(Node, Idx) ->
+    lager:info("Suspending vnode ~p/~p", [Node, Idx]),
+    Pid = rpc:call(Node, ?MODULE, remote_suspend_vnode, [Idx], infinity),
+    Pid.
+
+remote_suspend_vnode(Idx) ->
+    Parent = self(),
+    Pid = spawn(fun() ->
+                        {ok, Pid} = riak_core_vnode_manager:get_vnode_pid(Idx, riak_kv_vnode),
+                        erlang:suspend_process(Pid, []),
+                        Parent ! suspended,
+                        receive resume ->
+                                erlang:resume_process(Pid)
+                        end
+                end),
+    receive suspended -> ok end,
+    Pid.
+
+resume_vnode(Pid) ->
+    Pid ! resume.


### PR DESCRIPTION
Add ensemble_basic, ensemble_basic2, and ensemble_basic3 tests.

These tests test that Riak correctly generates proper consensus
groups, these groups reach quorum, handle leader failures, etc.

ensemble_basic3 tests basic consistent K/V API as well as behavior
during simple network partitions.

This is a sibling pull-request for basho/riak_ensemble#10
