### PR TITLE
Add additional ensemble tests to test peer syncing

### DIFF
--- a/src/rt.erl
+++ b/src/rt.erl
@@ -82,6 +82,9 @@
          partition/2,
          pbc/1,
          pbc_read/3,
+         pbc_read/4,
+         pbc_read_check/4,
+         pbc_read_check/5,
          pbc_set_bucket_prop/3,
          pbc_write/4,
          pbc_put_dir/3,
@@ -1164,8 +1167,25 @@ pbc(Node) ->
 %% @doc does a read via the erlang protobuf client
 -spec pbc_read(pid(), binary(), binary()) -> binary().
 pbc_read(Pid, Bucket, Key) ->
-    {ok, Value} = riakc_pb_socket:get(Pid, Bucket, Key),
+    pbc_read(Pid, Bucket, Key, []).
+
+-spec pbc_read(pid(), binary(), binary(), [any()]) -> binary().
+pbc_read(Pid, Bucket, Key, Options) ->
+    {ok, Value} = riakc_pb_socket:get(Pid, Bucket, Key, Options),
     Value.
+
+-spec pbc_read_check(pid(), binary(), binary(), [any()]) -> boolean().
+pbc_read_check(Pid, Bucket, Key, Allowed) ->
+    pbc_read_check(Pid, Bucket, Key, Allowed, []).
+
+-spec pbc_read_check(pid(), binary(), binary(), [any()], [any()]) -> boolean().
+pbc_read_check(Pid, Bucket, Key, Allowed, Options) ->
+    case riakc_pb_socket:get(Pid, Bucket, Key, Options) of
+        {ok, _} ->
+            true = lists:member(ok, Allowed);
+        Other ->
+            lists:member(Other, Allowed) orelse throw({failed, Other, Allowed})
+    end.
 
 %% @doc does a write via the erlang protobuf client
 -spec pbc_write(pid(), binary(), binary(), binary()) -> atom().

--- a/tests/ensemble_basic4.erl
+++ b/tests/ensemble_basic4.erl
@@ -1,0 +1,67 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2013-2014 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(ensemble_basic4).
+-export([confirm/0]).
+-include_lib("eunit/include/eunit.hrl").
+
+confirm() ->
+    NumNodes = 5,
+    NVal = 5,
+    Quorum = NVal div 2 + 1,
+    Config = ensemble_util:fast_config(NVal),
+    lager:info("Building cluster and waiting for ensemble to stablize"),
+    Nodes = ensemble_util:build_cluster(NumNodes, Config, NVal),
+    Node = hd(Nodes),
+
+    lager:info("Creating/activating 'strong' bucket type"),
+    rt:create_and_activate_bucket_type(Node, <<"strong">>,
+                                       [{consistent, true}, {n_val, NVal}]),
+    ensemble_util:wait_until_stable(Node, NVal),
+    Bucket = {<<"strong">>, <<"test">>},
+    Keys = [<<N:64/integer>> || N <- lists:seq(1,1000)],
+
+    Key1 = hd(Keys),
+    DocIdx = rpc:call(Node, riak_core_util, chash_std_keyfun, [{Bucket, Key1}]),
+    PL = rpc:call(Node, riak_core_apl, get_primary_apl, [DocIdx, NVal, riak_kv]),
+    Other = [VN || {VN={_, Owner}, _} <- PL,
+                   Owner =/= Node],
+
+    Minority = NVal - Quorum,
+    PartitionedVN = lists:sublist(Other, Minority),
+    Partitioned = [VNode || {_, VNode} <- PartitionedVN],
+
+    PBC = rt:pbc(Node),
+
+    lager:info("Partitioning quorum minority: ~p", [Partitioned]),
+    Part = rt:partition(Nodes -- Partitioned, Partitioned),
+    rpc:multicall(Nodes, riak_kv_entropy_manager, set_mode, [manual]),
+    ensemble_util:wait_until_stable(Node, Quorum),
+
+    lager:info("Writing ~p consistent keys", [1000]),
+    [ok = rt:pbc_write(PBC, Bucket, Key, Key) || Key <- Keys],
+
+    lager:info("Read keys to verify they exist"),
+    [rt:pbc_read(PBC, Bucket, Key) || Key <- Keys],
+
+    lager:info("Healing partition"),
+    rt:heal(Part),
+
+    pass.

