### PR TITLE
Refactor tests/overload to use less magical-number comparisons

### DIFF
--- a/tests/overload.erl
+++ b/tests/overload.erl
@@ -103,7 +103,7 @@ test_vnode_protection(Nodes, BKV, ConsistentType) ->
     rt:pmap(fun(Node) ->
                     rt:update_app_config(Node, Config)
             end, Nodes),
-    ProcFun = build_predicate_lt(test_vnode_protection, (?NUM_REQUESTS), "ProcFun", "Procs"),
+    ProcFun = build_predicate_lt(test_vnode_protection, (2*?THRESHOLD * 1.5), "ProcFun", "Procs"),
     QueueFun = build_predicate_lt(test_vnode_protection, (?NUM_REQUESTS), "QueueFun", "QueueSize"),
     verify_test_results(run_test(Nodes, BKV), ConsistentType, ProcFun, QueueFun),
 

--- a/tests/overload.erl
+++ b/tests/overload.erl
@@ -77,14 +77,10 @@ test_no_overload_protection(_Nodes, _BKV, true) ->
     ok;
 test_no_overload_protection(Nodes, BKV, ConsistentType) ->
     lager:info("Testing with no overload protection"),
-    ProcFun = fun(X) ->
-                      lager:info("in test_no_overload_protection ProcFun, Procs:~p, Metric:~p", [X, ?NUM_REQUESTS]),
-                      X >= ?NUM_REQUESTS
-              end,
-    QueueFun = fun(X) ->
-                      lager:info("in test_no_overload QueueFun, queue size:~p, Metric:~p", [X, ?NUM_REQUESTS]),
-                      X >= ?NUM_REQUESTS
-              end,
+    ProcFun = build_predicate_gte(test_no_overload_protection, ?NUM_REQUESTS,
+                                  "ProcFun", "Procs"),
+    QueueFun = build_predicate_gte(test_no_overload_protection, ?NUM_REQUESTS,
+                                  "QueueFun", "Queue Size"),
     verify_test_results(run_test(Nodes, BKV), ConsistentType, ProcFun, QueueFun).
 
 verify_test_results({_NumProcs, QueueLen}, true, _, QueueFun) ->
@@ -107,14 +103,8 @@ test_vnode_protection(Nodes, BKV, ConsistentType) ->
     rt:pmap(fun(Node) ->
                     rt:update_app_config(Node, Config)
             end, Nodes),
-    ProcFun = fun(X) ->
-                      lager:info("in test_vnode_protection ProcFun, Procs:~p, Metric:~p", [X, (2*?NUM_REQUESTS * 1.5)]),
-                      X =< (2*?THRESHOLD * 1.5)
-              end,
-    QueueFun = fun(X) ->
-                      lager:info("in test_vnode_protection QueueFun, QueueSize:~p, Metric:~p", [X, (?NUM_REQUESTS * 1.1)]),
-                      X =< (?THRESHOLD * 1.1)
-              end,
+    ProcFun = build_predicate_lt(test_vnode_protection, (2*?THRESHOLD * 1.5), "ProcFun", "Procs"),
+    QueueFun = build_predicate_lt(test_vnode_protection, (?THRESHOLD * 1.1), "QueueFun", "QueueSize"),
     verify_test_results(run_test(Nodes, BKV), ConsistentType, ProcFun, QueueFun),
 
     [Node1 | _] = Nodes,
@@ -127,15 +117,10 @@ test_vnode_protection(Nodes, BKV, ConsistentType) ->
 
     lager:info("Suspending vnode proxy for ~p", [Victim]),
     Pid = suspend_vnode_proxy(Victim),
