### PR TITLE
Update kerl URL to githubusercontent domain

### DIFF
--- a/bin/rtdev-build-releases.sh
+++ b/bin/rtdev-build-releases.sh
@@ -44,7 +44,7 @@ checkbuild()
                     echo "You need 'curl' to be able to run this script, exiting"
                     exit 1
                 fi
-                curl -O https://raw.github.com/spawngrid/kerl/master/kerl > /dev/null 2>&1; chmod a+x kerl
+                curl -O https://raw.githubusercontent.com/spawngrid/kerl/master/kerl > /dev/null 2>&1; chmod a+x kerl
             fi
         fi
     fi


### PR DESCRIPTION
On April 25, 2014, Github moved all raw user content to raw.githubusercontent.com. With the existing curl command to pull kerl, all that's returned is a 301, resulting in kerl not actually being downloaded

```
➜  ~  curl -v https://raw.github.com/spawngrid/kerl/master/kerl
* Hostname was NOT found in DNS cache
*   Trying 23.235.46.133...
* Connected to raw.github.com (23.235.46.133) port 443 (#0)
* TLS 1.2 connection using TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
* Server certificate: www.github.com
* Server certificate: DigiCert SHA2 High Assurance Server CA
* Server certificate: DigiCert High Assurance EV Root CA
> GET /spawngrid/kerl/master/kerl HTTP/1.1
> User-Agent: curl/7.37.1
> Host: raw.github.com
> Accept: */*
>
< HTTP/1.1 301 Moved Permanently
< Date: Wed, 04 Mar 2015 21:33:09 GMT
* Server Apache is not blacklisted
< Server: Apache
< Location: https://raw.githubusercontent.com/spawngrid/kerl/master/kerl
< Content-Length: 0
< Accept-Ranges: bytes
< Via: 1.1 varnish
< Age: 0
< X-Served-By: cache-iad2141-IAD
< X-Cache: MISS
< X-Cache-Hits: 0
< Vary: Accept-Encoding
<
* Connection #0 to host raw.github.com left intact
```

The alternative was to add the -L flag to follow redirects, but I wasn't sure if this was explicitly excluded for security reasons.
