### PR TITLE
PB connection used in verify_counter_capbilities can be closed during upgrade

### DIFF
--- a/tests/verify_counter_capability.erl
+++ b/tests/verify_counter_capability.erl
@@ -57,7 +57,11 @@ confirm() ->
     ?assertEqual({error,<<"\"Counters are not supported\"">>}, riakc_pb_socket:counter_incr(PB, ?BUCKET, ?KEY, 1)),
     ?assertEqual({error,<<"\"Counters are not supported\"">>}, riakc_pb_socket:counter_val(PB, ?BUCKET, ?KEY)),
 
+    riakc_pb_socket:stop(PrevPB),
+
     rt:upgrade(Legacy, previous),
+
+    PrevPB2 = rt:pbc(Legacy),
 
     ?assertEqual(ok, rt:wait_until_capability(Previous, {riak_kv, crdt}, [pncounter])),
 
@@ -67,12 +71,12 @@ confirm() ->
     ?assertMatch(ok, rhc:counter_incr(Http, ?BUCKET, ?KEY, 1)),
     ?assertMatch({ok, 2}, rhc:counter_val(Http, ?BUCKET, ?KEY)),
 
-    ?assertEqual(ok, riakc_pb_socket:counter_incr(PrevPB, ?BUCKET, ?KEY, 1)),
-    ?assertEqual({ok, 3}, riakc_pb_socket:counter_val(PrevPB, ?BUCKET, ?KEY)),
+    ?assertEqual(ok, riakc_pb_socket:counter_incr(PrevPB2, ?BUCKET, ?KEY, 1)),
+    ?assertEqual({ok, 3}, riakc_pb_socket:counter_val(PrevPB2, ?BUCKET, ?KEY)),
     ?assertEqual(ok, riakc_pb_socket:counter_incr(PB, ?BUCKET, ?KEY, 1)),
     ?assertEqual({ok, 4}, riakc_pb_socket:counter_val(PB, ?BUCKET, ?KEY)),
 
-    [riakc_pb_socket:stop(C) || C <- [PB, PrevPB]],
+    [riakc_pb_socket:stop(C) || C <- [PB, PrevPB2]],
 
     pass.
 


### PR DESCRIPTION
The PB connection to the `legacy` node can close if the upgrade takes too long and cause the test to fail with an error similar to this:

```
================ verify_counter_capability failure stack trace =====================
{{assertEqual_failed,[{module,verify_counter_capability},
                      {line,70},
                      {expression,"riakc_pb_socket : counter_incr ( PrevPB , ? BUCKET , ? KEY , 1 )"},
                      {expected,ok},
                      {value,{error,disconnected}}]},
 [{verify_counter_capability,'-confirm/0-fun-14-',2,
                             [{file,"tests/verify_counter_capability.erl"},
                              {line,70}]},
  {verify_counter_capability,confirm,0,
                             [{file,"tests/verify_counter_capability.erl"},
                              {line,70}]}]}
====================================================================================

09:38:09.576 [notice] verify_counter_capability Test Run Complete

Test Results:
verify_counter_capability-bitcask: fail
---------------------------------------------
1 Tests Failed
0 Tests Passed
That's 0.0% for those keeping score
```

The solution is to create a new PB connection to use after the node has been upgraded and restarted.
