### PR TITLE
improve riak_test bash completion

### DIFF
--- a/utils/riak_test.bash
+++ b/utils/riak_test.bash
@@ -1,18 +1,28 @@
 # bash_completion for riak_test
 _riak_test()
 {
-    local cur prev
-    _get_comp_words_by_ref cur prev
+    local cur prev tests
+    if type _get_comp_words_by_ref &>/dev/null; then
+        _get_comp_words_by_ref cur prev
+    else
+        for i in ${!COMP_WORDS[*]}; do
+            prev=$cur
+            cur=${COMP_WORDS[$i]}
+        done
+    fi
 
     case $prev in
-        riak_test)
-            COMPREPLY=( $( compgen -W "-h -c -t -s -d -v -o -b -u -r" -- "$cur" ) )
+        riak_test|*/riak_test)
+            COMPREPLY=( $(compgen -W "-h -c -t -s -d -x -v -o -b -u -r -F \
+                                      --help --conf --tests --suites \
+                                      --dir --skip --verbose --outdir --backend \
+                                      --upgrade --report --file" -- "$cur") )
             ;;
-        -t)
-            RT_TESTS=`grep -l confirm ./tests/*.erl | xargs basename -s .erl`
-            COMPREPLY=( $( compgen -W "$RT_TESTS" -- "$cur") )
+        -t|--tests)
+            tests=$(grep -l confirm/0 ./tests/*.erl 2>/dev/null \
+                | xargs basename -s .erl)
+            COMPREPLY=( $(compgen -W "$tests" -- "$cur") )
             ;;
-
     esac
 }
 complete -F _riak_test riak_test


### PR DESCRIPTION
Add missing riak_test options. Allow completion to work if riak_test is
invoked as ./riak_test or a similar pathname. Change the grep for "confirm"
to "confirm/0", which should be found in a test module export, so it
doesn't accidentally catch the plain word "confirm" in a comment in a
module that shouldn't be part of the testname completion. The
_get_comp_words_by_ref helper function is not available by default on OS X,
so add code to compensate for that case. Use a local variable to capture
the grep output, rather than overwriting a global variable.
