### PR TITLE
Update tests that return something other than pass for success

### DIFF
--- a/tests/bucket_types.erl
+++ b/tests/bucket_types.erl
@@ -464,7 +464,7 @@ confirm() ->
                                          undefined, true}])),
 
     riakc_pb_socket:stop(PB),
-    ok.
+    pass.
 
 accumulate(ReqID) ->
     receive

--- a/tests/cluster_meta_basic.erl
+++ b/tests/cluster_meta_basic.erl
@@ -33,8 +33,8 @@ confirm() ->
     Nodes = rt:build_cluster(5),
     ok = test_fold_full_prefix(Nodes),
     ok = test_metadata_conflicts(Nodes),
-    ok = test_writes_after_partial_cluster_failure(Nodes).
-
+    ok = test_writes_after_partial_cluster_failure(Nodes),
+    pass.
 
 %% 1. write a key and waits til it propogates around the cluster
 %% 2. stop the immediate eager peers of the node that performed the write

--- a/tests/cluster_meta_rmr.erl
+++ b/tests/cluster_meta_rmr.erl
@@ -29,7 +29,8 @@ confirm() ->
     lager:info("SEED: ~p", [Seed]),
     random:seed(Seed),
 %    run([10,20,40], 10, 50, 10).
-    run([5], 1, 5, 1).
+    run([5], 1, 5, 1),
+    pass.
 
 run(NumNodes, SuperRounds, NumRounds, StableRounds) when is_list(NumNodes) ->
     [begin

--- a/tests/handoff_ttl.erl
+++ b/tests/handoff_ttl.erl
@@ -36,8 +36,4 @@ confirm() ->
 
     %% TODO Wait the remainder of the 5 minutes and make sure all the keys are
     %% gone
-    ok.
-
-
-
-
+    pass.

--- a/tests/http_bucket_types.erl
+++ b/tests/http_bucket_types.erl
@@ -424,7 +424,7 @@ confirm() ->
                                         {reduce, {jsfun,
                                                   <<"Riak.reduceSum">>},
                                          undefined, true}])),
-    ok.
+    pass.
 
 mapred_modfun(Pipe, Args, _Timeout) ->
     lager:info("Args for mapred modfun are ~p", [Args]),

--- a/tests/http_security.erl
+++ b/tests/http_security.erl
@@ -287,15 +287,15 @@ confirm() ->
                                                    <<"John">>)),
 
             lager:info("Checking that 2i on a bucket-type is disallowed"),
-            ?assertMatch({error, {"403", _}}, 
-                         rhc:get_index(C7, {<<"list-keys-test">>, 
+            ?assertMatch({error, {"403", _}},
+                         rhc:get_index(C7, {<<"list-keys-test">>,
                                             <<"hello">>}, {binary_index, "name"}, <<"John">>)),
 
             lager:info("Granting riak_kv.index on the bucket type, checking that get_index succeeds"),
             ok = rpc:call(Node, riak_core_console, grant, [["riak_kv.index", "on",
                                                     "list-keys-test", "to", Username]]),
-            ?assertMatch({ok, ?INDEX_RESULTS{}}, 
-                         rhc:get_index(C7, {<<"list-keys-test">>, 
+            ?assertMatch({ok, ?INDEX_RESULTS{}},
+                         rhc:get_index(C7, {<<"list-keys-test">>,
                                             <<"hello">>}, {binary_index, "name"}, <<"John">>)),
 
             ok
@@ -497,7 +497,7 @@ confirm() ->
                                                                      "rootCA/cert.pem"])},
                                          {verify, verify_peer},
                                          {reuse_sessions, false}]}])),
-    ok.
+    pass.
 
 enable_ssl(Node) ->
     [{http, {_IP, Port}}|_] = rt:connection_info(Node),

--- a/tests/pb_security.erl
+++ b/tests/pb_security.erl
@@ -755,7 +755,7 @@ group_test(Node, Port, CertDir) ->
                            riakc_pb_socket:search(PB, <<"index">>, <<"foo:bar">>)),
 
     riakc_pb_socket:stop(PB),
-    ok.
+    pass.
 
 grant(Node, Args) ->
     ok = rpc:call(Node, riak_core_console, grant, [Args]).

--- a/tests/repl_fs_stat_caching.erl
+++ b/tests/repl_fs_stat_caching.erl
@@ -31,7 +31,7 @@ confirm() ->
 
     true = rpc:block_call(node(Suspended), erlang, resume_process, [Suspended]),
 
-    ?assert(true).
+    pass.
 
 setup() ->
     rt:set_conf(all, [{"buckets.default.allow_mult", "false"}]),
@@ -107,4 +107,3 @@ maybe_suspend_an_fs_source(Node, [{_Remote, Pid} | Tail]) ->
         true ->
             Pid
     end.
-

--- a/tests/rpc_output.erl
+++ b/tests/rpc_output.erl
@@ -34,7 +34,7 @@
          handle_info/2,
          terminate/2,
          code_change/3]).
-         
+
 confirm() ->
     gen_event:add_handler(lager_event, ?MODULE, []),
     io:put_chars("This is an io:put_chars/1 call"),
@@ -43,7 +43,8 @@ confirm() ->
     lager:info("This is a lager message"),
     {ok, {LogId, Failures}} = gen_event:delete_handler(lager_event, ?MODULE, []),
     ?assertEqual(5, LogId),
