### PR TITLE
Test the operation of list keys and buckets for undefined bucket types

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,30 @@ or `make stagedevrel` before you run `rtdev-current.sh`. Like setting up
 releases you can override [`$RT_DEST_DIR`](https://github.com/basho/riak_test/blob/master/bin/rtdev-current.sh#L6)
 so all your riak builds are in one place.
 
+####  reset-current-env.sh
+
+`reset-current-env.sh` resets test environments setup using `rtdev-current.sh`
+using the following process:
+
+  1. Delete the current stagedevrel/devrel environment
+  1. `make stagedevrel` for the Riak release being tested (current default is 2.0,
+     overidden with the `-v` flag).  When the `-c` option is specified,
+     `make devclean` will be executed before rebuilding.
+  1. Execute `rtdev-current.sh` for the Riak release being tested
+  1. Rebuild the current riak_test branch.  When the `-c` option is specified,
+     'make clean' will be executed before rebuilding.
+
+This script is intended to provide to cover the common test environment
+reset method -- not cover all possible testing configurations/scenarios.
+As such, it makes the following assumptions regarding the environment and
+test operation:
+
+   * Riak source trees will be symlinked into the riak_test root directory
+     as `riak-<version>`.
+   * The script will be located in a sub-directory of <riak_test home>.  It
+     can be executed from any directory, but it uses the script location to
+     determine the riak_test home directory.
+
 ### Config file.
 
 Now that you've got your releases all ready and gitified, you'll need

--- a/bin/reset-current-env.sh
+++ b/bin/reset-current-env.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+# Bail out on error ...
+set -e
+
+# Stash the current directory before doing any work so we can return back to where we started ...
+CURRENT_DIR=`pwd`
+
+# Determine the location of script which will allow to determine the riak_test home ...
+# Borrowed liberally from http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+
+RT_BIN_DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+RT_HOME="$( dirname "$RT_BIN_DIR" )"
+FULL_CLEAN=false
+VERSION="2.0"
+
+usage() {
+  echo "Resets the current riak_test environment by rebuilding riak and riak_test using rtdev-current.sh"
+  echo "  -c: Perform a devclean on the riak and clean on riak_test projects (default: $FULL_CLEAN)"
+  echo "  -v: The Riak version to test.  The Riak home is calculated as $RT_HOME/riak-<version> (default: $VERSION)"
+  echo "  -h: This help message"
+}
+
+while getopts chv: opt; do
+  case $opt in
+    c) FULL_CLEAN=true
+       ;;
+    v) VERSION=$OPTARG
+       ;;
+    h) usage
+       exit 0
+       ;;
+  esac
+  shift
+done
+
+RIAK_HOME=$RT_HOME/riak-$VERSION
+
+if ! [[ -d $RIAK_HOME || -h $RIAK_HOME ]]; then
+  echo "Riak home $RIAK_HOME does not exist."
+  exit 1
+fi
+
+cd $RIAK_HOME
+
+echo "Removing previous stagedevrel instance from $RIAK_HOME and rebuilding ..."
+
+# Clean out previous devrel build ...
+if [ "$FULL_CLEAN" = true ] ; then
+  make devclean
+else
+  rm -rf dev
+fi
+
+# Rebuild Riak ...
+make stagedevrel
+
+$RT_HOME/bin/rtdev-current.sh
+
+echo "Rebuilding riak_test in $RT_HOME ..."
+cd $RT_HOME
+
+if [ "$FULL_CLEAN" = true ] ; then
+  make clean
+fi
+make
+
+# Return back to where we started ...
+cd $CURRENT_DIR
+
+exit 0
+

--- a/tests/verify_listkeys.erl
+++ b/tests/verify_listkeys.erl
@@ -25,6 +25,8 @@
 -define(BUCKET, <<"listkeys_bucket">>).
 -define(NUM_BUCKETS, 1200).
 -define(NUM_KEYS, 1000).
+-define(UNDEFINED_BUCKET,  <<"880bf69d-5dab-44ee-8762-d24c6f759ce1">>).
+-define(UNDEFINED_BUCKET_TYPE,  <<"880bf69d-5dab-44ee-8762-d24c6f759ce1">>).
 
 confirm() ->
     [Node1, Node2, Node3, Node4] = Nodes = rt:deploy_nodes(4),
