### PR TITLE
Fix error printing for non-atom version names (versions are term()s, not only atoms).

### DIFF
--- a/src/rtdev.erl
+++ b/src/rtdev.erl
@@ -715,7 +715,7 @@ check_node({_N, Version}) ->
         true -> ok;
         _ ->
             lager:error("You don't have Riak ~s installed or configured", [Version]),
-            erlang:error("You don't have Riak " ++ atom_to_list(Version) ++ " installed or configured")
+            erlang:error(lists:flatten(io_lib:format("You don't have Riak ~p installed or configured", [Version])))
     end.
 
 set_backend(Backend) ->


### PR DESCRIPTION
This prevents the error message from failing to print properly, as the existing code causes a badarg error calling erlang:atom_to_list:

11:49:56.544 [error] You don't have Riak 2.0.2 installed or configured
11:49:56.544 [error] Error in process <0.21072.9> on node 'riak_test@127.0.0.1' with exit value: {badarg,[{erlang,atom_to_list,["2.0.2"],[]},{rtdev,check_node,1,[{file,"src/rtdev.erl"},{line,718}]},{rtdev,'-deploy_nodes/1-lc$^1/1-1-',1,[{file,"src/rtdev.erl"},{line,402}]},{rtdev,deploy_nodes,1,[{file,"src/rtdev.erl"},{line,402}]},{rt... 


11:49:56.545 [warning] riak667_mixed failed: {badarg,[{erlang,atom_to_list,["2.0.2"],[]},{rtdev,check_node,1,[{file,"src/rtdev.erl"},{line,718}]},{rtdev,'-deploy_nodes/1-lc$^1/1-1-',1,[{file,"src/rtdev.erl"},{line,402}]},{rtdev,deploy_nodes,1,[{file,"src/rtdev.erl"},{line,402}]},{rt,deploy_nodes,2,[{file,"src/rt.erl"},{line,313}]},{rt,build_cluster,3,[{file,"src/rt.erl"},{line,1071}]},{riak667_mixed,confirm,0,[{file,"tests/riak667_mixed.erl"},{line,45}]},{riak_test_runner,return_to_exit,3,[{file,"src/riak_test_runner.erl"},{line,159}]}]}
11:49:56.545 [error] 
================ riak667_mixed failure stack trace =====================
{badarg,[{erlang,atom_to_list,["2.0.2"],[]},
         {rtdev,check_node,1,[{file,"src/rtdev.erl"},{line,718}]},
         {rtdev,'-deploy_nodes/1-lc$^1/1-1-',1,
                [{file,"src/rtdev.erl"},{line,402}]},
         {rtdev,deploy_nodes,1,[{file,"src/rtdev.erl"},{line,402}]},
         {rt,deploy_nodes,2,[{file,"src/rt.erl"},{line,313}]},
         {rt,build_cluster,3,[{file,"src/rt.erl"},{line,1071}]},
         {riak667_mixed,confirm,0,
                        [{file,"tests/riak667_mixed.erl"},{line,45}]},
         {riak_test_runner,return_to_exit,3,
                           [{file,"src/riak_test_runner.erl"},{line,159}]}]}
========================================================================

11:49:56.545 [notice] riak667_mixed Test Run Complete