### PR TITLE
Remove code:which/1 from pb_security and http_security

### DIFF
--- a/tests/http_security.erl
+++ b/tests/http_security.erl
@@ -435,8 +435,8 @@ confirm() ->
                                                true}])),
 
     lager:info("whitelisting module path"),
-    ok = rpc:call(Node, application, set_env, [riak_kv, add_paths,
-                                    [filename:dirname(code:which(?MODULE))]]),
+    {?MODULE, _ModBin, ModFile} = code:get_object_code(?MODULE),
+    ok = rpc:call(Node, application, set_env, [riak_kv, add_paths, [filename:dirname(ModFile)]]),
 
     lager:info("checking that insecure input modfun fails when whitelisted but"
                " lacking permissions"),

--- a/tests/pb_security.erl
+++ b/tests/pb_security.erl
@@ -432,8 +432,8 @@ confirm() ->
                                          undefined, true}])),
 
     lager:info("whitelisting module path"),
-    ok = rpc:call(Node, application, set_env, [riak_kv, add_paths,
-                                    [filename:dirname(code:which(?MODULE))]]),
+    {?MODULE, _ModBin, ModFile} = code:get_object_code(?MODULE),
+    ok = rpc:call(Node, application, set_env, [riak_kv, add_paths, [filename:dirname(ModFile)]]),
 
     lager:info("checking mapreduce with a insecure modfun input fails when"
                " whitelisted but lacking permissions"),


### PR DESCRIPTION
Currently `code:which/1` relies on specific settings in the Erlang path.  Replacing it with `code:get_object_code/1` seems to be more flexible and will work better with the up and coming testing framework.

**NOTE:** `http_security` seems to be rather fragile and does not pass every time.  YMMV.