### PR TITLE
Rename overload test module to avoid shielding the same name in sasl app

### DIFF
--- a/tests/overload_protection.erl
+++ b/tests/overload_protection.erl
@@ -17,7 +17,7 @@
 %% under the License.
 %%
 %% -------------------------------------------------------------------
--module(overload).
+-module(overload_protection).
 -compile(export_all).
 -include_lib("eunit/include/eunit.hrl").
 


### PR DESCRIPTION
There is a test module with name `overload` which is included in escriptized `riak_test`. It shields the module with the same name in sasl app, then `riak_test` for riak_cs output error logs.

```
2015-01-20 15:38:14.890 [error] <0.152.0> Supervisor sasl_safe_sup had child overload started with overload:start_link() at undefined exit with reason {'EXIT',{undef,[{overload,start_link,[],[]},{supervisor,do_start_child,2,[{file,"supervisor.erl"},{line,310}]},{supervisor,start_children,3,[{file,"supervisor.erl"},{line,293}]},{supervisor,init_children,2,[{file,"supervisor.erl"},{line,259}]},{gen_server,init_it,6,[{file,"gen_server.erl"},{line,304}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,239}]}]}} in context start_error
```

This PR renames the test module.
