### PR TITLE
support for anonymous function intercepts

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -6,6 +6,7 @@
 %%{edoc_opts, [{layout, my_layout}, {file_suffix, ".xml"}, {pretty_printer, erl_pp}]}.
 {erl_opts, [{src_dirs, [src, intercepts]},
            warnings_as_errors, {parse_transform, lager_transform}]}.
+{erl_first_files, ["src/rt_intercept_pt.erl"]}.
 
 {deps, [
         {lager, ".*", {git, "git://github.com/basho/lager", {tag, "2.0.3"}}},

--- a/src/rt_intercept_pt.erl
+++ b/src/rt_intercept_pt.erl
@@ -1,0 +1,99 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2014 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(rt_intercept_pt).
+-export([parse_transform/2]).
+
+%% This parse transform looks for calls to rt_intercept:add/2, and if found
+%% potentially modifies the second argument. The second argument can be a
+%% list of intercept tuples or a single intercept tuple. An intercept tuple
+%% can have either 2 or 3 elements, but either way, a final element of the
+%% form
+%%
+%%   [{{F,Arity},{[var], fun()}}]
+%%
+%% is transformed into
+%%
+%%   [{{F,Arity},{[{varname, var}], tuple()}}]
+%%
+%% Only the second element of this tuple is modified. In the first form the
+%% fun() is an anonymous interceptor function and [var] represents the list
+%% of free variables used within the function but defined in the context in
+%% which the function is defined. The list of vars is transformed into a
+%% list of 2-tuples of var name and var, while the function is replaced
+%% with its abstract format (which, since we are already dealing with
+%% abstract format, is actually the abstract format of its abstract
+%% format). If the final element of the argument tuple (or list of argument
+%% tuples) is instead
+%%
+%%   [{{F,Arity}, fun()}]
+%%
+%% then the fun() is assumed to not use any free variables from the context
+%% in which the function is defined. This is transformed to
+%%
+%%   [{{F,Arity},{[], tuple()}}]
+%%
+%% which is the same as the prior transformation but with an empty list of
+%% free variables. A final element of any other form is left as is.
+
+parse_transform(Forms, _) ->
+    forms(Forms).
+
+forms([F|Forms]) ->
+    [form(F)|forms(Forms)];
+forms(F) ->
+    form(F).
+
+form({function,LF,F,A,Clauses}) ->
+    {function,LF,F,A,forms(Clauses)};
+form({clause,L,H,G,B}) ->
+    {clause,L,H,G,forms(B)};
+form({match,L,Lhs,Rhs}) ->
+    {match,L,forms(Lhs),forms(Rhs)};
+form({call,L,{remote,_,{atom,_,rt_intercept},{atom,_,add}}=Fun,Args}) ->
+    [Node, Intercept] = Args,
+    {call,L,Fun,[Node,intercept(Intercept)]};
+form(F) when is_tuple(F) ->
+    list_to_tuple(forms(tuple_to_list(F)));
+form(F) ->
+    F.
+
+intercept({tuple,L,[Mod,Intercepts]}) ->
+    {tuple,L,[Mod,intercepts(Intercepts)]};
+intercept({tuple,L,[Mod,ModInt,Intercepts]}) ->
+    {tuple,L,[Mod,ModInt,intercepts(Intercepts)]}.
+
+intercepts({cons,L1,{tuple,L2,[FA,Int]},T}) ->
+    {cons,L1,{tuple,L2,[FA,intercepts(Int)]},intercepts(T)};
+intercepts({tuple,L,[FreeVars,{'fun',LF,_}=Fun]}) ->
+    {tuple,L,[freevars(FreeVars),erl_parse:abstract(Fun, LF)]};
+intercepts({'fun',L,_}=Fun) ->
+    {tuple,L,[{nil,L},erl_parse:abstract(Fun, L)]};
+intercepts(F) ->
+    F.
+
+freevars({cons,L,H,T}) ->
+    {cons,L,freevar(H),freevars(T)};
+freevars({nil,_}=Nil) ->
+    Nil.
+
+freevar({var,L,V}=Var) ->
+    {tuple,L,[{atom,L,V},Var]};
+freevar(Term) ->
+    Term.


### PR DESCRIPTION
Allow intercept functions passed to rt_intercept:add/2 to be anonymous. In
compiled code they can either be a plain anonymous function, assuming they
don't use any variables from the surrounding context, or they can be a
2-tuple like this:

{[FreeVar1, ...],
 fun(Arg1, ...) -> ... end}

where FreeVar1 etc. is a list of free variables to be closed over so that
they can be used within the anonymous function. For making interactive
calls to rt_intercept:add/2 from the Erlang shell, only the anonymous
function form is required, even if it uses free variables, though the
2-tuple form is also acceptable.

For compiled code, support for anonymous intercept functions is implemented
via a parse transform, and so to use anonymous functions the intercept
structure(s) containing them must be defined directly inline as part of the
final argument to rt_intercept:add/2, i.e., they cannot be first assigned
to a variable that is then used within the argument. This is because the
value of such a variable might not be visible to the parse transform.
