### PR TITLE
Add verification of handoff heartbeat to verify_handoff test

### DIFF
--- a/intercepts/riak_core_handoff_sender_intercepts.erl
+++ b/intercepts/riak_core_handoff_sender_intercepts.erl
@@ -1,0 +1,8 @@
+-module(riak_core_handoff_sender_intercepts).
+-compile(export_all).
+-include("intercept.hrl").
+-define(M, riak_core_handoff_sender_orig).
+
+delayed_visit_item_3(K, V, Acc) ->
+    timer:sleep(100),
+    ?M:visit_item_orig(K, V, Acc).


### PR DESCRIPTION
Add testing of the handoff heartbeat change from the following pull
request: https://github.com/basho/riak_core/pull/560. Add an intercept
module for the riak_core_handoff_sender module to introduce artificial
delay on item visitation during a handoff fold. This delay along with
the changes to the verify_handoff test induces test failure when run
without the heartbeat change. The handoff_receive_timeout is exceeded,
handoff stalls, and the test eventually fails due to timeout. The test
succeeds when run with the heartbeat change.
