### PR TITLE
Make rtssh set public Cuttlefish IPs for PB/HTTP

### DIFF
--- a/src/rtssh.erl
+++ b/src/rtssh.erl
@@ -179,7 +179,16 @@ deploy_nodes(NodeConfig, Hosts) ->
                     end, Nodes),
 
             timer:sleep(500);
-        true -> ok
+        true ->
+            rt:pmap(fun(Node) ->
+                            IP = get_ip(Node),
+                            set_conf(Node,
+                                     [{"listener.protobuf.internal",
+                                       IP ++ ":10017"},
+                                      {"listener.http.internal",
+                                       IP ++ ":10018"}])
+                    end, Nodes),
+            timer:sleep(500)
     end,
 
     create_dirs(Nodes),


### PR DESCRIPTION
Something in Riak has changed such that the previous approach to setting public IPs no longer appears to work for `rtssh`. Thus, `rtssh` users such as [rtcloud](https://github.com/basho/rtcloud) cannot provision clusters that can talk on anything other than `127.0.0.1`.

This commits add code that explicitly sets the PB/HTTP IPs when Cuttlefish is being used, which seems to fix the issue.

**_Note:**_ This change uses hardcoded ports for the new PB/HTTP settings, and thus only works if there's a single Riak instance per node. Since [rtcloud](https://github.com/basho/rtcloud) is the only real consumer of `rtssh` currently and `rtcloud` currently runs 1 Riak instance per node, this is fine for now. We should consider changing in the future when we're not in a release crunch.