--- a/tests/ensemble_interleave.erl
+++ b/tests/ensemble_interleave.erl
@@ -1,0 +1,101 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2013-2014 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% Tests the specific corner case where two ensemble peers become
+%% corrupted one after the other. The goal is to provoke the scenario
+%% where one of the peers initially trusts the other and syncs with it,
+%% but completes the sync after the peer becomes untrusted.
+%%
+%% Actually hitting this specific interleaving may require multiple runs,
+%% but it has been observed and lead to the addition of the `check_sync`
+%% logic to riak_ensemble/riak_ensemble_peer.erl that verifies a peer is
+%% still trustworthy after a peer syncs with it.
+%%
+%% Without the check_sync addition, this test could incorectly report
+%% {error, notfound} -- eg. data loss. With the addition, this test
+%% should now always pass.
+
+-module(ensemble_interleave).
+-export([confirm/0]).
+-include_lib("eunit/include/eunit.hrl").
+
+confirm() ->
+    NVal = 5,
+    Quorum = NVal div 2 + 1,
+    Config = ensemble_util:fast_config(NVal),
+    lager:info("Building cluster and waiting for ensemble to stablize"),
+    Nodes = ensemble_util:build_cluster(8, Config, NVal),
+    Node = hd(Nodes),
+    vnode_util:load(Nodes),
+
+    lager:info("Creating/activating 'strong' bucket type"),
+    rt:create_and_activate_bucket_type(Node, <<"strong">>,
+                                       [{consistent, true}, {n_val, NVal}]),
+    ensemble_util:wait_until_stable(Node, NVal),
+    Bucket = {<<"strong">>, <<"test">>},
+    Keys = [<<N:64/integer>> || N <- lists:seq(1,1000)],
+
+    Key1 = hd(Keys),
+    DocIdx = rpc:call(Node, riak_core_util, chash_std_keyfun, [{Bucket, Key1}]),
+    PL = rpc:call(Node, riak_core_apl, get_primary_apl, [DocIdx, NVal, riak_kv]),
+    All = [VN || {VN, _} <- PL],
+    Other = [VN || {VN={_, Owner}, _} <- PL,
+                   Owner =/= Node],
+
+    Minority = NVal - Quorum,
+    PartitionedVN = lists:sublist(Other, Minority),
+    Partitioned = [VNode || {_, VNode} <- PartitionedVN],
+    [KillFirst,KillSecond|Suspend] = All -- PartitionedVN,
+
+    io:format("PL: ~p~n", [PL]),
+    PBC = rt:pbc(Node),
+    Options = [{timeout, 500}],
+
+    rpc:multicall(Nodes, riak_kv_entropy_manager, set_mode, [manual]),
+    Part = rt:partition(Nodes -- Partitioned, Partitioned),
+    ensemble_util:wait_until_stable(Node, Quorum),
+
+    lager:info("Writing ~p consistent keys", [1000]),
+    [ok = rt:pbc_write(PBC, Bucket, Key, Key) || Key <- Keys],
+
+    lager:info("Read keys to verify they exist"),
+    [rt:pbc_read(PBC, Bucket, Key, Options) || Key <- Keys],
+    rt:heal(Part),
+
+    [begin
+         lager:info("Suspending vnode: ~p", [VIdx]),
+         vnode_util:suspend_vnode(VNode, VIdx)
+     end || {VIdx, VNode} <- Suspend],
+
+    vnode_util:kill_vnode(KillFirst),
+    timer:sleep(5000),
+    vnode_util:kill_vnode(KillSecond),
+    vnode_util:rebuild_vnode(KillFirst),
+    rpc:multicall(Nodes, riak_kv_entropy_manager, set_mode, [automatic]),
+    ensemble_util:wait_until_stable(Node, Quorum),
+
+    lager:info("Disabling AAE"),
+    rpc:multicall(Nodes, riak_kv_entropy_manager, disable, []),
+    ensemble_util:wait_until_stable(Node, Quorum),
+
+    lager:info("Re-reading keys to verify they exist"),
+    Expect = [ok, {error, timeout}, {error, <<"timeout">>}],
+    [rt:pbc_read_check(PBC, Bucket, Key, Expect, Options) || Key <- Keys],
+    pass.

