### PR TITLE
Fix occasional setup errors in verify_listkeys_eqcfsm

### DIFF
--- a/tests/verify_listkeys_eqcfsm.erl
+++ b/tests/verify_listkeys_eqcfsm.erl
@@ -119,8 +119,6 @@ precondition(_From,_To,_S,{call,_,_,_}) ->
 %% ====================================================================
 %% EQC FSM postconditions
 %% ====================================================================
-%postcondition(_From,_To,_S,{call,_,setup_cluster,_},Res) ->
-%    ok == Res;
 postcondition(_From,_To,_S,{call,_,verify,_},{error, Reason}) ->
     lager:info("Error: ~p", [Reason]),
     false;


### PR DESCRIPTION
Move cluster set-up into the property instead of in its own state to avoid side effects and fix transient issue.
