### PR TITLE
Switch all the selfsigned certificates to be generated on demand

### DIFF
--- a/tests/repl_util.erl
+++ b/tests/repl_util.erl
@@ -254,7 +254,6 @@ wait_for_connection(Node, Name) ->
                 case rpc:call(Node, riak_core_cluster_mgr,
                         get_connections, []) of
                     {ok, Connections} ->
-			lager:info("Connections: ~p", [Connections]),
                         Conn = [P || {{cluster_by_name, N}, P} <- Connections, N == Name],
                         case Conn of
                             [] ->

--- a/tests/replication2_pg.erl
+++ b/tests/replication2_pg.erl
@@ -20,19 +20,24 @@ setup_repl_clusters(Conf, SSL) ->
     NumNodes = 6,
     lager:info("Deploy ~p nodes", [NumNodes]),
 
+    CertDir = rt_config:get(rt_scratch_dir) ++ "/certs",
 
-    PrivDir = rt:priv_dir(),
+    %% make a bunch of crypto keys
+    make_certs:rootCA(CertDir, "rootCA"),
+    make_certs:intermediateCA(CertDir, "intCA", "rootCA"),
+    make_certs:endusers(CertDir, "rootCA", ["site3.basho.com", "site4.basho.com"]),
+    make_certs:endusers(CertDir, "intCA", ["site1.basho.com", "site2.basho.com"]),
 
     SSLConfig1 = [
             {riak_core,
              [
                     {ssl_enabled, true},
-                    {certfile, filename:join([PrivDir,
-                                              "certs/selfsigned/site1-cert.pem"])},
-                    {keyfile, filename:join([PrivDir,
-                                             "certs/selfsigned/site1-key.pem"])},
-                    {cacertdir, filename:join([PrivDir,
-                                               "certs/selfsigned/ca"])}
+                    {certfile, filename:join([CertDir,
+                                              "site1.basho.com/cert.pem"])},
+                    {keyfile, filename:join([CertDir,
+                                             "site1.basho.com/key.pem"])},
+                    {cacertdir, filename:join([CertDir,
+                                               "site1.basho.com/cacerts.pem"])}
                     ]}
             ],
 
@@ -40,12 +45,12 @@ setup_repl_clusters(Conf, SSL) ->
             {riak_core,
              [
                     {ssl_enabled, true},
-                    {certfile, filename:join([PrivDir,
-                                              "certs/selfsigned/site2-cert.pem"])},
-                    {keyfile, filename:join([PrivDir,
-                                             "certs/selfsigned/site2-key.pem"])},
-                    {cacertdir, filename:join([PrivDir,
-                                               "certs/selfsigned/ca"])}
+                    {certfile, filename:join([CertDir,
+                                              "site2.basho.com/cert.pem"])},
+                    {keyfile, filename:join([CertDir,
+                                             "site2.basho.com/key.pem"])},
+                    {cacertdir, filename:join([CertDir,
+                                               "site2.basho.com/cacerts.pem"])}
                     ]}
             ],
 
@@ -53,12 +58,12 @@ setup_repl_clusters(Conf, SSL) ->
             {riak_core,
              [
                     {ssl_enabled, true},
-                    {certfile, filename:join([PrivDir,
-                                              "certs/selfsigned/site3-cert.pem"])},
-                    {keyfile, filename:join([PrivDir,
-                                             "certs/selfsigned/site3-key.pem"])},
-                    {cacertdir, filename:join([PrivDir,
-                                               "certs/selfsigned/ca"])}
+                    {certfile, filename:join([CertDir,
+                                              "site3.basho.com/cert.pem"])},
+                    {keyfile, filename:join([CertDir,
+                                             "site3.basho.com/key.pem"])},
+                    {cacertdir, filename:join([CertDir,
+                                               "site3.basho.com/cacerts.pem"])}
                     ]}
             ],
 

--- a/tests/replication2_ssl.erl
+++ b/tests/replication2_ssl.erl
@@ -12,6 +12,14 @@ confirm() ->
     NumNodes = rt_config:get(num_nodes, 6),
     ClusterASize = rt_config:get(cluster_a_size, 3),
 
