### PR TITLE
Reduce the SNMP stats poll interval form 1 minute to 1 second

### DIFF
--- a/tests/verify_snmp.erl
+++ b/tests/verify_snmp.erl
@@ -27,7 +27,8 @@
 
 confirm() ->
     %% Bring up a small cluster
-    [Node1] = rt:deploy_nodes(1),
+    Config = [{riak_snmp, [{polling_interval, 1000}]}],
+    [Node1] = rt:deploy_nodes(1, Config),
     ?assertEqual(ok, rt:wait_until_nodes_ready([Node1])),
 
     Keys = [{vnodeGets,<<"vnode_gets">>},


### PR DESCRIPTION
Reduces the SNMP stats poll interval to reduce the probability of a race condition occurring when comparing the SNMP and HTTP stats

/cc @vinoski