-    ProcFun2 = fun(X) ->
-                      lager:info("in test_vnode_protection after suspend ProcFun, Procs:~p, Metric:~p", [X, ?NUM_REQUESTS]),
-                      X >= ?NUM_REQUESTS
-
-              end,
-    QueueFun2 = fun(X) ->
-                      lager:info("in test_vnode_protection after suspend QueueFun, QueueSize:~p, Metric:~p", [X, (?THRESHOLD * 1.1)]),
-                      X =< (?THRESHOLD * 1.1)
-              end,
+    ProcFun2 = build_predicate_gte("test_vnode_protection after suspend",
+                                   (?NUM_REQUESTS), "ProcFun", "Procs"),
+    QueueFun2 = build_predicate_lt("test_vnode_protection after suspend",
+                                   (?THRESHOLD) * 1.1, "QueueFun", "QueueSize"),
     verify_test_results(run_test(Nodes, BKV), ConsistentType, ProcFun2, QueueFun2),
     Pid ! resume,
     ok.
@@ -147,14 +132,10 @@ test_fsm_protection(Nodes, BKV, ConsistentType) ->
     rt:pmap(fun(Node) ->
                     rt:update_app_config(Node, Config)
             end, Nodes),
-    ProcFun = fun(X) ->
-                      lager:info("in test_fsm_protection ProcFun, Procs:~p, Metric:~p", [X, (?THRESHOLD * 1.1)]),
-                      X =< (?THRESHOLD * 1.2)
-              end,
-    QueueFun = fun(X) ->
-                      lager:info("in test_fsm_protection QueueFun, QueueSize:~p, Metric:~p", [X, (?THRESHOLD * 1.1)]),
-                      X =< (?THRESHOLD * 1.2)
-              end,
+    ProcFun = build_predicate_lt(test_fsm_protection, (?THRESHOLD * 1.2),
+                                 "ProcFun", "Procs"),
+    QueueFun = build_predicate_lt(test_fsm_protection, (?THRESHOLD * 1.2),
+                                  "QueueFun", "QueueSize"),
     verify_test_results(run_test(Nodes, BKV), ConsistentType, ProcFun, QueueFun),
     ok.
 
@@ -490,3 +471,21 @@ remote_vnode_queue(Idx) ->
     {ok, Pid} = riak_core_vnode_manager:get_vnode_pid(Idx, riak_kv_vnode),
     {message_queue_len, Len} = process_info(Pid, message_queue_len),
     Len.
+
+%% In tests that do not expect work to be shed, we want to confirm that
+%% at least ?NUM_REQUESTS (processes|queue entries) are handled.
+build_predicate_gte(Test, Metric, Label, ValueLabel) ->
+    fun (X) ->
+        lager:info("in test ~w ~w, ~w:~w, expected no overload, Metric:>=~w",
+                   [Test, Label, ValueLabel, X, Metric]),
+        X >= Metric
+    end.
+%% In tests that expect work to be shed due to overload, the success
+%% condition is simply that the number of (fsms|queue entries) is
+%% less than ?NUM_REQUESTS.
+build_predicate_lt(Test, Metric, Label, ValueLabel) ->
+    fun (X) ->
+        lager:info("in test ~w ~w, ~w:~w, expected overload, Metric:<~w",
+                   [Test, Label, ValueLabel, X, Metric]),
+        X < Metric
+    end.

--- a/tests/overload.erl
+++ b/tests/overload.erl
@@ -103,7 +103,7 @@ test_vnode_protection(Nodes, BKV, ConsistentType) ->
     rt:pmap(fun(Node) ->
                     rt:update_app_config(Node, Config)
             end, Nodes),
-    ProcFun = build_predicate_lt(test_vnode_protection, (2*?THRESHOLD * 1.5), "ProcFun", "Procs"),
+    ProcFun = build_predicate_lt(test_vnode_protection, (?NUM_REQUESTS+1), "ProcFun", "Procs"),
     QueueFun = build_predicate_lt(test_vnode_protection, (?NUM_REQUESTS), "QueueFun", "QueueSize"),
     verify_test_results(run_test(Nodes, BKV), ConsistentType, ProcFun, QueueFun),
 

--- a/tests/overload.erl
+++ b/tests/overload.erl
@@ -103,8 +103,8 @@ test_vnode_protection(Nodes, BKV, ConsistentType) ->
     rt:pmap(fun(Node) ->
                     rt:update_app_config(Node, Config)
             end, Nodes),