--- a/tests/ensemble_sync.erl
+++ b/tests/ensemble_sync.erl
@@ -1,0 +1,127 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2013-2014 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(ensemble_sync).
+-export([confirm/0]).
+-include_lib("eunit/include/eunit.hrl").
+
+confirm() ->
+    NVal = 5,
+    Config = ensemble_util:fast_config(NVal),
+    Nodes = ensemble_util:build_cluster(8, Config, NVal),
+    Node = hd(Nodes),
+    vnode_util:load(Nodes),
+
+    lager:info("Creating/activating 'strong' bucket type"),
+    rt:create_and_activate_bucket_type(Node, <<"strong">>,
+                                       [{consistent, true}, {n_val, NVal}]),
+    ensemble_util:wait_until_stable(Node, NVal),
+
+    ExpectOkay    = [ok],
+    ExpectTimeout = [{error, timeout}, {error, <<"timeout">>} | ExpectOkay],
+    ExpectFail    = [{error, notfound} | ExpectTimeout],
+
+    Scenarios = [%% corrupted, suspended, valid, empty, bucket, expect
+                 {1, 1, 1, 2, <<"test1">>, ExpectOkay},
+                 {1, 2, 0, 2, <<"test2">>, ExpectTimeout},
+                 {2, 1, 0, 2, <<"test3">>, ExpectTimeout},
+                 {3, 0, 0, 2, <<"test4">>, ExpectFail}
+                ],
+    [ok = run_scenario(Nodes, NVal, Scenario) || Scenario <- Scenarios],
+    pass.
+
+run_scenario(Nodes, NVal, {NumKill, NumSuspend, NumValid, _, Name, Expect}) ->
+    Node = hd(Nodes),
+    Quorum = NVal div 2 + 1,
+    Bucket = {<<"strong">>, Name},
+    Keys = [<<N:64/integer>> || N <- lists:seq(1,1000)],
+
+    Key1 = hd(Keys),
+    DocIdx = rpc:call(Node, riak_core_util, chash_std_keyfun, [{Bucket, Key1}]),
+    PL = rpc:call(Node, riak_core_apl, get_primary_apl, [DocIdx, NVal, riak_kv]),
+    All = [VN || {VN, _} <- PL],
+    Other = [VN || {VN={_, Owner}, _} <- PL,
+                   Owner =/= Node],
+
+    Minority = NVal - Quorum,
+    PartitionedVN = lists:sublist(Other, Minority),
+    Partitioned = [VNode || {_, VNode} <- PartitionedVN],
+    Valid = All -- PartitionedVN,
+
+    {KillVN,    Valid2} = lists:split(NumKill,    Valid),
+    {SuspendVN, Valid3} = lists:split(NumSuspend, Valid2),
+    {AfterVN,   _}      = lists:split(NumValid,   Valid3),
+
+    io:format("PL: ~p~n", [PL]),
+    PBC = rt:pbc(Node),
+    Options = [{timeout, 500}],
+
+    rpc:multicall(Nodes, riak_kv_entropy_manager, set_mode, [manual]),
+    Part = rt:partition(Nodes -- Partitioned, Partitioned),
+    ensemble_util:wait_until_stable(Node, Quorum),
+
+    %% Write data while minority is partitioned
+    lager:info("Writing ~p consistent keys", [1000]),
+    [ok = rt:pbc_write(PBC, Bucket, Key, Key) || Key <- Keys],
+
+    lager:info("Read keys to verify they exist"),
+    [rt:pbc_read(PBC, Bucket, Key, Options) || Key <- Keys],
+    rt:heal(Part),
+
+    %% Suspend desired number of valid vnodes
+    S1 = [vnode_util:suspend_vnode(VNode, VIdx) || {VIdx, VNode} <- SuspendVN],
+
+    %% Kill/corrupt desired number of valid vnodes
+    [vnode_util:kill_vnode(VN) || VN <- KillVN],
+    [vnode_util:rebuild_vnode(VN) || VN <- KillVN],
+    rpc:multicall(Nodes, riak_kv_entropy_manager, set_mode, [automatic]),
+    ensemble_util:wait_until_stable(Node, Quorum),
+
+    lager:info("Disabling AAE"),
+    rpc:multicall(Nodes, riak_kv_entropy_manager, disable, []),
+    ensemble_util:wait_until_stable(Node, Quorum),
+
+    %% Suspend remaining valid vnodes to ensure data comes from repaired vnodes
+    S2 = [vnode_util:suspend_vnode(VNode, VIdx) || {VIdx, VNode} <- AfterVN],
+    ensemble_util:wait_until_stable(Node, Quorum),
+
+    lager:info("Checking that key results match scenario"),
+    [rt:pbc_read_check(PBC, Bucket, Key, Expect, Options) || Key <- Keys],
+
+    lager:info("Re-enabling AAE"),
+    rpc:multicall(Nodes, riak_kv_entropy_manager, enable, []),
+
+    lager:info("Resuming all vnodes"),
+    [vnode_util:resume_vnode(Pid) || Pid <- S1 ++ S2],
+    ensemble_util:wait_until_stable(Node, NVal),
+
+    %% Check that for other than the "all bets are off" failure case,
+    %% we can successfully read all keys after all vnodes are available.
+    case lists:member({error, notfound}, Expect) of
+        true ->
+            ok;
+        false ->
+            lager:info("Re-reading keys to verify they exist"),
+            [rt:pbc_read(PBC, Bucket, Key, Options) || Key <- Keys]
+    end,
+
+    lager:info("Scenario passed"),
+    lager:info("-----------------------------------------------------"),
+    ok.


### PR DESCRIPTION
Add `ensemble_basic4`, `ensemble_sync`, and `ensemble_interleave` tests.

`ensemble_sync` tests the new AAE-based peer syncing logic. The test checks various scenarios with different levels of data corruption.

`ensemble_interleave` tests a specific scenario where two peers become corrupted one after the other. This tests the scenario where the second peer becomes untrusted while the first peer may be syncing with it.

FYI, two of these tests require 8-node clusters so make sure to setup your `riak_test` build directory with an 8-node devrel.

Sibling pull-requests: basho/riak_ensemble#14, basho/riak_kv#896
