### PR TITLE
Configure all JMX listeners to use an unprivileged port

### DIFF
--- a/tests/jmx_verify.erl
+++ b/tests/jmx_verify.erl
@@ -106,7 +106,7 @@ confirm() ->
     pass.
 
 test_supervision() ->
-    JMXPort = 80,
+    JMXPort = 41111,
     Config = [{riak_jmx, [{enabled, true}, {port, JMXPort}]}],
     [Node|[]] = rt:deploy_nodes(1, Config),
     timer:sleep(20000),
@@ -219,6 +219,7 @@ jmx_dump_cmd(IP, Port) ->
 
 jmx_dump(Cmd) ->
     timer:sleep(40000), %% JMX only updates every 30seconds
+    lager:info("Dumping JMX stats using command ~s", [Cmd]),
     Output = string:strip(os:cmd(Cmd), both, $\n),
     JSONOutput = mochijson2:decode(Output),
     [ {Key, Value} || {struct, [{Key, Value}]} <- JSONOutput].


### PR DESCRIPTION
The jmx_verify test case configured the JMX listener to use port 80 which caused the test fail when run as a non-root user.  This PR changes the test to always use an unprivileged port.  It also adds logging of the JMX query command to assist with test failure debugging.
