### PR TITLE
Java tests fail against 2.0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -15,6 +15,7 @@
         {mapred_verify, ".*", {git, "git://github.com/basho/mapred_verify", {branch, "master"}}},
         {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {branch, "master"}}},
         {riakhttpc, ".*", {git, "git://github.com/basho/riak-erlang-http-client", {branch, "master"}}},
+        {riak_java_client, "1.4.2", {git, "git://github.com/basho/riak-java-client", {tag, "riak-client-1.4.2"}}, [raw]},
         {kvc, "1.3.0", {git, "https://github.com/etrepum/kvc", {tag, "v1.3.0"}}},
         {druuid, ".*", {git, "git://github.com/kellymclaughlin/druuid.git", {tag, "0.2"}}}
        ]}.

--- a/tests/client_java_verify.erl
+++ b/tests/client_java_verify.erl
@@ -3,22 +3,19 @@
 -export([confirm/0]).
 -include_lib("eunit/include/eunit.hrl").
 
-%% Change when a new release comes out.
--define(JAVA_FAT_BE_URL, rt_config:get('java.fat_be_url')).
--define(JAVA_TESTS_URL, rt_config:get('java.tests_url')).
-
 -prereq("java").
+-prereq("mvn").
 -prereq("curl").
 
 confirm() ->
-    
+
     lager:info("+P ~p", [erlang:system_info(process_limit)]),
     prereqs(),
     Nodes = rt:deploy_nodes(1),
     [Node1] = Nodes,
     ?assertEqual(ok, rt:wait_until_nodes_ready([Node1])),
-    
-    rpc:call(Node1, application, set_env, [erlang_js, script_timeout, 10000]), 
+
+    rpc:call(Node1, application, set_env, [erlang_js, script_timeout, 10000]),
     [{Node1, ConnectionInfo}] = rt:connection_info([Node1]),
     {HTTP_Host, HTTP_Port} = orddict:fetch(http, ConnectionInfo),
     {PB_Host, PB_Port} = orddict:fetch(pb, ConnectionInfo),
@@ -29,23 +26,19 @@ confirm() ->
     pass.
 
 prereqs() ->
-    %% Does you have the java client available?
-    rt_local:download(?JAVA_FAT_BE_URL),
-    rt_local:download(?JAVA_TESTS_URL),
     ok.
 
 java_unit_tests(HTTP_Host, HTTP_Port, _PB_Host, PB_Port) ->
     lager:info("Run the Java unit tests from somewhere on the local machine."),
-
     %% run the following:
     Cmd = io_lib:format(
-        "java -Dcom.basho.riak.host=~s -Dcom.basho.riak.http.port=~p -Dcom.basho.riak.pbc.port=~p -cp ~s:~s org.junit.runner.JUnitCore com.basho.riak.client.AllTests",
-        [HTTP_Host, HTTP_Port, PB_Port, 
-        rt_config:get(rt_scratch_dir) ++ "/" ++ rt_local:url_to_filename(?JAVA_FAT_BE_URL), 
-        rt_config:get(rt_scratch_dir) ++ "/" ++ rt_local:url_to_filename(?JAVA_TESTS_URL)]),
+            "mvn -f deps/riak_java_client/pom.xml -Pitest clean compile verify "
+            "-DargLine=\"-Dcom.basho.riak.host=~s -Dcom.basho.riak.http.port=~p"
+            " -Dcom.basho.riak.pbc.port=~p\"",
+            [HTTP_Host, HTTP_Port, PB_Port]),
     lager:info("Cmd: ~s", [Cmd]),
 
-    {ExitCode, JavaLog} = rt_local:stream_cmd(Cmd, [{cd, rt_config:get(rt_scratch_dir)}]),
+    {ExitCode, JavaLog} = rt_local:stream_cmd(Cmd, []),
     ?assertEqual(0, ExitCode),
     lager:info(JavaLog),
     ?assertNot(rt:str(JavaLog, "FAILURES!!!")),


### PR DESCRIPTION
### TL;DR

`06:20:03.077 [info] Could not find the main class: org.junit.runner.JUnitCore. Program will exit.`
### Problem

The java tests used to OOM on the testers, now there seems to be a setup problem.  I know very little about java, so this might be a very easy fix for someone in the know. cc @broach @mgodave 
### Log

http://giddyup.basho.com/#/projects/riak_ee/scorecards/57/57-249-client_java_verify-centos-6-64/31084/artifacts/439456
