### PR TITLE
Add repl_bucket_types check that RTQ is drained after bucket type mis-match

### DIFF
--- a/tests/repl_bucket_types.erl
+++ b/tests/repl_bucket_types.erl
@@ -109,9 +109,11 @@ realtime_test({ClusterNodes, BucketTypes, PBA, PBB}) ->
     UndefBucketTyped = {UndefType, <<"badtype">>},
     UndefKeyTyped = <<"badkeytyped">>,
     UndefObjTyped = riakc_obj:new(UndefBucketTyped, UndefKeyTyped, Bin),
+    UndefObjTyped2 = riakc_obj:new(UndefBucketTyped, UndefKeyTyped, <<"data1">>),
 
     lager:info("doing typed put on A where type is not defined on B, bucket:~p", [UndefBucketTyped]),
     riakc_pb_socket:put(PBA, UndefObjTyped, [{w,3}]),
+    riakc_pb_socket:put(PBA, UndefObjTyped2, [{w,3}]),
 
     lager:info("waiting for undefined type pb get on B, should get error <<\"no_type\">>"),
 
@@ -119,13 +121,7 @@ realtime_test({ClusterNodes, BucketTypes, PBA, PBB}) ->
     ?assertEqual({error, <<"no_type">>}, ErrorResult),
 
     % checking the rtq had drained on the source cluster
-    lager:info("making sure the rtq has drained"),
-    Got = lists:map(fun(Node) ->
-                        rpc:call(Node, riak_repl2_rtq, all_queues_empty, [])
-            end, ANodes),
-    Expected = [true || _ <- lists:seq(1, length(ANodes))],
-    ?assertEqual(Expected, Got),
-
+    ensure_rtq_drained(ANodes),
 
     DefaultProps = get_current_bucket_props(BNodes, DefinedType),
     ?assertEqual({n_val, 3}, lists:keyfind(n_val, 1, DefaultProps)),
@@ -459,3 +455,14 @@ get_current_bucket_props(Node, Type) when is_atom(Node) ->
              riak_core_bucket_type,
              get,
              [Type]).
+
+ensure_rtq_drained(ANodes) ->
+    lager:info("making sure the rtq has drained"),
+    Got = lists:map(fun(Node) ->
+                        case rpc:call(Node, riak_repl2_rtq, dumpq, []) of
+                            [] -> true;
+			    _ -> false
+                        end
+                    end, ANodes),
+    Expected = [true || _ <- lists:seq(1, length(ANodes))],
+    ?assertEqual(Expected, Got).


### PR DESCRIPTION
During RT, in the case of a bucket type mis-match on the sink, riak_repl2_sink_conn was not acknowledging the replication with the source RTQ after dropping the put, resulting in the queue filling. 

Add a check to make sure that the queue is empty after a dropped put due to bucket type mismatch.

Issue: https://github.com/basho/riak_repl/issues/611
