### PR TITLE
Wait for realtime connections after node upgrades in replication tests

### DIFF
--- a/tests/replication2_upgrade.erl
+++ b/tests/replication2_upgrade.erl
@@ -76,7 +76,28 @@ confirm() ->
                           rt:log_to_nodes(Nodes, "Upgrade node: ~p", [Node]),
                           rtdev:upgrade(Node, current),
                           %% The upgrade did a wait for pingable
-                          timer:sleep(1000),
+                          rt:wait_for_service(Node, [riak_kv, riak_pipe, riak_repl]),
+                          [rt:wait_until_ring_converged(N) || N <- [ANodes, BNodes]],
+
+                          %% Prior to 1.4.8 riak_repl registered
+                          %% as a service before completing all
+                          %% initialization including establishing
+                          %% realtime connections.
+                          %%
+                          %% @TODO Ideally the test would only wait
+                          %% for the connection in the case of the
+                          %% node version being < 1.4.8, but currently
+                          %% the rt API does not provide a
+                          %% harness-agnostic method do get the node
+                          %% version. For now the test waits for all
+                          %% source cluster nodes to establish a
+                          %% connection before proceeding.
+                          case lists:member(Node, ANodes) of
+                              true ->
+                                  repl_util:wait_for_connection(Node, "B");
+                              false ->
+                                  ok
+                          end,
                           lager:info("Replication with upgraded node: ~p", [Node]),
                           rt:log_to_nodes(Nodes, "Replication with upgraded node: ~p", [Node]),
                           replication2:replication(ANodes, BNodes, true)


### PR DESCRIPTION
Prior to Riak 1.4.8 replication registers as a service prior to completing all
initialization tasks including establishing realtime connections to sink
clusters. This leads to a race condition in the replication_upgrade and
replication2_upgrade tests where the test may begin writing data to the source
cluster to verify the function of realtime replication before the most
recently upgraded node establishes a connection to the sink cluster. The
result of this is that the data is silently discarded by the realtime
replication system and the test fails because all of the expected data is not
replicated and able to be read on the sink cluster. Change the 
replication_upgrade and replication2_upgrade tests to explicitly wait for the
realtime connection to be established after each source cluster node is
upgraded before proceeding with the test.