-    ProcFun = build_predicate_lt(test_vnode_protection, (2*?THRESHOLD * 1.5), "ProcFun", "Procs"),
-    QueueFun = build_predicate_lt(test_vnode_protection, (?THRESHOLD * 1.1), "QueueFun", "QueueSize"),
+    ProcFun = build_predicate_lt(test_vnode_protection, (?NUM_REQUESTS), "ProcFun", "Procs"),
+    QueueFun = build_predicate_lt(test_vnode_protection, (?NUM_REQUESTS), "QueueFun", "QueueSize"),
     verify_test_results(run_test(Nodes, BKV), ConsistentType, ProcFun, QueueFun),
 
     [Node1 | _] = Nodes,
@@ -120,7 +120,7 @@ test_vnode_protection(Nodes, BKV, ConsistentType) ->
     ProcFun2 = build_predicate_gte("test_vnode_protection after suspend",
                                    (?NUM_REQUESTS), "ProcFun", "Procs"),
     QueueFun2 = build_predicate_lt("test_vnode_protection after suspend",
-                                   (?THRESHOLD) * 1.1, "QueueFun", "QueueSize"),
+                                   (?NUM_REQUESTS), "QueueFun", "QueueSize"),
     verify_test_results(run_test(Nodes, BKV), ConsistentType, ProcFun2, QueueFun2),
     Pid ! resume,
     ok.
@@ -132,9 +132,9 @@ test_fsm_protection(Nodes, BKV, ConsistentType) ->
     rt:pmap(fun(Node) ->
                     rt:update_app_config(Node, Config)
             end, Nodes),
-    ProcFun = build_predicate_lt(test_fsm_protection, (?THRESHOLD * 1.2),
+    ProcFun = build_predicate_lt(test_fsm_protection, (?NUM_REQUESTS),
                                  "ProcFun", "Procs"),
-    QueueFun = build_predicate_lt(test_fsm_protection, (?THRESHOLD * 1.2),
+    QueueFun = build_predicate_lt(test_fsm_protection, (?NUM_REQUESTS),
                                   "QueueFun", "QueueSize"),
     verify_test_results(run_test(Nodes, BKV), ConsistentType, ProcFun, QueueFun),
     ok.

--- a/tests/overload.erl
+++ b/tests/overload.erl
@@ -476,7 +476,7 @@ remote_vnode_queue(Idx) ->
 %% at least ?NUM_REQUESTS (processes|queue entries) are handled.
 build_predicate_gte(Test, Metric, Label, ValueLabel) ->
     fun (X) ->
-        lager:info("in test ~w ~w, ~w:~w, expected no overload, Metric:>=~w",
+        lager:info("in test ~p ~p, ~p:~p, expected no overload, Metric:>=~p",
                    [Test, Label, ValueLabel, X, Metric]),
         X >= Metric
     end.
@@ -485,7 +485,7 @@ build_predicate_gte(Test, Metric, Label, ValueLabel) ->
 %% less than ?NUM_REQUESTS.
 build_predicate_lt(Test, Metric, Label, ValueLabel) ->
     fun (X) ->
-        lager:info("in test ~w ~w, ~w:~w, expected overload, Metric:<~w",
+        lager:info("in test ~p ~p, ~p:~p, expected overload, Metric:<~p",
                    [Test, Label, ValueLabel, X, Metric]),
         X < Metric
     end.


### PR DESCRIPTION
Since this test often fails due to fuzzy magic number comparisons (e.g. 1.2*?THRESHOLD) when trying to determine whether or not overload thresholds are being correctly enforced. Since these aren't exact, it seems that a decent approach is to, for now, ask "did any work get shed" instead — this changeset does that (and a little refactoring to reduce repetition).

In the future we should revisit this and just explicitly track denials instead of fsm processes / vnode queue depth, as @slfritchie initially suggested.