@@ -123,6 +125,31 @@ list_keys(Node, Interface, Bucket, Attempt, Num, ShouldPass) ->
         _ -> ok
     end.
 
+list_keys_for_undefined_bucket_type(Node, Interface, Bucket, Attempt, ShouldPass) ->
+    case Interface of
+        pbc ->
+            Pid = rt:pbc(Node),
+            Mod = riakc_pb_socket;
+        http ->
+            Pid = rt:httpc(Node),
+            Mod = rhc
+    end,
+
+    lager:info("Listing keys using undefined bucket type ~p on ~p using ~p. Attempt #~p",
+               [?UNDEFINED_BUCKET_TYPE, Node, Interface, Attempt]),
+    case ShouldPass of
+	true -> ok;
+	_ ->
+	    {Status, Message} = Mod:list_keys(Pid, { ?UNDEFINED_BUCKET_TYPE, Bucket }),
+	    ?assertEqual(error, Status),
+	    ?assertEqual(<<"No bucket-type named '880bf69d-5dab-44ee-8762-d24c6f759ce1'">>, Message)
+    end,
+
+    case Interface of
+        pbc -> riakc_pb_socket:stop(Pid);
+        _ -> ok
+    end.
+
 put_buckets(Node, Num) ->
     Pid = rt:pbc(Node),
     Buckets = [list_to_binary(["", integer_to_list(Ki)])
@@ -166,6 +193,33 @@ list_buckets(Node, Interface, Attempt, Num, ShouldPass) ->
         _ -> ok
     end.
 
+list_buckets_for_undefined_bucket_type(Node, Interface, Attempt, ShouldPass) ->
+    case Interface of
+	pbc ->
+	    Pid = rt:pbc(Node),
+	    Mod = riakc_pb_socket;
+	http ->
+	    Pid = rt:httpc(Node),
+	    Mod = rhc
+    end,
+
+    lager:info("Listing buckets on ~p for undefined bucket type ~p using ~p.  Attempt ~p.",
+	       [Node, ?UNDEFINED_BUCKET_TYPE, Interface, Attempt]),
+
+    case ShouldPass of
+	true -> ok;
+	_ ->
+	    {Status, Message} = Mod:list_buckets(Pid, ?UNDEFINED_BUCKET_TYPE, []),
+	    lager:info("Received status ~p and message ~p", [Status, Message]),
+	    ?assertEqual(error, Status),
+	    ?assertEqual(<<"No bucket-type named '880bf69d-5dab-44ee-8762-d24c6f759ce1'">>, Message)
+    end,
+
+    case Interface of
+	pbc ->
+	    riakc_pb_socket:stop(Pid);
+	_ -> ok
+    end.
 
 assert_equal(Expected, Actual) ->
     case Expected -- Actual of
@@ -187,5 +241,10 @@ check_it_all(Nodes, Interface, ShouldPass) ->
 check_a_node(Node, Interface, ShouldPass) ->
     [list_keys(Node, Interface, ?BUCKET, Attempt, ?NUM_KEYS, ShouldPass)
      || Attempt <- [1,2,3] ],
+    [list_keys_for_undefined_bucket_type(Node, Interface, ?BUCKET, Attempt, ShouldPass)
+     || Attempt <- [1,2,3] ],
     [list_buckets(Node, Interface, Attempt, ?NUM_BUCKETS, ShouldPass)
+     || Attempt <- [1,2,3] ], 
+    [list_buckets_for_undefined_bucket_type(Node, Interface, Attempt, ShouldPass)
      || Attempt <- [1,2,3] ].
+


### PR DESCRIPTION
Per defect [riak kv defect 875](https://github.com/basho/riak_kv/issues/875), the client hangs when a list keys operation is issued for a undefined bucket type.  Additionally, list buckets returns an ok rather than error.  This PR adds tests to verify that the client does not hang and returns the appropriate error when this condition occurs.  It verifies the changes introduced by [riak_kv PR 966](https://github.com/basho/riak_kv/pull/966).

This PR supersedes [616](https://github.com/basho/riak_test/pull/616) which has been closed due to the changes in the message, as well as, the need to properly squash all commits.

/cc @seancribbs @reiddraper @seancribbs 
