### PR TITLE
Feature/parallel stop

### DIFF
--- a/src/rt_cs_dev.erl
+++ b/src/rt_cs_dev.erl
@@ -252,7 +252,7 @@ stop_all(DevPath) ->
                 end,
                 lager:info("Stopping Node... ~s ~~ ~s.", [Cmd, Status])
             end,
-            [Stop(D) || D <- Devs];
+            rt:pmap(Stop, Devs);
         _ -> lager:info("~s is not a directory.", [DevPath])
     end,
     ok.


### PR DESCRIPTION
Stopping nodes in `rt_cs_dev` takes rather long time. With 4 nodes configuration this hack reduced single testcase time in riak_cs by 30 seconds (with 4 nodes CS setup). This seems like stop command uses polling internally and that made sequenceal stopping take longer time than expected.