+    CertDir = rt_config:get(rt_scratch_dir) ++ "/certs",
+
+    %% make a bunch of crypto keys
+    make_certs:rootCA(CertDir, "rootCA"),
+    make_certs:intermediateCA(CertDir, "intCA", "rootCA"),
+    make_certs:endusers(CertDir, "rootCA", ["site3.basho.com", "site4.basho.com"]),
+    make_certs:endusers(CertDir, "intCA", ["site1.basho.com", "site2.basho.com"]),
+
     lager:info("Deploy ~p nodes", [NumNodes]),
     BaseConf = [
         {riak_core,
@@ -36,12 +44,12 @@ confirm() ->
         {riak_core,
             [
                 {ssl_enabled, true},
-                {certfile, filename:join([PrivDir,
-                            "certs/selfsigned/site1-cert.pem"])},
-                {keyfile, filename:join([PrivDir,
-                            "certs/selfsigned/site1-key.pem"])},
-                {cacertdir, filename:join([PrivDir,
-                            "certs/selfsigned/ca"])}
+                {certfile, filename:join([CertDir,
+                            "site1.basho.com/cert.pem"])},
+                {keyfile, filename:join([CertDir,
+                            "site1.basho.com/key.pem"])},
+                {cacertdir, filename:join([CertDir,
+                            "site1.basho.com/cacerts.pem"])}
             ]}
     ],
 
@@ -54,12 +62,12 @@ confirm() ->
         {riak_core,
             [
                 {ssl_enabled, true},
-                {certfile, filename:join([PrivDir,
-                            "certs/selfsigned/site2-cert.pem"])},
-                {keyfile, filename:join([PrivDir,
-                            "certs/selfsigned/site2-key.pem"])},
-                {cacertdir, filename:join([PrivDir,
-                            "certs/selfsigned/ca"])}
+                {certfile, filename:join([CertDir,
+                            "site2.basho.com/cert.pem"])},
+                {keyfile, filename:join([CertDir,
+                            "site2.basho.com/key.pem"])},
+                {cacertdir, filename:join([CertDir,
+                            "site2.basho.com/cacerts.pem"])}
             ]}
     ],
 
@@ -72,12 +80,12 @@ confirm() ->
         {riak_core,
             [
                 {ssl_enabled, true},
-                {certfile, filename:join([PrivDir,
-                            "certs/selfsigned/site3-cert.pem"])},
-                {keyfile, filename:join([PrivDir,
-                            "certs/selfsigned/site3-key.pem"])},
-                {cacertdir, filename:join([PrivDir,
-                            "certs/selfsigned/ca"])}
+                {certfile, filename:join([CertDir,
+                            "site3.basho.com/cert.pem"])},
+                {keyfile, filename:join([CertDir,
+                            "site3.basho.com/key.pem"])},
+                {cacertdir, filename:join([CertDir,
+                            "site3.basho.com/cacerts.pem"])}
             ]}
     ],
 
@@ -93,12 +101,12 @@ confirm() ->
 
                 {ssl_enabled, true},
                 {ssl_depth, 0},
-                {certfile, filename:join([PrivDir,
-                            "certs/selfsigned/site3-cert.pem"])},
-                {keyfile, filename:join([PrivDir,
-                            "certs/selfsigned/site3-key.pem"])},
-                {cacertdir, filename:join([PrivDir,
-                            "certs/selfsigned/ca"])}
+                {certfile, filename:join([CertDir,
+                            "site3.basho.com/cert.pem"])},
+                {keyfile, filename:join([CertDir,
+                            "site3.basho.com/key.pem"])},
+                {cacertdir, filename:join([CertDir,
+                            "site3.basho.com/cacerts.pem"])}
             ]}
     ],
 
@@ -112,12 +120,12 @@ confirm() ->
             [
                 {ssl_enabled, true},
                 {ssl_depth, 0},
-                {certfile, filename:join([PrivDir,
-                            "certs/selfsigned/site4-cert.pem"])},
-                {keyfile, filename:join([PrivDir,
-                            "certs/selfsigned/site4-key.pem"])},
-                {cacertdir, filename:join([PrivDir,
-                            "certs/selfsigned/ca"])}
+                {certfile, filename:join([CertDir,
+                            "site4.basho.com/cert.pem"])},
+                {keyfile, filename:join([CertDir,
+                            "site4.basho.com/key.pem"])},
+                {cacertdir, filename:join([CertDir,
+                            "site4.basho.com/cacerts.pem"])}
             ]}
     ],
 

--- a/tests/replication_ssl.erl
+++ b/tests/replication_ssl.erl
@@ -11,6 +11,14 @@ confirm() ->
     NumNodes = rt_config:get(num_nodes, 6),
     ClusterASize = rt_config:get(cluster_a_size, 3),
 
