### PR TITLE
Removed 'allow_mult false' for test.

### DIFF
--- a/tests/replication2.erl
+++ b/tests/replication2.erl
@@ -12,9 +12,6 @@
 
 confirm() ->
 
-    %% test requires allow_mult=false
-    rt:set_conf(all, [{"buckets.default.allow_mult", "false"}]),
-
     NumNodes = rt_config:get(num_nodes, 6),
     ClusterASize = rt_config:get(cluster_a_size, 3),
 


### PR DESCRIPTION
This reverses an earlier change to support a feature that has been stripped
(for now). When said feature is put back in, it should support multi.
Setting this to allow mutlt = true allows for more confidence in tests.

Addresses #478 .
