### PR TITLE
Fix problems with cert specifications causing replication_ssl to fail

### DIFF
--- a/tests/replication_ssl.erl
+++ b/tests/replication_ssl.erl
@@ -40,11 +40,11 @@ confirm() ->
                 {fullsync_interval, disabled},
                 {ssl_enabled, true},
                 {certfile, filename:join([CertDir,
-                            "site1/basho.com/cert.pem"])},
+                            "site1.basho.com/cert.pem"])},
                 {keyfile, filename:join([CertDir,
                             "site1.basho.com/key.pem"])},
                 {cacertdir, filename:join([CertDir,
-                            "site1.basho.com/cacerts.pem"])}
+                            "site1.basho.com"])}
             ]}
     ],
 
@@ -59,7 +59,7 @@ confirm() ->
                 {keyfile, filename:join([CertDir,
                             "site2.basho.com/key.pem"])},
                 {cacertdir, filename:join([CertDir,
-                            "site2.basho.com/cacerts.pem"])}
+                            "site2.basho.com"])}
             ]}
     ],
 
@@ -74,7 +74,7 @@ confirm() ->
                 {keyfile, filename:join([CertDir,
                             "site3.basho.com/key.pem"])},
                 {cacertdir, filename:join([CertDir,
-                            "site3.basho.com/cacerts.pem"])}
+                            "site3.basho.com"])}
             ]}
     ],
 
@@ -91,7 +91,7 @@ confirm() ->
                 {keyfile, filename:join([CertDir,
                             "site3.basho.com/key.pem"])},
                 {cacertdir, filename:join([CertDir,
-                            "site3.basho.com/cacerts.pem"])}
+                            "site3.basho.com"])}
             ]}
     ],
 
@@ -107,7 +107,7 @@ confirm() ->
                 {keyfile, filename:join([CertDir,
                             "site4.basho.com/key.pem"])},
                 {cacertdir, filename:join([CertDir,
-                            "site4.basho.com/cacerts.pem"])}
+                            "site4.basho.com"])}
             ]}
     ],
 
@@ -260,7 +260,3 @@ test_connection({Node1, Config1}, {Node2, Config2}) ->
     rt:wait_for_service(Node2, riak_kv),
     timer:sleep(5000),
     replication:wait_until_connection(Node1).
-
-
-
-


### PR DESCRIPTION
Fix problem with `cacertdir` specification in `replication_ssl` test. The [code](https://github.com/basho/riak_repl/blob/develop/src/riak_repl_util.erl#L481) used load cert files in v2 replication expects the path specific by the `cacertdir` key to only be a directory. With v3 replication the [code](https://github.com/basho/riak_core/blob/develop/src/riak_core_ssl_util.erl#L135) used is flexible enough to allow a directory or a file. Also, correct a typo in the `certfile` path for the `SSLConfig1` configuration.

These changes get the `replication_ssl` test passing for me locally, but the test does rely on the exhaustion of `rt_max_wait_time` for several conditions so I recommend setting it to a value of `60000` or less for more expedient verification. 
