### PR TITLE
Update ensemble tests to work with auto-activation

### DIFF
--- a/tests/ensemble_util.erl
+++ b/tests/ensemble_util.erl
@@ -26,9 +26,6 @@
 build_cluster(Num, Config, NVal) ->
     Nodes = rt:deploy_nodes(Num, Config),
     Node = hd(Nodes),
-    ok = rpc:call(Node, riak_ensemble_manager, enable, []),
-    _ = rpc:call(Node, riak_core_ring_manager, force_update, []),
-    ensemble_util:wait_until_stable(Node, NVal),
     rt:join_cluster(Nodes),
     ensemble_util:wait_until_cluster(Nodes),
     ensemble_util:wait_for_membership(Node),

--- a/tests/repl_consistent_object_filter.erl
+++ b/tests/repl_consistent_object_filter.erl
@@ -111,21 +111,14 @@ make_clusters() ->
     AFirst = hd(ANodes),
     BFirst = hd(BNodes),
 
-    ok = rpc:call(AFirst, riak_ensemble_manager, enable, []),
-    rpc:call(AFirst, riak_core_ring_manager, force_update, []),
-    ?assertEqual(true, rpc:call(AFirst, riak_ensemble_manager, enabled, [])),
-    ensemble_util:wait_until_stable(AFirst, NVal),
-
-    ok = rpc:call(BFirst, riak_ensemble_manager, enable, []),
-    rpc:call(BFirst, riak_core_ring_manager, force_update, []),
-    ?assertEqual(true, rpc:call(BFirst, riak_ensemble_manager, enabled, [])),
-    ensemble_util:wait_until_stable(BFirst, NVal),
-
     lager:info("Build cluster A"),
     repl_util:make_cluster(ANodes),
 
     lager:info("Build cluster B"),
     repl_util:make_cluster(BNodes),
+
+    ensemble_util:wait_until_stable(AFirst, NVal),
+    ensemble_util:wait_until_stable(BFirst, NVal),
 
     %% get the leader for the first cluster
     lager:info("waiting for leader to converge on cluster A"),


### PR DESCRIPTION
Prior to this commit, the various riak_ensemble related tests would
manually enable the consensus system on one-and-only-one node in a
given cluster in order to work around issue basho/riak_core#571.

This commit changes the tests to work properly after the above issue
has been fixed.

In addition to removing the call to `riak_ensemble_manager:enable()`
that is now handled automatically by Riak, this commit also removes
a few `wait_until_stable/2` checks against 1-node clusters. These
checks no longer apply, since Riak is now designed to only enable
the consensus system after the cluster contains at least 3 nodes.

Related pull-request: basho/riak_core#601
