### PR TITLE
Add tests for bugs reported against riak_kv: 917, 918

### DIFF
--- a/tests/http_security.erl
+++ b/tests/http_security.erl
@@ -180,6 +180,10 @@ confirm() ->
     ?assertMatch({error, {ok, "403", _, _}}, rhc:delete(C7, <<"hello">>,
                                                         <<"world">>)),
 
+    lager:info("Checking that delete for non-existing key is disallowed"),
+    ?assertMatch({error, {ok, "403", _, _}}, rhc:delete(C7, <<"hello">>,
+                                                        <<"_xxboguskey">>)),
+
     lager:info("Granting riak_kv.delete, checking that delete succeeds"),
     ok = rpc:call(Node, riak_core_console, grant, [["riak_kv.delete", "on",
                                                     "default", "hello", "to", Username]]),
@@ -192,6 +196,11 @@ confirm() ->
 
     %% write it back for list_buckets later
     ?assertEqual(ok, rhc:put(C7, Object)),
+
+    lager:info("Checking that delete for non-existing key is allowed"),
+    ?assertMatch({error, {ok, "404", _, _}}, rhc:delete(C7, <<"hello">>,
+                                                        <<"_xxboguskey">>)),
+
 
     %% slam the door in the user's face
     lager:info("Revoking get/put/delete, checking that get/put/delete are disallowed"),
@@ -237,6 +246,9 @@ confirm() ->
     ?assertEqual(3, proplists:get_value(n_val, element(2, rhc:get_bucket(C7,
                                                                          <<"hello">>)))),
 
+    lager:info("Checking that reset_bucket is disallowed"),
+    ?assertMatch({error, {ok, "403", _, _}}, rhc:reset_bucket(C7, <<"hello">>)),
+
     lager:info("Checking that set_bucket is disallowed"),
     ?assertMatch({error, {ok, "403", _, _}}, rhc:set_bucket(C7, <<"hello">>,
                                                             [{n_val, 5}])),
@@ -250,6 +262,9 @@ confirm() ->
 
     ?assertEqual(5, proplists:get_value(n_val, element(2, rhc:get_bucket(C7,
                                                                          <<"hello">>)))),
+
+    lager:info("Checking that reset_bucket is allowed after set_bucket grant"),
+    ?assertMatch(ok, rhc:reset_bucket(C7, <<"hello">>)),
 
     %% counters
 


### PR DESCRIPTION
@javajolt found two glaring bugs with security and filed tickets (basho/riak_kv#917, basho/riak_kv#918); these new tests should detect any regressions.

@bowrocker, please give this branch a try against your bug fix for basho/riak_kv#918. It should still fail on the props test (waiting for a fix on basho/riak_kv#917), but should pass the non-existent key test.
