### PR TITLE
Ensure cover:start is called after verifying node is pingable

### DIFF
--- a/src/rt_cover.erl
+++ b/src/rt_cover.erl
@@ -188,6 +188,7 @@ maybe_start_on_node(Node, Version) ->
             ok;
         true ->
             lager:debug("Starting cover on node ~p", [Node]),
+            rt:wait_until_pingable(Node),
             {ok, _Node} = cover:start(Node),
             ok
     end.


### PR DESCRIPTION
The cover server was failing to start until I added this wait in rt_cover in a
fork of riak_test for a riak_core based app.