### PR TITLE
Investigate failure of verify_busy_dist_port test

### DIFF
--- a/tests/cause_bdp.erl
+++ b/tests/cause_bdp.erl
@@ -24,8 +24,8 @@
 -compile(export_all).
 
 spam_nodes(TargetNodes) ->
-        [[spawn(?MODULE, spam, [N]) || _ <- lists:seq(1,10*1000)] || N <- TargetNodes].
+        [[spawn(?MODULE, spam, [N]) || _ <- lists:seq(1,1000*1000)] || N <- TargetNodes].
 
 spam(Node) ->
-    timer:sleep(random:uniform(1500)), 
+    timer:sleep(random:uniform(100)),
     catch rpc:call(Node, erlang, whereis, [rex]).


### PR DESCRIPTION
This test failed on the pre21 giddyup scorecard (http://giddyup.basho.com/#/projects/riak_ee/scorecards/94/94-369-verify_busy_dist_port-centos-6-64/46195) and I have reproduced the failure locally.
