### PR TITLE
Updating rebar.config to be set purely to tags/SHAs

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -14,10 +14,10 @@
         {lager, ".*", {git, "git://github.com/basho/lager", {tag, "2.0.3"}}},
         {getopt, ".*", {git, "git://github.com/jcomellas/getopt", {tag, "v0.4"}}},
         {meck, ".*", {git, "git://github.com/basho/meck.git", {tag, "0.8.2"}}},
-        {mapred_verify, ".*", {git, "git://github.com/basho/mapred_verify", {branch, "master"}}},
-        {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {branch, "master"}}},
-        {riakhttpc, ".*", {git, "git://github.com/basho/riak-erlang-http-client", {branch, "master"}}},
-        {kvc, "1.3.0", {git, "https://github.com/etrepum/kvc", {tag, "v1.3.0"}}},
+        {mapred_verify, ".*", {git, "git://github.com/basho/mapred_verify", "51b79c5b05eb04640e13131f06ef96561b96ba8e"}},
+        {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {tag, "2.0.1"}}},
+        {riakhttpc, ".*", {git, "git://github.com/basho/riak-erlang-http-client", {tag, "1.3.1"}}},
+        {kvc, ".*", {git, "https://github.com/etrepum/kvc", {tag, "v1.3.0"}}},
         {druuid, ".*", {git, "git://github.com/kellymclaughlin/druuid.git", {tag, "0.2"}}}
        ]}.
 


### PR DESCRIPTION
As requested following conversations with Andrew Stone, here's a PR to pin deps to the latest tags available in subrepos. Be aware that work may be needed in those subrepos to actually bring in commits that are expected, as previous builds have been against branches.