### PR TITLE
Use result of fold in ensemble_basic3

### DIFF
--- a/tests/ensemble_basic3.erl
+++ b/tests/ensemble_basic3.erl
@@ -87,7 +87,7 @@ confirm() ->
                         lager:info("Suspending vnode: ~p", [VIdx]),
                         Pid2 = vnode_util:suspend_vnode(VNode, VIdx),
                         orddict:store(VN, Pid2, Suspended)
-                end, L2, L2),
+                end, orddict:new(), L2),
 
     lager:info("Resuming all vnodes"),
     [vnode_util:resume_vnode(Pid) || {_, Pid} <- L3],


### PR DESCRIPTION
When resuming vnodes we need the proper pid from the previous suspend.
Use the result of the fold to get the right pids.