-    ?assertEqual([], Failures).
+    ?assertEqual([], Failures),
+    pass.
 
 -record(state, {level = debug, verbose = true, log_id = 1, failures = []}).
 
@@ -55,7 +56,7 @@ handle_event({log, _Level, {_Date, _Time}, [_LevelStr, _Location, Message]}, Sta
     check_log_message(lists:flatten(Message), State);
 handle_event(_, State) ->
     {ok, State}.
-    
+
 handle_call(_, State) ->
     {ok, State}.
 
@@ -67,7 +68,7 @@ code_change(_OldVsn, State, _Extra) ->
 
 terminate(_Reason, #state{log_id = LogId, failures = Failures}) ->
     {ok, {LogId, Failures}}.
-    
+
 check_log_message(Message, #state{log_id = LogId, failures = Failures} = State) ->
     try
         case LogId of
@@ -80,4 +81,4 @@ check_log_message(Message, #state{log_id = LogId, failures = Failures} = State) 
         {ok, State#state{log_id = LogId + 1}}
     catch
         _:Reason -> {ok, State#state{log_id = LogId + 1, failures = [Reason|Failures]}}
-    end.            
+    end.

--- a/tests/verify_busy_dist_port.erl
+++ b/tests/verify_busy_dist_port.erl
@@ -2,17 +2,17 @@
 %%
 %% Copyright (c) 2012 Basho Technologies, Inc.
 %%
-%% Test for regression in riak_sysmon where busy_port/busy_dist_port were not set to 
-%% true in app.config by default. Originally reported in az1018 (AgileZen 1018). 
+%% Test for regression in riak_sysmon where busy_port/busy_dist_port were not set to
+%% true in app.config by default. Originally reported in az1018 (AgileZen 1018).
 %%
 %% This test starts two riak nodes and pauses the process of one of the node's vms
 %% using "kill -STOP". The other node (not paused) is then directed to send thousands
 %% of messages to the paused node, which should cause busy_dist_port. We then check
-%% for busy_dist_port messages in the logs. 
-%% 
-%% see: https://issues.basho.com/show_bug.cgi?id=1305 
+%% for busy_dist_port messages in the logs.
+%%
+%% see: https://issues.basho.com/show_bug.cgi?id=1305
 %% see: https://github.com/basho/basho_expect/blob/master/basho_expect/regression_az1018.py
-%% 
+%%
 %% -- ORIGINAL TICKET TEXT FROM AGILE ZEN (AZ1018) --
 %% As we discovered in a customer's production network, riak_sysmon has been
 %% mis-configured and buggy and therefore was not logging 'busy_dist_port' events
@@ -23,9 +23,9 @@
 %%
 %% Fix the riak_sysmon_filter:init() code.
 %% Tune the app.config settings to correct values.
-%% 
+%%
 %% -- END ORIGINAL TICKET --
-%% 
+%%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
 %% except in compliance with the License.  You may obtain
@@ -52,7 +52,7 @@ confirm() ->
 
     rt:load_modules_on_nodes([cause_bdp, verify_bdp_event_handler,
                              riak_test_lager_backend], [Node1]),
-    Res = rpc:call(Node1, verify_bdp_event_handler, add_handler, [self()]),    
+    Res = rpc:call(Node1, verify_bdp_event_handler, add_handler, [self()]),
     ok = rpc:call(Node1, gen_event, add_handler, [lager_event, riak_test_lager_backend, [info, false]]),
     ok = rpc:call(Node1, lager, set_loglevel, [riak_test_lager_backend, info]),
     lager:info("RES: ~p", [Res]),
@@ -63,7 +63,7 @@ confirm() ->
     rpc:cast(Node2, os, cmd, [lists:flatten(io_lib:format("kill -STOP ~s", [OsPid]))]),
 
     lager:info("flooding node 2 (paused) with messages from node 1"),
-    rpc:call(Node1, cause_bdp, spam_nodes, [[Node2]]), 
+    rpc:call(Node1, cause_bdp, spam_nodes, [[Node2]]),
 
 
     receive
@@ -100,10 +100,10 @@ confirm() ->
 
     lager:info("continuing node 2 (~p) pid ~s", [Node2, OsPid]),
     %% NOTE: this call must be executed on the OS running Node2 in order to unpause it
-    %%       and not break future test runs. The command cannot be executed via 
-    %%       rpc:cast(Node2, os, cmd, ...) because Node2 is paused and will never process the 
+    %%       and not break future test runs. The command cannot be executed via
+    %%       rpc:cast(Node2, os, cmd, ...) because Node2 is paused and will never process the
     %%       message!
     rt:cmd(lists:flatten(io_lib:format("kill -CONT ~p", [OsPid]))),
 
-    ?assert(Success).
-
+    ?assert(Success),
+    pass.

--- a/tests/verify_riak_object_reformat.erl
+++ b/tests/verify_riak_object_reformat.erl
@@ -53,7 +53,7 @@ confirm() ->
          lager:info("Ensuring keys still readable on ~p", [Node]),
          ?assertEqual([], rt:systest_read(Node, 100, ?N))
      end || Node <- Nodes],
-    ok.
+    pass.
 
 run_reformat(Node, KillHandoffs) ->
     {_Success, _Ignore, Error} = rpc:call(Node,


### PR DESCRIPTION
As of commit 3044839456249f6f70b9642a60ad9be3dfb6056c tests that return
something other than the prescribed success atom 'pass' to indicate success
result in test failure. Change tests that return the atom 'ok' or some other
value to instead return 'pass' to indicate success.
