### PR TITLE
replication_object_reformat test fails after riak_repl #590

### DIFF
--- a/tests/replication_object_reformat.erl
+++ b/tests/replication_object_reformat.erl
@@ -54,32 +54,47 @@ verify_replication(AVersion, BVersion, Start, End, Realtime) ->
     lager:info("Get leader of A cluster."),
     LeaderA = repl_util:get_leader(AFirst),
 
+    %% Before starting writes, initiate a rolling downgrade.
+    Me = self(),
+
     case Realtime of
         true ->
-            lager:info("Running kv_reformat to downgrade to v0 on ~p",
-                       [BFirst]),
-            {_, _, Error1} = rpc:call(BFirst,
-                                      riak_kv_reformat,
-                                      run,
-                                      [v0, [{kill_handoffs, false}]]),
-            ?assertEqual(0, Error1),
+            spawn(fun() ->
+                          lager:info("Running kv_reformat to downgrade to v0 on ~p",
+                                     [BFirst]),
+                          {_, _, Error1} = rpc:call(BFirst,
+                                                    riak_kv_reformat,
+                                                    run,
+                                                    [v0, [{kill_handoffs, false}]]),
+                          ?assertEqual(0, Error1),
 
-            lager:info("Waiting for all nodes to see the v0 capability."),
-            [rt:wait_until_capability(N, {riak_kv, object_format}, v0, v0)
-             || N <- BNodes],
+                          lager:info("Waiting for all nodes to see the v0 capability."),
+                          [rt:wait_until_capability(N, {riak_kv, object_format}, v0, v0)
+                           || N <- BNodes],
 
-            lager:info("Downgrading node ~p to previous.",
-                       [BFirst]),
-            rt:upgrade(BFirst, previous),
+                          lager:info("Allowing downgrade and writes to occurr concurrently."),
+                          Me ! continue,
 
-            lager:info("Waiting for riak_kv to start on node ~p.",
-                       [BFirst]),
-            rt:wait_for_service(BFirst, [riak_kv, riak_repl]),
-            rt:wait_until_nodes_ready(BNodes),
-            rt:wait_until_no_pending_changes(BNodes),
-            rt:wait_until_registered(BFirst, riak_repl2_fs_node_reserver),
+                          lager:info("Downgrading node ~p to previous.",
+                                     [BFirst]),
+                          rt:upgrade(BFirst, previous),
+
+                          lager:info("Waiting for riak_kv to start on node ~p.",
+                                     [BFirst]),
+                          rt:wait_for_service(BFirst, [riak_kv])
+                  end),
             ok;
         _ ->
+            ok
+    end,
+
+    %% Pause and wait for rolling upgrade to begin, if it takes too
+    %% long, proceed anyway and the test will fail when it attempts
+    %% to read the keys.
+    receive
+        continue ->
+            ok
+    after 60000 ->
             ok
     end,
 
@@ -97,6 +112,12 @@ verify_replication(AVersion, BVersion, Start, End, Realtime) ->
 
     lager:info("Verify we can read the keys on the source."),
     repl_util:read_from_cluster(AFirst, Start, End, ?TEST_BUCKET, 0, ?N),
+
+    %% Wait until the sink cluster is in a steady state before
+    %% starting fullsync
+    rt:wait_until_nodes_ready(BNodes),
+    rt:wait_until_no_pending_changes(BNodes),
+    rt:wait_until_registered(BFirst, riak_repl2_fs_node_reserver),
 
     repl_util:validate_completed_fullsync(
         LeaderA, BFirst, "B", Start, End, ?TEST_BUCKET),


### PR DESCRIPTION
This test relies on `repl_util:check_fullsync/3` that makes assumptions about the values of the `error_exits` and `retry_exits` stats after a fullsync is completed. The merge of https://github.com/basho/riak_repl/pull/590 affected these stats and they no longer match the expectation of the test. Here is the failure output from riak_test:

```
================ replication_object_reformat failure stack trace =====================
{{assertEqual_failed,[{module,repl_util},
                      {line,571},
                      {expression,"ErrorExits"},
                      {expected,0},
                      {value,4}]},
 [{repl_util,'-check_fullsync/3-fun-3-',2,
             [{file,"tests/repl_util.erl"},{line,571}]},
  {repl_util,check_fullsync,3,[{file,"tests/repl_util.erl"},{line,571}]},
  {repl_util,validate_completed_fullsync,6,
             [{file,"tests/repl_util.erl"},{line,515}]},
  {replication_object_reformat,verify_replication,5,
                               [{file,"tests/replication_object_reformat.erl"},
                                {line,116}]},
  {replication_object_reformat,confirm,0,
                               [{file,"tests/replication_object_reformat.erl"},
                                {line,35}]},
  {riak_test_runner,return_to_exit,3,
                    [{file,"src/riak_test_runner.erl"},{line,159}]}]}
======================================================================================
```

I modified the test to output the values for the `retry_exits` and `error_exits` stats reported before the test failed:

```
22:41:27.528 [info] Fullsync on 'dev1@127.0.0.1' complete
22:41:27.528 [info] Fullsync completed in 3.018526 seconds
22:41:27.529 [info] Retry exits: 0
22:41:27.529 [info] Error exits: 4
```

I am unsure if this is a just a case of the test expectations needing to be updated or if there is an actual problem here. I did verify that the test passes using the commit prior to the change commit from riak_repl #590. 

cc: @cmeiklejohn 
