### PR TITLE
Fix repl_util:wait_for_connection

### DIFF
--- a/tests/repl_util.erl
+++ b/tests/repl_util.erl
@@ -300,11 +300,10 @@ wait_for_connection(Node, Name) ->
                             [] ->
                                 false;
                             [Pid] ->
-                                Pid ! {self(), status},
-                                receive
+                                case riak_core_cluster_conn:status(Pid) of
                                     {Pid, status, _} ->
                                         true;
-                                    {Pid, connecting, _} ->
+                                    _ ->
                                         false
                                 end
                         end;


### PR DESCRIPTION
After cluster connection manager refactor,
real tests hang when waiting for a cluster conn
to be established.  This is due to a change in the
internal protocol inside riak_core_cluster_conn.

Since we don’t expose that API, this fix simply
uses the official status/1 API.

As is, this will only work on a recent riak ee.
