### PR TITLE
Fixed test to handle soft exits.

### DIFF
--- a/tests/repl_aae_fullsync.erl
+++ b/tests/repl_aae_fullsync.erl
@@ -573,7 +573,7 @@ validate_intercepted_fullsync(InterceptTarget,
         N -> N
     end,
     SoftExitsIncremented = rt:wait_until(fun() ->
-        SoftExits = deep_status([fullsync_coordinator, ReplicationCluster, soft_rety_exits], ReplicationLeader),
+        SoftExits = deep_status([fullsync_coordinator, ReplicationCluster, soft_retry_exits], ReplicationLeader),
         SoftExits > SoftExits0
     end),
     ?assertEqual(ok, SoftExitsIncremented),


### PR DESCRIPTION
The error conditions in the test now create soft_exit_retries rather than
error conditions, so the tests had to change to wait for those numbers to
go up, and allow the fullsync to finish.

This tests the feature/fix in basho/riak_repl/pull/626
