### PR TITLE
Add option to return exit code from rt:admin calls

### DIFF
--- a/src/rt.erl
+++ b/src/rt.erl
@@ -30,6 +30,7 @@
 -compile(export_all).
 -export([
          admin/2,
+         admin/3,
          assert_nodes_agree_about_ownership/1,
          async_start/1,
          attach/2,
@@ -1474,7 +1475,13 @@ httpc_write(C, Bucket, Key, Value) ->
 
 %% @doc Call 'bin/riak-admin' command on `Node' with arguments `Args'
 admin(Node, Args) ->
-    ?HARNESS:admin(Node, Args).
+    admin(Node, Args, []).
+
+%% @doc Call 'bin/riak-admin' command on `Node' with arguments `Args'.
+%% The third parameter is a list of options. Valid options are:
+%%    * `return_exit_code' - Return the exit code along with the command output
+admin(Node, Args, Options) ->
+    ?HARNESS:admin(Node, Args, Options).
 
 %% @doc Call 'bin/riak' command on `Node' with arguments `Args'
 riak(Node, Args) ->


### PR DESCRIPTION
Add an rt:admin/3 function that accepts a list of options as the third
parameter.  Currently the only valid option is return_exit_code. The
rtdev, rtssh, and rt_cs_dev harnesses have been updated to support
this option. If return_to_exit is specified the return from a
?HARNESS:admin call is a pair with the exit code as the first member
and the command output as the second member. Finally the
basic_command_line test has been changed to use return_for_exit to
verify the changes.
