### PR TITLE
Update intercept to match new put function

### DIFF
--- a/intercepts/riak_kv_vnode_intercepts.erl
+++ b/intercepts/riak_kv_vnode_intercepts.erl
@@ -84,8 +84,9 @@ error_do_put(Sender, BKey, RObj, ReqId, StartTime, Options, State) ->
                     %% sleep for a while, so the vnode response order is
                     %% deterministic
                     timer:sleep(1000),
-                    riak_core_vnode:reply(Sender, {fail, Partition, ReqId}),
-                    State;
+                    Reply = {fail, Partition, ReqId},
+                    riak_core_vnode:reply(Sender, Reply),
+                    {Reply, State};
                 false ->
                     ?M:do_put_orig(Sender, BKey, RObj, ReqId, StartTime, Options, State)
             end


### PR DESCRIPTION
The do_put function was changed between 1.4.11 and 1.4.12 as part of the
fix to prevent a type of sibling explosion when vnodes forward requests
during handoff.  The intercept used by this test needed to be updated to
match the return type.
