### PR TITLE
Fix ensemble_interleave error condition

### DIFF
--- a/tests/ensemble_interleave.erl
+++ b/tests/ensemble_interleave.erl
@@ -96,6 +96,6 @@ confirm() ->
     ensemble_util:wait_until_stable(Node, Quorum),
 
     lager:info("Re-reading keys to verify they exist"),
-    Expect = [ok, {error, timeout}, {error, <<"timeout">>}],
+    Expect = [ok, {error, timeout}, {error, <<"timeout">>}, {error, <<"failed">>}],
     [rt:pbc_read_check(PBC, Bucket, Key, Expect, Options) || Key <- Keys],
     pass.


### PR DESCRIPTION
Include {error, <<"failed">>} as allowed failure so that test passes
with changes for basho/riak_ensemble#37 and basho/riak_kv#1002
