### PR TITLE
Add test that always passes. [JIRA: RIAK-1588]

### DIFF
--- a/tests/always_pass_test.erl
+++ b/tests/always_pass_test.erl
@@ -1,0 +1,8 @@
+%% @doc A test that always returns `pass'.
+-module(always_pass_test).
+-behavior(riak_test).
+-export([confirm/0]).
+
+-spec confirm() -> pass | fail.
+confirm() ->
+    pass.


### PR DESCRIPTION
When included in an automatically generated list of tests that may only contain one test, ensures riak_test will continue if that test fails.