### PR TITLE
Fix several framework bugs found while testing

### DIFF
--- a/src/riak_test_runner.erl
+++ b/src/riak_test_runner.erl
@@ -100,7 +100,7 @@ init([TestModule, Backend, Properties]) ->
     {ok, UpdProperties} =
         rt_properties:set(metadata, MetaData, Properties),
     TestTimeout = rt_config:get(test_timeout, rt_config:get(rt_max_wait_time)),
-    SetupModFun = function_name(setup, TestModule, 2, rt_cluster),
+    SetupModFun = function_name(setup, TestModule, 1, rt_cluster),
     {ConfirmMod, _} = ConfirmModFun = function_name(confirm, TestModule),
     BackendCheck = check_backend(Backend,
                                  rt_properties:get(valid_backends, Properties)),

--- a/src/rt.erl
+++ b/src/rt.erl
@@ -222,7 +222,7 @@ stream_cmd_loop(Port, Buffer, NewLineBuffer, Time={_MegaSecs, Secs, _MicroSecs})
         {Port, {exit_status, Status}} ->
             catch port_close(Port),
             {Status, Buffer}
-    after rt:config(rt_max_wait_time) ->
+    after rt_config:get(rt_max_wait_time) ->
             {-1, Buffer}
     end.
 

--- a/src/rt_cluster.erl
+++ b/src/rt_cluster.erl
@@ -71,7 +71,7 @@ create_bucket_types([Cluster], Properties, BucketTypes) ->
     NodeMap = rt_properties:get(node_map, Properties),
     NodeIds = rt_cluster_info:get(node_ids, Cluster),
     Nodes = [rt_node:node_name(NodeId, NodeMap) || NodeId <- NodeIds],
-    lists:foldl(fun maybe_create_bucket_type/2, [{Nodes, 1}], BucketTypes);
+    lists:foldl(fun maybe_create_bucket_type/2, {Nodes, 1}, BucketTypes);
 create_bucket_types(Clusters, Properties, BucketTypes) ->
     NodeMap = rt_properties:get(node_map, Properties),
     [begin
@@ -96,7 +96,7 @@ maybe_create_bucket_type({TypeName, TypeProps}, {Nodes, _ClusterIndex}) ->
 -spec prepare_clusters([list(string())], rt_properties:properties()) ->
                                     [rt_cluster_info:cluster_info()].
 prepare_clusters([ClusterNodes], _Properties) ->
-    rt_cluster_info:new([{node_ids, ClusterNodes}]);
+    [rt_cluster_info:new([{node_ids, ClusterNodes}])];
 prepare_clusters(ClusterNodesList, Properties) ->
     %% If the count of clusters is > 1 the assumption is made that the
     %% test is exercising replication and some extra

--- a/src/rtdev.erl
+++ b/src/rtdev.erl
@@ -58,7 +58,8 @@
 -define(SCRATCH_DIR, (rt_config:get(rt_scratch_dir))).
 
 get_deps() ->
-    lists:flatten(io_lib:format("~s/dev1/lib", [filename:join(?PATH, "head")])).
+    DefaultVersionPath = filename:join(?PATH, rt_config:get(default_version)),
+    lists:flatten(io_lib:format("~s/dev1/lib", [DefaultVersionPath])).
 
 riakcmd(Path, N, Cmd) ->
     ExecName = rt_config:get(exec_name, "riak"),


### PR DESCRIPTION
* Address two issues related to bucket type creation in rt_cluster
* Address an issue with rt:stream_cmd_loop using an outdated rt:config
call
* Adjust the expected arity of the setup function in riak_test_runner
from 2 to 1
* Change rtdev:get_deps/0 to use the default_version from the config
instead of a hardcoded path