+    CertDir = rt_config:get(rt_scratch_dir) ++ "/certs",
+
+    %% make a bunch of crypto keys
+    make_certs:rootCA(CertDir, "rootCA"),
+    make_certs:intermediateCA(CertDir, "intCA", "rootCA"),
+    make_certs:endusers(CertDir, "rootCA", ["site3.basho.com", "site4.basho.com"]),
+    make_certs:endusers(CertDir, "intCA", ["site1.basho.com", "site2.basho.com"]),
+
     lager:info("Deploy ~p nodes", [NumNodes]),
     BaseConf = [
             {riak_repl,
@@ -31,12 +39,12 @@ confirm() ->
                 {fullsync_on_connect, false},
                 {fullsync_interval, disabled},
                 {ssl_enabled, true},
-                {certfile, filename:join([PrivDir,
-                            "certs/selfsigned/site1-cert.pem"])},
-                {keyfile, filename:join([PrivDir,
-                            "certs/selfsigned/site1-key.pem"])},
-                {cacertdir, filename:join([PrivDir,
-                            "certs/selfsigned/ca"])}
+                {certfile, filename:join([CertDir,
+                            "site1/basho.com/cert.pem"])},
+                {keyfile, filename:join([CertDir,
+                            "site1.basho.com/key.pem"])},
+                {cacertdir, filename:join([CertDir,
+                            "site1.basho.com/cacerts.pem"])}
             ]}
     ],
 
@@ -46,12 +54,12 @@ confirm() ->
                 {fullsync_on_connect, false},
                 {fullsync_interval, disabled},
                 {ssl_enabled, true},
-                {certfile, filename:join([PrivDir,
-                            "certs/selfsigned/site2-cert.pem"])},
-                {keyfile, filename:join([PrivDir,
-                            "certs/selfsigned/site2-key.pem"])},
-                {cacertdir, filename:join([PrivDir,
-                            "certs/selfsigned/ca"])}
+                {certfile, filename:join([CertDir,
+                            "site2.basho.com/cert.pem"])},
+                {keyfile, filename:join([CertDir,
+                            "site2.basho.com/key.pem"])},
+                {cacertdir, filename:join([CertDir,
+                            "site2.basho.com/cacerts.pem"])}
             ]}
     ],
 
@@ -61,12 +69,12 @@ confirm() ->
                 {fullsync_on_connect, false},
                 {fullsync_interval, disabled},
                 {ssl_enabled, true},
-                {certfile, filename:join([PrivDir,
-                            "certs/selfsigned/site3-cert.pem"])},
-                {keyfile, filename:join([PrivDir,
-                            "certs/selfsigned/site3-key.pem"])},
-                {cacertdir, filename:join([PrivDir,
-                            "certs/selfsigned/ca"])}
+                {certfile, filename:join([CertDir,
+                            "site3.basho.com/cert.pem"])},
+                {keyfile, filename:join([CertDir,
+                            "site3.basho.com/key.pem"])},
+                {cacertdir, filename:join([CertDir,
+                            "site3.basho.com/cacerts.pem"])}
             ]}
     ],
 
@@ -78,12 +86,12 @@ confirm() ->
                 {fullsync_interval, disabled},
                 {ssl_enabled, true},
                 {ssl_depth, 0},
-                {certfile, filename:join([PrivDir,
-                            "certs/selfsigned/site3-cert.pem"])},
-                {keyfile, filename:join([PrivDir,
-                            "certs/selfsigned/site3-key.pem"])},
-                {cacertdir, filename:join([PrivDir,
-                            "certs/selfsigned/ca"])}
+                {certfile, filename:join([CertDir,
+                            "site3.basho.com/cert.pem"])},
+                {keyfile, filename:join([CertDir,
+                            "site3.basho.com/key.pem"])},
+                {cacertdir, filename:join([CertDir,
+                            "site3.basho.com/cacerts.pem"])}
             ]}
     ],
 
@@ -94,12 +102,12 @@ confirm() ->
                 {fullsync_interval, disabled},
                 {ssl_enabled, true},
                 {ssl_depth, 0},
-                {certfile, filename:join([PrivDir,
-                            "certs/selfsigned/site4-cert.pem"])},
-                {keyfile, filename:join([PrivDir,
-                            "certs/selfsigned/site4-key.pem"])},
-                {cacertdir, filename:join([PrivDir,
-                            "certs/selfsigned/ca"])}
+                {certfile, filename:join([CertDir,
+                            "site4.basho.com/cert.pem"])},
+                {keyfile, filename:join([CertDir,
+                            "site4.basho.com/key.pem"])},
+                {cacertdir, filename:join([CertDir,
+                            "site4.basho.com/cacerts.pem"])}
             ]}
     ],
 


### PR DESCRIPTION
Using the make_cert tool we can generate arbitrary certificate chains on
demand, so they never have to be regenerated.

cc @kellymclaughlin @lordnull 
