### PR TITLE
Wait for transfers to complete in replication2_pg:test_pg_proxy

### DIFF
--- a/tests/replication2_pg.erl
+++ b/tests/replication2_pg.erl
@@ -116,6 +116,10 @@ setup_repl_clusters(Conf, SSL) ->
     ?assertEqual(ok, repl_util:wait_for_connection(LeaderA, "C")),
     rt:wait_until_ring_converged(ANodes),
 
+    rt:wait_until_transfers_complete(ANodes),
+    rt:wait_until_transfers_complete(BNodes),
+    rt:wait_until_transfers_complete(CNodes),
+
     {LeaderA, ANodes, BNodes, CNodes, Nodes}.
 
 


### PR DESCRIPTION
Wait for transfers to complete in `replication2_pg:test_pg_proxy`. Replication tests that test the `n_val=1` request option can fail with `insufficient_vnodes` errors if the cluster setup does not include waiting for transfers to complete. Change the `test_pg_proxy` test case to wait until transfers complete on the "A" and "B" clusters before proceeding.

This is intended to address the beta giddyup failure of `replication2_pg:test_basic_pg_mode_mixed_ssl`, but probably affects a good portion of the replication `proxy_get` tests.
