### PR TITLE
First pass at consolidating tests : 2i

### DIFF
--- a/include/rt.hrl
+++ b/include/rt.hrl
@@ -18,6 +18,12 @@
 %%
 %% -------------------------------------------------------------------
 
+-record(rt_test_context,
+        {
+         nodes :: [atom()],
+         buckets :: [binary()]
+        }).
+
 -record(rt_webhook, {
         name :: string(),
         url :: string(),

--- a/src/rt.erl
+++ b/src/rt.erl
@@ -98,6 +98,8 @@
          riak/2,
          riak_repl/2,
          rpc_get_env/2,
+         rpc_set_env/4,
+         rpc_unset_env/3,
          set_backend/1,
          set_backend/2,
          set_conf/2,
@@ -233,6 +235,38 @@ rpc_get_env(Node, [{App,Var}|Others]) ->
         _ ->
             rpc_get_env(Node, Others)
     end.
+
+%% @doc Sets an application environment variable in all given nodes.
+%% The function asserts and the test fails if any of the remote
+%% set_env calls fails.
+-spec rpc_set_env([atom()] | atom(), atom(), atom(), any()) -> ok.
+rpc_set_env(Nodes, App, Var, Val) when is_list(Nodes) ->
+    Timeout = rt_config:get(rt_max_wait_time),
+    {R0, _} = rpc:multicall(Nodes, application, set_env,
+                            [App, Var, Val], Timeout),
+    BadReplies = [{Node, Reply} || {Node, Reply} <- lists:zip(Nodes, R0),
+                                   Reply /= ok],
+    Tag = {failed_rpc_set_env, App, Var, Val},
+    ?assertEqual({Tag, []}, {Tag, BadReplies}),
+    ok;
+rpc_set_env(Node, App, Var, Val) when is_atom(Node) ->
+    rpc_set_env([Node], App, Var, Val).
+
+%% @doc Unsets an application environment variable in all given nodes.
+%% The function asserts and the test fails if any of the remote
+%% unset_env calls fails.
+-spec rpc_unset_env([atom()] | atom(), atom(), any()) -> ok.
+rpc_unset_env(Nodes, App, Var) when is_list(Nodes) ->
+    Timeout = rt_config:get(rt_max_wait_time),
+    {R0, _} = rpc:multicall(Nodes, application, unset_env,
+                            [App, Var], Timeout),
+    BadReplies = [{Node, Reply} || {Node, Reply} <- lists:zip(Nodes, R0),
+                                   Reply /= ok],
+    Tag = {failed_rpc_unset_env, App, Var},
+    ?assertEqual({Tag, []}, {Tag, BadReplies}),
+    ok;
+rpc_unset_env(Node, App, Var) when is_atom(Node) ->
+    rpc_unset_env([Node], App, Var).
 
 -type interface() :: {http, tuple()} | {pb, tuple()}.
 -type interfaces() :: [interface()].

--- a/tests/verify_2i.erl
+++ b/tests/verify_2i.erl
@@ -1,0 +1,63 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2014 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(verify_2i).
+-behavior(riak_test).
+
+-include("include/rt.hrl").
+
+-export([confirm/0]).
+
+-define(CONFIG,
+        [{riak_core,
+          [{handoff_concurrency, 100},
+           {ring_creation_size, 16},
+           {vnode_management_timer, 1000}
+          ]},
+         {riak_kv,
+          [{anti_entropy, {off, []}},
+           {anti_entropy_build_limit, {100, 500}},
+           {anti_entropy_concurrency, 100},
+           {anti_entropy_tick, 200}]}]).
+
+confirm() ->
+    inets:start(),
+    Nodes = rt:build_cluster(3, ?CONFIG),
+    run(secondary_index_tests, <<"2i_basic">>, Nodes),
+    run(verify_2i_returnterms, <<"2i_returnterms">>, Nodes),
+    run(verify_2i_timeout, <<"2i_timeout">>, Nodes),
+    run(verify_2i_stream, <<"2i_stream">>, Nodes),
+    run(verify_2i_limit, <<"2i_limit">>, Nodes),
+    run(verify_2i_aae, <<"2i_aae">>, Nodes).
+
+run(Mod, BucketOrBuckets, Nodes) ->
+    Buckets = to_list(BucketOrBuckets),
+    lager:info("Running test in ~s", [Mod]),
+    Exports = Mod:module_info(exports),
+    HasSetup = lists:member({setup, 1}, Exports),
+    HasCleanup = lists:member({cleanup, 1}, Exports),
+    Ctx = #rt_test_context{buckets=Buckets, nodes=Nodes},
+    RollbackInfo = HasSetup andalso Mod:setup(Ctx),
+    Mod:confirm(Ctx),
+    HasCleanup andalso Mod:cleanup(RollbackInfo).
+
+to_list(L) when is_list(L) ->
+    L;
+to_list(L) ->
+    [L].

--- a/tests/verify_2i_limit.erl
+++ b/tests/verify_2i_limit.erl
@@ -20,40 +20,50 @@
 -module(verify_2i_limit).
 -behavior(riak_test).
 -export([confirm/0]).
+-export([confirm/1]).
+
+-include("include/rt.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("riakc/include/riakc.hrl").
--import(secondary_index_tests, [put_an_object/2, put_an_object/4, int_to_key/1,
-                                stream_pb/3, http_query/3, pb_query/3]).
--define(BUCKET, <<"2ibucket">>).
+-import(secondary_index_tests, [put_an_object/3, put_an_object/5, int_to_key/1,
+                                stream_pb/4, http_query/4, pb_query/4]).
 -define(FOO, <<"foo">>).
 -define(MAX_RESULTS, 50).
 
 confirm() ->
     inets:start(),
-
+    Bucket = <<"2ilimits">>,
     Nodes = rt:build_cluster(3),
-    ?assertEqual(ok, (rt:wait_until_nodes_ready(Nodes))),
+    confirm(#rt_test_context{buckets=[Bucket], nodes=Nodes}).
 
+confirm(#rt_test_context{buckets=[Bucket|_], nodes=Nodes}) ->
     RiakHttp = rt:httpc(hd(Nodes)),
     HttpUrl = rt:http_url(hd(Nodes)),
     PBPid = rt:pbc(hd(Nodes)),
 
-    [put_an_object(PBPid, N) || N <- lists:seq(0, 100)],
+    lager:info("Writing objects 0-100"),
+    [put_an_object(PBPid, Bucket, N) || N <- lists:seq(0, 100)],
 
     ExpectedKeys = lists:sort([int_to_key(N) || N <- lists:seq(0, 100)]),
     {FirstHalf, Rest} = lists:split(?MAX_RESULTS, ExpectedKeys),
     Q = {<<"$key">>, int_to_key(0), int_to_key(999)},
 
     %% PB
-    {ok, PBRes} = stream_pb(PBPid, Q, [{max_results, ?MAX_RESULTS}]),
+    lager:info("Test PB stream"),
+    {ok, PBRes} = stream_pb(PBPid, Bucket, Q, [{max_results, ?MAX_RESULTS}]),
     ?assertEqual(FirstHalf, proplists:get_value(keys, PBRes, [])),
     PBContinuation = proplists:get_value(continuation, PBRes),
 
-    {ok, PBKeys2} = stream_pb(PBPid, Q, [{continuation, PBContinuation}]),
+    lager:info("Test PB continuation"),
+    {ok, PBKeys2} = stream_pb(PBPid, Bucket, Q, [{continuation, PBContinuation}]),
     ?assertEqual(Rest, proplists:get_value(keys, PBKeys2, [])),
 
     %% HTTP
-    HttpRes = rhc:get_index(RiakHttp, ?BUCKET, <<"$key">>,
+    lager:info("Test HTTP"),
+    lager:info("Params: ~p", [[RiakHttp, Bucket, <<"$key">>,
+                            {int_to_key(0), int_to_key(999)},
+                           [{max_results, ?MAX_RESULTS}]]]),
+    HttpRes = rhc:get_index(RiakHttp, Bucket, <<"$key">>,
                             {int_to_key(0), int_to_key(999)},
                            [{max_results, ?MAX_RESULTS}]),
     ?assertMatch({ok, ?INDEX_RESULTS{}}, HttpRes),
@@ -62,7 +72,8 @@ confirm() ->
     ?assertEqual(FirstHalf, HttpResKeys),
     ?assertEqual(PBContinuation, HttpContinuation),
 
-    HttpRes2 = rhc:get_index(RiakHttp, ?BUCKET, <<"$key">>,
+    lager:info("Test continuation with HTTP"),
+    HttpRes2 = rhc:get_index(RiakHttp, Bucket, <<"$key">>,
                              {int_to_key(0), int_to_key(999)},
                              [{continuation, HttpContinuation}]),
     ?assertMatch({ok, ?INDEX_RESULTS{}}, HttpRes2),
@@ -70,57 +81,61 @@ confirm() ->
     ?assertEqual(Rest, HttpRes2Keys),
 
     %% Multiple indexes for single key
-    O1 = riakc_obj:new(?BUCKET, <<"bob">>, <<"1">>),
+    lager:info("Put object 'bob' with multiple index values"),
+    O1 = riakc_obj:new(Bucket, <<"bob">>, <<"1">>),
     Md = riakc_obj:get_metadata(O1),
     Md2 = riakc_obj:set_secondary_index(Md, {{integer_index, "i1"}, [300, 301, 302]}),
     O2 = riakc_obj:update_metadata(O1, Md2),
     riakc_pb_socket:put(PBPid, O2),
 
+    lager:info("Query it with PB"),
     MQ = {"i1_int", 300, 302},
-    {ok, ?INDEX_RESULTS{terms=Terms, continuation=RTContinuation}} = pb_query(PBPid, MQ, [{max_results, 2}, return_terms]),
+    {ok, ?INDEX_RESULTS{terms=Terms, continuation=RTContinuation}} = pb_query(PBPid, Bucket, MQ, [{max_results, 2}, return_terms]),
 
     ?assertEqual([{<<"300">>, <<"bob">>},
                   {<<"301">>, <<"bob">>}], Terms),
 
-    {ok, ?INDEX_RESULTS{terms=Terms2}} = pb_query(PBPid, MQ, [{max_results, 2}, return_terms,
+    lager:info("Query it with PB and continuation"),
+    {ok, ?INDEX_RESULTS{terms=Terms2}} = pb_query(PBPid, Bucket, MQ, [{max_results, 2}, return_terms,
                                       {continuation, RTContinuation}]),
 
     ?assertEqual([{<<"302">>,<<"bob">>}], Terms2),
 
     %% gh611 - equals query pagination
-    riakc_pb_socket:delete(PBPid, ?BUCKET, <<"bob">>),
-    rt:wait_until(fun() -> rt:pbc_really_deleted(PBPid, ?BUCKET, [<<"bob">>]) end),
+    lager:info("Delete 'bob'"),
+    riakc_pb_socket:delete(PBPid, Bucket, <<"bob">>),
+    rt:wait_until(fun() -> rt:pbc_really_deleted(PBPid, Bucket, [<<"bob">>]) end),
 
-    [put_an_object(PBPid, int_to_key(N), 1000, <<"myval">>) || N <- lists:seq(0, 100)],
+    [put_an_object(PBPid, Bucket, int_to_key(N), 1000, <<"myval">>) || N <- lists:seq(0, 100)],
 
-    [ verify_eq_pag(PBPid, HttpUrl, EqualsQuery, FirstHalf, Rest) ||
+    [ verify_eq_pag(PBPid, HttpUrl, Bucket, EqualsQuery, FirstHalf, Rest) ||
         EqualsQuery <- [{"field1_bin", <<"myval">>},
                         {"field2_int", 1000},
-                        {"$bucket", ?BUCKET}]],
+                        {"$bucket", Bucket}]],
 
     riakc_pb_socket:stop(PBPid),
     pass.
 
-verify_eq_pag(PBPid, RiakHttp, EqualsQuery, FirstHalf, Rest) ->
-    HTTPEqs = http_query(RiakHttp, EqualsQuery, [{max_results, ?MAX_RESULTS}]),
+verify_eq_pag(PBPid, RiakHttp, Bucket, EqualsQuery, FirstHalf, Rest) ->
+    HTTPEqs = http_query(RiakHttp, Bucket, EqualsQuery, [{max_results, ?MAX_RESULTS}]),
     ?assertEqual({EqualsQuery, FirstHalf},
                  {EqualsQuery, proplists:get_value(<<"keys">>, HTTPEqs, [])}),
     EqualsHttpContinuation = proplists:get_value(<<"continuation">>, HTTPEqs),
 
-    HTTPEqs2 = http_query(RiakHttp, EqualsQuery,
+    HTTPEqs2 = http_query(RiakHttp, Bucket, EqualsQuery,
                           [{continuation, EqualsHttpContinuation}]),
     ?assertEqual({EqualsQuery, Rest},
                  {EqualsQuery, proplists:get_value(<<"keys">>, HTTPEqs2, [])}),
 
     %% And PB
 
-    {ok, EqPBRes} = stream_pb(PBPid, EqualsQuery,
+    {ok, EqPBRes} = stream_pb(PBPid, Bucket, EqualsQuery,
                               [{max_results, ?MAX_RESULTS}]),
     ?assertEqual({EqualsQuery, FirstHalf},
                  {EqualsQuery, proplists:get_value(keys, EqPBRes, [])}),
     EqPBContinuation = proplists:get_value(continuation, EqPBRes),
 
-    {ok, EqPBKeys2} = stream_pb(PBPid, EqualsQuery,
+    {ok, EqPBKeys2} = stream_pb(PBPid, Bucket, EqualsQuery,
                                 [{continuation, EqPBContinuation}]),
     ?assertEqual({EqualsQuery, Rest},
                  {EqualsQuery, proplists:get_value(keys, EqPBKeys2, [])}).

--- a/tests/verify_2i_returnterms.erl
+++ b/tests/verify_2i_returnterms.erl
@@ -19,46 +19,52 @@
 %% -------------------------------------------------------------------
 -module(verify_2i_returnterms).
 -behavior(riak_test).
+
 -export([confirm/0]).
+-export([confirm/1]).
+
+-import(secondary_index_tests, [put_an_object/3, put_an_object/5, int_to_key/1,
+                               stream_pb/4, http_query/4]).
+
+-include("include/rt.hrl").
 -include_lib("eunit/include/eunit.hrl").
--import(secondary_index_tests, [put_an_object/2, put_an_object/4, int_to_key/1,
-                               stream_pb/3, http_query/3]).
--define(BUCKET, <<"2ibucket">>).
+
 -define(FOO, <<"foo">>).
 -define(Q_OPTS, [{return_terms, true}]).
 
 confirm() ->
     inets:start(),
-
     Nodes = rt:build_cluster(3),
-    ?assertEqual(ok, (rt:wait_until_nodes_ready(Nodes))),
+    Ctx = #rt_test_context{buckets=[<<"2i_returnterms">>], nodes=Nodes},
+    confirm(Ctx).
 
+confirm(#rt_test_context{buckets=[Bucket|_], nodes=Nodes}) ->
     RiakHttp = rt:http_url(hd(Nodes)),
     PBPid = rt:pbc(hd(Nodes)),
 
-    [put_an_object(PBPid, N) || N <- lists:seq(0, 100)],
-    [put_an_object(PBPid, int_to_key(N), N, ?FOO) || N <- lists:seq(101, 200)],
+    [put_an_object(PBPid, Bucket, N) || N <- lists:seq(0, 100)],
+    [put_an_object(PBPid, Bucket, int_to_key(N), N, ?FOO) || N <- lists:seq(101, 200)],
 
     %% Bucket, key, and index_eq queries should ignore `return_terms'
     ExpectedKeys = lists:sort([int_to_key(N) || N <- lists:seq(0, 200)]),
-    assertEqual(RiakHttp, PBPid, ExpectedKeys, {<<"$key">>, int_to_key(0), int_to_key(999)}, ?Q_OPTS, keys),
-    assertEqual(RiakHttp, PBPid, ExpectedKeys, { <<"$bucket">>, ?BUCKET}, ?Q_OPTS, keys),
+    assertEqual(RiakHttp, PBPid, Bucket, ExpectedKeys, {<<"$key">>, int_to_key(0), int_to_key(999)}, ?Q_OPTS, keys),
+    assertEqual(RiakHttp, PBPid, Bucket, ExpectedKeys, { <<"$bucket">>, Bucket}, ?Q_OPTS, keys),
 
     ExpectedFooKeys = lists:sort([int_to_key(N) || N <- lists:seq(101, 200)]),
-    assertEqual(RiakHttp, PBPid, ExpectedFooKeys, {<<"field1_bin">>, ?FOO}, ?Q_OPTS, keys),
+    assertEqual(RiakHttp, PBPid, Bucket, ExpectedFooKeys, {<<"field1_bin">>, ?FOO}, ?Q_OPTS, keys),
 
     ExpectedRangeResults = lists:sort([{list_to_binary(integer_to_list(N)), int_to_key(N)} || N <- lists:seq(1, 100)]),
-    assertEqual(RiakHttp, PBPid, ExpectedRangeResults, {<<"field2_int">>, "1", "100"}, ?Q_OPTS, results),
+    assertEqual(RiakHttp, PBPid, Bucket, ExpectedRangeResults, {<<"field2_int">>, "1", "100"}, ?Q_OPTS, results),
 
     riakc_pb_socket:stop(PBPid),
     pass.
 
 %% Check the PB result against our expectations
 %% and the non-streamed HTTP
-assertEqual(Http, PB, Expected, Query, Opts, ResultKey) ->
-    {ok, PBRes} = stream_pb(PB, Query, Opts),
+assertEqual(Http, PB, Bucket, Expected, Query, Opts, ResultKey) ->
+    {ok, PBRes} = stream_pb(PB, Bucket, Query, Opts),
     PBKeys = proplists:get_value(ResultKey, PBRes, []),
-    HTTPRes = http_query(Http, Query, Opts),
+    HTTPRes = http_query(Http, Bucket, Query, Opts),
     HTTPResults0 = proplists:get_value(atom_to_binary(ResultKey, latin1), HTTPRes, []),
     HTTPResults = decode_http_results(ResultKey, HTTPResults0),
     ?assertEqual(Expected, lists:sort(PBKeys)),

--- a/tests/verify_2i_timeout.erl
+++ b/tests/verify_2i_timeout.erl
@@ -19,51 +19,72 @@
 %% -------------------------------------------------------------------
 -module(verify_2i_timeout).
 -behavior(riak_test).
+
 -export([confirm/0]).
+-export([confirm/1, setup/1, cleanup/1]).
+-import(secondary_index_tests, [put_an_object/3, put_an_object/5, int_to_key/1,
+                               stream_pb/4, url/2, http_query/4, http_stream/4]).
+
+-include("include/rt.hrl").
 -include_lib("eunit/include/eunit.hrl").
--import(secondary_index_tests, [put_an_object/2, put_an_object/4, int_to_key/1,
-                               stream_pb/3, url/2, http_query/3, http_stream/3]).
--define(BUCKET, <<"2ibucket">>).
 -define(FOO, <<"foo">>).
 
 confirm() ->
     inets:start(),
-    Config = [{riak_kv, [{secondary_index_timeout, 1}]}], %% ludicrously short, should fail always
-    Nodes = rt:build_cluster([{current, Config}, {current, Config}, {current, Config}]),
-    ?assertEqual(ok, (rt:wait_until_nodes_ready(Nodes))),
+    Nodes = rt:build_cluster(3),
+    Ctx = #rt_test_context{nodes=Nodes, buckets=[<<"2i_timeout">>]},
+    setup(Ctx),
+    confirm(Ctx).
 
+setup(#rt_test_context{nodes=Nodes}) ->
+    lager:debug("Setting ridiculously low 2i timeout"),
+    OldVals = [{Node,
+                rt:rpc_get_env(Node, [{riak_kv, secondary_index_timeout}])}
+                || Node <- Nodes],
+    rt:rpc_set_env(Nodes, riak_kv, secondary_index_timeout, 1),
+    OldVals.
+
+cleanup(OldVals) ->
+    lager:debug("Restoring 2i timeouts"),
+    [case OldVal of
+         undefined -> rt:rpc_unset_env(Node, riak_kv, secondary_index_timeout);
+         _ -> rt:rpc_set_env(Node, riak_kv, secondary_index_timeout, OldVal)
+     end
+     || {Node, OldVal} <- OldVals].
+
+confirm(#rt_test_context{buckets=[Bucket], nodes=Nodes}) ->
     PBPid = rt:pbc(hd(Nodes)),
     Http = rt:http_url(hd(Nodes)),
 
-    [put_an_object(PBPid, N) || N <- lists:seq(0, 100)],
-    [put_an_object(PBPid, int_to_key(N), N, ?FOO) || N <- lists:seq(101, 200)],
+    [put_an_object(PBPid, Bucket, N) || N <- lists:seq(0, 100)],
+    [put_an_object(PBPid, Bucket, int_to_key(N), N, ?FOO) || N <- lists:seq(101, 200)],
 
     ExpectedKeys = lists:sort([int_to_key(N) || N <- lists:seq(0, 200)]),
-    Query = {<<"$bucket">>, ?BUCKET},
+    Query = {<<"$bucket">>, Bucket},
     %% Verifies that the app.config param was used
-    ?assertEqual({error, timeout}, stream_pb(PBPid, Query, [])),
+    ?assertEqual({error, timeout}, stream_pb(PBPid, Bucket, Query, [])),
 
     %% Override app.config
-    {ok, Res} =  stream_pb(PBPid, Query, [{timeout, 5000}]),
+    {ok, Res} =  stream_pb(PBPid, Bucket, Query, [{timeout, 5000}]),
     ?assertEqual(ExpectedKeys, lists:sort(proplists:get_value(keys, Res, []))),
 
     {ok, {{_, ErrCode, _}, _, Body}} = httpc:request(url("~s/buckets/~s/index/~s/~s~s",
-                                                     [Http, ?BUCKET, <<"$bucket">>, ?BUCKET, []])),
+                                                     [Http, Bucket, <<"$bucket">>, Bucket, []])),
 
     ?assertEqual(true, ErrCode >= 500),
     ?assertMatch({match, _}, re:run(Body, "request timed out|{error,timeout}")), %% shows the app.config timeout
 
-    HttpRes = http_query(Http, Query, [{timeout, 5000}]),
+    HttpRes = http_query(Http, Bucket, Query, [{timeout, 5000}]),
     ?assertEqual(ExpectedKeys, lists:sort(proplists:get_value(<<"keys">>, HttpRes, []))),
 
-    stream_http(Http, Query, ExpectedKeys),
+    stream_http(Http, Bucket, Query, ExpectedKeys),
 
     riakc_pb_socket:stop(PBPid),
     pass.
 
-stream_http(Http, Query, ExpectedKeys) ->
-     Res = http_stream(Http, Query, []),
+stream_http(Http, Bucket, Query, ExpectedKeys) ->
+     Res = http_stream(Http, Bucket, Query, []),
      ?assert(lists:member({<<"error">>,<<"timeout">>}, Res)),
-     Res2 = http_stream(Http, Query, [{timeout, 5000}]),
+     Res2 = http_stream(Http, Bucket, Query, [{timeout, 5000}]),
      ?assertEqual(ExpectedKeys, lists:sort(proplists:get_value(<<"keys">>, Res2, []))).
 


### PR DESCRIPTION
All tests that can run without modifying the cluster or taking nodes up
and down are run within verify_2i.erl now. All tests can
still run by themselves. Mostly they have been refactored to run given a
set of running nodes and a bucket name. Each test has a chance to set up
and clean up after itself.  When/if this merges, we can replace all 2i tests but mixed cluster
with this one. Mixed cluster will be added hopefully soon. 

/cc @kellymclaughlin @reiddraper 

This is just a tiny exploratory incremental step towards refactoring riak tests to make it smarter and specifically be able to run a short version of the integration tests for CI.  There is a _lot_ more that can be refactored and optimized within the tests themselves, but I'm choosing not to go there yet and keep an eye on the goal instead of refactoring all the things at once.
