### PR TITLE
Verify Riak Startup when Strong Consistency is Misconfigured

### DIFF
--- a/tests/ensemble_start_without_aae.erl
+++ b/tests/ensemble_start_without_aae.erl
@@ -1,0 +1,34 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2013-2014 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(ensemble_start_without_aae).
+-export([confirm/0]).
+-include_lib("eunit/include/eunit.hrl").
+
+confirm() ->
+
+    NumNodes = 5,
+    NVal = 5,
+
+    Config = ensemble_util:fast_config(NVal, false),
+    lager:info("Building cluster with consensus enabled and AAE disabled. Waiting for ensemble to stablize ..."),
+
+    _ = ensemble_util:build_cluster_without_quorum(NumNodes, Config),
+    pass.


### PR DESCRIPTION
Tests the Riak startup behavior when strong consistency is enabled and AAE is disabled as described in basho/riak_kv#959.  Riak should startup without error, but the ensembles should never reach quorum.

In addition to adding this test case, the following enhancements were made to the `reset-current-env.sh` script to properly execute strong consistency tests requiring more than five (5) nodes:
- Adds additional console output to reset-current-env to explain configuration and steps being executed
- Adds the -n option to the reset-current-env script to specify the number of nodes to build.  By default, 5 will be created.

I had intended to add a test to verify the [Riak KV warning PR](https://github.com/basho/riak_kv/pull/978).  Unfortunately, riak_test's log capture facility is not enabled at startup, and requires significant changes to allow such operation.  @kelly and I determined that these changes were too invasive given the proximity of the Riak 2.0 release.  Therefore, I have opened the following tickets to enhance the framework and add the automated test for the warning to be addressed in the 2.1 release cycle:
- #634: Capture Logs on Node Startup
- #635: Test Strong Consistency Configuration Warning
