### PR TITLE
Update expected return to match change in riak_pb API

### DIFF
--- a/tests/verify_dt_upgrade.erl
+++ b/tests/verify_dt_upgrade.erl
@@ -74,7 +74,7 @@ verify_counters(Node) ->
     %% Check that 1.4 counters work with bucket types
     case catch rt:capability(Node, {riak_core, bucket_types}) of
         true ->
-            ?assertEqual({ok, {counter, 4, 0}}, riakc_pb_socket:fetch_type(PBC, {<<"default">>, ?COUNTER_BUCKET}, <<"pbkey">>));
+            ?assertEqual({ok, {counter, 4, undefined}}, riakc_pb_socket:fetch_type(PBC, {<<"default">>, ?COUNTER_BUCKET}, <<"pbkey">>));
         _ ->
             ok
     end,


### PR DESCRIPTION
See https://github.com/basho/riak-erlang-client/commit/2b68a97710efa0167ab1caeca653eaa9d3a8747e
for details. Basically, a counter with no local modifications has `undefined` as the 3rd element in the tuple, not `0`. This PR addresses the change.

To test? Run the test.
