### PR TITLE
Specifying the sink cluster is pretty much required.

### DIFF
--- a/tests/replication2_dirty.erl
+++ b/tests/replication2_dirty.erl
@@ -97,7 +97,7 @@ confirm() ->
     wait_until_coord_has_dirty(LeaderA),
 
     lager:info("Starting fullsync"),
-    repl_util:start_and_wait_until_fullsync_complete(LeaderA),
+    repl_util:start_and_wait_until_fullsync_complete(LeaderA, "B"),
     lager:info("Wait for all nodes to show up clean"),
     wait_until_all_nodes_clean(LeaderA),
 
@@ -120,7 +120,7 @@ confirm() ->
     wait_until_coord_has_dirty(DirtyB),
 
     lager:info("Starting fullsync"),
-    repl_util:start_and_wait_until_fullsync_complete(LeaderA),
+    repl_util:start_and_wait_until_fullsync_complete(LeaderA, "B"),
     lager:info("Wait for all nodes to show up clean"),
     wait_until_all_nodes_clean(LeaderA),
 
@@ -146,7 +146,7 @@ confirm() ->
                 ResultC = rpc:call(DirtyD, riak_repl_stats, rt_source_errors, []),
                 lager:info("Result = ~p", [ResultC])
            end),
-    repl_util:start_and_wait_until_fullsync_complete(LeaderA),
+    repl_util:start_and_wait_until_fullsync_complete(LeaderA, "B"),
 
     lager:info("Checking to see if C is still clean"),
     wait_until_node_clean(DirtyC),


### PR DESCRIPTION
This was uncovered while attempting to rebase and update https://github.com/basho/riak_repl/pull/389.
