### PR TITLE
Add test for safe_rpc when rex is down

### DIFF
--- a/tests/riak_rex.erl
+++ b/tests/riak_rex.erl
@@ -16,35 +16,38 @@ confirm() ->
     pass.
 
 setup(Type) ->
-    deploy_nodes(Type).
+    deploy_node(Type).
 
 rex_test(Node) ->
     % validated we can get the rex pid on the node
-    RexPid = riak_core_util:safe_rpc(Node, erlang, whereis, [rex]),
-    ?assertEqual(node(RexPid), Node),
-    % kill rex on the node
-    ok = supervisor:terminate_child({kernel_sup, Node}, rex),
+    RexPid1 = riak_core_util:safe_rpc(Node, erlang, whereis, [rex]),
+    ?assertEqual(node(RexPid1), Node),
+    % kill rex on the node and check that safe_rpc works
+    kill_rex(Node),
     ErrorTuple = riak_core_util:safe_rpc(Node, erlang, whereis, [rex]),
     ?assertEqual(ErrorTuple, {badrpc,rpc_process_down}),
-    % restart rex so we can shut it down later
-    supervisor:restart_child({kernel_sup, Node}, rex).
+    % restart rex
+    supervisor:restart_child({kernel_sup, Node}, rex),
+    RexPid2 = riak_core_util:safe_rpc(Node, erlang, whereis, [rex]),
+    ?assertEqual(node(RexPid2), Node).
 
-deploy_nodes(NumNodes, current) ->
+
+deploy_node(NumNodes, current) ->
     rt:deploy_nodes(NumNodes, conf());
-deploy_nodes(_, mixed) ->
+deploy_node(_, mixed) ->
     Conf = conf(),
     rt:deploy_nodes([{current, Conf}, {previous, Conf}]).
 
-deploy_nodes(Type) ->
+deploy_node(Type) ->
     NumNodes = rt_config:get(num_nodes, 1),
 
-    lager:info("Deploy ~p nodes", [NumNodes]),
-    Node = deploy_nodes(NumNodes, Type),
+    lager:info("Deploy ~p node", [NumNodes]),
+    Node = deploy_node(NumNodes, Type),
     lager:info("Node: ~p", [Node]),
     hd(Node).
 
 kill_rex(Node) ->
-    rpc:call(Node, erlang, exit, [whereis(rex), kill]).
+    ok = supervisor:terminate_child({kernel_sup, Node}, rex).
 
 conf() ->
     [


### PR DESCRIPTION
Test starts a node, terminates rex keeping node up, tests that riak_core_util:safe_rpc does not crash, then brings rex back up and ensures rpc still works.

Related PR:
https://github.com/basho/riak_core/pull/586
