### PR TITLE
Fix smoke tests uploading artifacts

### DIFF
--- a/src/smoke_test_escript.erl
+++ b/src/smoke_test_escript.erl
@@ -9,21 +9,28 @@ get_version() ->
 cli_options() ->
 %% Option Name, Short Code, Long Code, Argument Spec, Help Message
 [
- {project,            $p, "project",     string,  "specifices which project"},
- {debug,              $v, "debug",         undefined,  "debug?"},
- {directory,          $d, "directory", string,  "source tree directory"},
- {jobs,               $j, "jobs",         integer,  "jobs?"},
- {tasks,               $T, "tasks",         string,  "What task(s) to run (eunit|dialyzer|xref)"}
+ {project,   $p, "project",   string,    "specifies which project"},
+ {debug,     $v, "debug",     undefined, "debug?"},
+ {directory, $d, "directory", string,    "source tree directory"},
+ {jobs,      $j, "jobs",      integer,   "jobs?"},
+ {tasks,     $T, "tasks",     string,     "What task(s) to run (eunit|dialyzer|xref)"}
 ].
 
 
 main(Args) ->
-    {ok, {Parsed, _Other}} = getopt:parse(cli_options(), Args),
+    Parsed = case getopt:parse(cli_options(), Args) of
+                 {ok, {Parsed0, _Other}} -> Parsed0;
+                 _ ->
+                     getopt:usage(cli_options(), escript:script_name()),
+                     halt(1),
+                     []
+             end,
     application:start(ibrowse),
     lager:start(),
     rt_config:load("default", filename:join([os:getenv("HOME"), ".riak_test.config"])),
     case lists:keyfind(project, 1, Parsed) of
         false ->
+            getopt:usage(cli_options(), escript:script_name()),
             lager:error("Must specify project!"),
             application:stop(lager),
             halt(1);


### PR DESCRIPTION
GiddyUp has changed slightly since this was last updated. You no longer post the captured log as the `log` field in the test result, you post an artifact after the result has been posted. The `riak_test` runner already reflected this change.

Previously (note no artifacts in list):

![screen shot 2014-08-25 at 3 56 04 pm](https://cloud.githubusercontent.com/assets/1772/4036485/5bce3f76-2c9a-11e4-9f7b-7d388f5ca173.png)

Now (note artifact in list):

![screen shot 2014-08-25 at 3 56 22 pm](https://cloud.githubusercontent.com/assets/1772/4036490/672f38ca-2c9a-11e4-9afb-f05bf5ab04bc.png)

Also fixed where it would crash if you gave it bad command-line options. Now it just prints the usage output and exits.
