### PR TITLE
Add xmerl_version to the list of expected stats

### DIFF
--- a/tests/verify_riak_stats.erl
+++ b/tests/verify_riak_stats.erl
@@ -794,6 +794,7 @@ common_stats() ->
         <<"vnode_set_update_time_median">>,
         <<"vnode_set_update_total">>,
         <<"webmachine_version">>,
+        <<"xmerl_version">>,
         <<"yokozuna_version">>
     ].
 


### PR DESCRIPTION
This fixes some failures we were seeing with the verify_riak_stats test.