### PR TITLE
Fix two issues with replication_upgrade test

### DIFF
--- a/tests/replication.erl
+++ b/tests/replication.erl
@@ -528,7 +528,6 @@ start_and_wait_until_fullsync_complete(Node, Retries) ->
         _  when Retries > 0 ->
             ?assertEqual(ok, wait_until_connection(Node)),
             lager:warning("Node failed to fullsync, retrying"),
-            rpc:call(Node, riak_repl_console, cancel_fullsync, [[]]),
             start_and_wait_until_fullsync_complete(Node, Retries-1)
     end,
     lager:info("Fullsync on ~p complete", [Node]).

--- a/tests/replication_upgrade.erl
+++ b/tests/replication_upgrade.erl
@@ -85,7 +85,7 @@ confirm() ->
                                %% connection before proceeding.
                                case lists:member(Node, ANodes) of
                                    true ->
-                                       repl_util:wait_for_connection(Node, "B");
+                                       replication:wait_until_connection(Node);
                                    false ->
                                        ok
                                end,


### PR DESCRIPTION
- Do not attempt to cancel fullsync if the initial attempt to start
  and wait for completion fails. It has not been observed that the
  problem is fullsync starting and not completing in time, but rather
  the issue is that the initial call to start fullsync does not take
  effect. Therefore the cancellation is unnecessary.
- Replace the call to repl_util:wait_for_connection/2 in the node
  upgrade process with a call to
  replication:wait_until_connection/1. This function is geared towards
  v2 replication and should speed up test execution.
