### PR TITLE
Fix ensemble_sync by allowing {error, <<"failed">>

### DIFF
--- a/tests/ensemble_sync.erl
+++ b/tests/ensemble_sync.erl
@@ -35,7 +35,8 @@ confirm() ->
     ensemble_util:wait_until_stable(Node, NVal),
 
     ExpectOkay    = [ok],
-    ExpectTimeout = [{error, timeout}, {error, <<"timeout">>} | ExpectOkay],
+    ExpectTimeout = [{error, timeout}, {error, <<"timeout">>},
+                     {error, <<"failed">>} | ExpectOkay],
     ExpectFail    = [{error, notfound} | ExpectTimeout],
 
     Scenarios = [%% corrupted, suspended, valid, empty, bucket, expect


### PR DESCRIPTION
Allow {error, <<"failed">>} as an error response in ensemble_sync. Fixes
the test with basho/riak_ensemble#37 and basho/riak_kv#1002
