### PR TITLE
Change rpc handling in rt module to handle badrpc returns

### DIFF
--- a/src/rt.erl
+++ b/src/rt.erl
@@ -671,7 +671,7 @@ wait_until_all_members(Nodes, ExpectedMembers) ->
     S1 = ordsets:from_list(ExpectedMembers),
     F = fun(Node) ->
                 case members_according_to(Node) of
-                    {badprc, _} ->
+                    {badrpc, _} ->
                         false;
                     ReportedMembers ->
                         S2 = ordsets:from_list(ReportedMembers),


### PR DESCRIPTION
Change how the return from some rpc calls is handled in the rt module in order
to avoid spurious or misleading test failures.
