### PR TITLE
Restore deleted intercept.

### DIFF
--- a/intercepts/riak_kv_get_fsm_intercepts.erl
+++ b/intercepts/riak_kv_get_fsm_intercepts.erl
@@ -3,16 +3,6 @@
 -include("intercept.hrl").
 -define(M, riak_kv_get_fsm_orig).
 
-%count_init([From, Bucket, Key, Options0, Monitor]) ->
-%    ?I_INFO("Counting init call"),
-%    gen_server:call({global, overload_proxy}, increment_count, infinity),
-%    ?M:init_orig([From, Bucket, Key, Options0, Monitor]).
- 
-%count_start_link_5(ReqId,Bucket,Key,R,Timeout,From) ->
-%    ?I_INFO("sending startlink/5 through proxy"),
-%    gen_server:call({global, overload_proxy}, increment_count),
-%    ?M:start_link_orig(ReqId,Bucket,Key,R,Timeout,From).
-
 count_start_link_4(From, Bucket, Key, GetOptions) ->
     ?I_INFO("sending startlink/4 through proxy"),
     case ?M:start_link_orig(From, Bucket, Key, GetOptions) of
@@ -20,4 +10,9 @@ count_start_link_4(From, Bucket, Key, GetOptions) ->
             ?I_INFO("riak_kv_get_fsm not started due to overload.");
         {ok, _} ->
             gen_server:cast({global, overload_proxy}, increment_count)
-    end.    
+    end.
+
+%% @doc simulate slow puts by adding delay to the prepare state.
+slow_prepare(Atom, State) ->
+    timer:sleep(1000),
+    ?M:prepare_orig(Atom, State).


### PR DESCRIPTION
Restore deleted intercept which is causing any test which references
this to fail.

Manually tested verify_api_timeouts and overload.

@jrwest 
