### PR TITLE
Change replication upgrade tests to return pass on success

### DIFF
--- a/tests/replication2_upgrade.erl
+++ b/tests/replication2_upgrade.erl
@@ -71,34 +71,35 @@ confirm() ->
     lager:info("Upgrading nodes in order: ~p", [NodeUpgrades]),
     rt:log_to_nodes(Nodes, "Upgrading nodes in order: ~p", [NodeUpgrades]),
     %% upgrade the nodes, one at a time
-    lists:foreach(fun(Node) ->
-                          lager:info("Upgrade node: ~p", [Node]),
-                          rt:log_to_nodes(Nodes, "Upgrade node: ~p", [Node]),
-                          rtdev:upgrade(Node, current),
-                          %% The upgrade did a wait for pingable
-                          rt:wait_for_service(Node, [riak_kv, riak_pipe, riak_repl]),
-                          [rt:wait_until_ring_converged(N) || N <- [ANodes, BNodes]],
+    ok = lists:foreach(fun(Node) ->
+                               lager:info("Upgrade node: ~p", [Node]),
+                               rt:log_to_nodes(Nodes, "Upgrade node: ~p", [Node]),
+                               rtdev:upgrade(Node, current),
+                               %% The upgrade did a wait for pingable
+                               rt:wait_for_service(Node, [riak_kv, riak_pipe, riak_repl]),
+                               [rt:wait_until_ring_converged(N) || N <- [ANodes, BNodes]],
 
-                          %% Prior to 1.4.8 riak_repl registered
-                          %% as a service before completing all
-                          %% initialization including establishing
-                          %% realtime connections.
-                          %%
-                          %% @TODO Ideally the test would only wait
-                          %% for the connection in the case of the
-                          %% node version being < 1.4.8, but currently
-                          %% the rt API does not provide a
-                          %% harness-agnostic method do get the node
-                          %% version. For now the test waits for all
-                          %% source cluster nodes to establish a
-                          %% connection before proceeding.
-                          case lists:member(Node, ANodes) of
-                              true ->
-                                  repl_util:wait_for_connection(Node, "B");
-                              false ->
-                                  ok
-                          end,
-                          lager:info("Replication with upgraded node: ~p", [Node]),
-                          rt:log_to_nodes(Nodes, "Replication with upgraded node: ~p", [Node]),
-                          replication2:replication(ANodes, BNodes, true)
-                  end, NodeUpgrades).
+                               %% Prior to 1.4.8 riak_repl registered
+                               %% as a service before completing all
+                               %% initialization including establishing
+                               %% realtime connections.
+                               %%
+                               %% @TODO Ideally the test would only wait
+                               %% for the connection in the case of the
+                               %% node version being < 1.4.8, but currently
+                               %% the rt API does not provide a
+                               %% harness-agnostic method do get the node
+                               %% version. For now the test waits for all
+                               %% source cluster nodes to establish a
+                               %% connection before proceeding.
+                               case lists:member(Node, ANodes) of
+                                   true ->
+                                       repl_util:wait_for_connection(Node, "B");
+                                   false ->
+                                       ok
+                               end,
+                               lager:info("Replication with upgraded node: ~p", [Node]),
+                               rt:log_to_nodes(Nodes, "Replication with upgraded node: ~p", [Node]),
+                               replication2:replication(ANodes, BNodes, true)
+                       end, NodeUpgrades),
+    pass.

--- a/tests/replication_upgrade.erl
+++ b/tests/replication_upgrade.erl
@@ -63,33 +63,34 @@ confirm() ->
     lager:info("Upgrading nodes in order: ~p", [NodeUpgrades]),
     rt:log_to_nodes(Nodes, "Upgrading nodes in order: ~p", [NodeUpgrades]),
     %% upgrade the nodes, one at a time
-    lists:foreach(fun(Node) ->
-                          lager:info("Upgrade node: ~p", [Node]),
-                          rt:log_to_nodes(Nodes, "Upgrade node: ~p", [Node]),
-                          rtdev:upgrade(Node, current),
-                          rt:wait_until_pingable(Node),
-                          rt:wait_for_service(Node, [riak_kv, riak_pipe, riak_repl]),
-                          [rt:wait_until_ring_converged(N) || N <- [ANodes, BNodes]],
-                          %% Prior to 1.4.8 riak_repl registered
-                          %% as a service before completing all
-                          %% initialization including establishing
-                          %% realtime connections.
-                          %%
-                          %% @TODO Ideally the test would only wait
-                          %% for the connection in the case of the
-                          %% node version being < 1.4.8, but currently
-                          %% the rt API does not provide a
-                          %% harness-agnostic method do get the node
-                          %% version. For now the test waits for all
-                          %% source cluster nodes to establish a
-                          %% connection before proceeding.
-                          case lists:member(Node, ANodes) of
-                              true ->
-                                  repl_util:wait_for_connection(Node, "B");
-                              false ->
-                                  ok
-                          end,
-                          lager:info("Replication with upgraded node: ~p", [Node]),
-                          rt:log_to_nodes(Nodes, "Replication with upgraded node: ~p", [Node]),
-                          replication:replication(ANodes, BNodes, true)
-        end, NodeUpgrades).
+    ok = lists:foreach(fun(Node) ->
+                               lager:info("Upgrade node: ~p", [Node]),
+                               rt:log_to_nodes(Nodes, "Upgrade node: ~p", [Node]),
+                               rtdev:upgrade(Node, current),
+                               rt:wait_until_pingable(Node),
+                               rt:wait_for_service(Node, [riak_kv, riak_pipe, riak_repl]),
+                               [rt:wait_until_ring_converged(N) || N <- [ANodes, BNodes]],
+                               %% Prior to 1.4.8 riak_repl registered
+                               %% as a service before completing all
+                               %% initialization including establishing
+                               %% realtime connections.
+                               %%
+                               %% @TODO Ideally the test would only wait
+                               %% for the connection in the case of the
+                               %% node version being < 1.4.8, but currently
+                               %% the rt API does not provide a
+                               %% harness-agnostic method do get the node
+                               %% version. For now the test waits for all
+                               %% source cluster nodes to establish a
+                               %% connection before proceeding.
+                               case lists:member(Node, ANodes) of
+                                   true ->
+                                       repl_util:wait_for_connection(Node, "B");
+                                   false ->
+                                       ok
+                               end,
+                               lager:info("Replication with upgraded node: ~p", [Node]),
+                               rt:log_to_nodes(Nodes, "Replication with upgraded node: ~p", [Node]),
+                               replication:replication(ANodes, BNodes, true)
+                       end, NodeUpgrades),
+    pass.


### PR DESCRIPTION
As of commit 3044839456249f6f70b9642a60ad9be3dfb6056c tests that
return something other than the prescribed success atom 'pass' to
indicate success result in test failure. Change the
replication_upgrade and replication2_upgrade tests that return the
result of the a call to lists:foreach/2 to instead return 'pass' to
indicate success.
