### PR TITLE
Make default riak services and console configurable in rt.erl

### DIFF
--- a/examples/riak_test.config
+++ b/examples/riak_test.config
@@ -46,6 +46,17 @@
     %% scripts in the bin/ directory.
     {rt_harness, rtdev},
 
+    %% The riak test environment can ensure that a default set of riak
+    %% services are started. The set of services can be configured by
+    %% configuring the desired set of services. To alter the default
+    %% enable and configure the following variable
+    %% {rt_services, [riak_kv]},
+
+    %% The riak test environment integreates with riak_kv_console by
+    %% default. To override this for other riak_core based apps uncomment
+    %% and configure teh following variable
+    %% {rt_console, riak_kv_console},
+
     %% The scratch directory specifies where riak_test will put
     %% temporary testing artifacts like client packages, git
     %% checkouts, etc.

--- a/src/rt.erl
+++ b/src/rt.erl
@@ -27,6 +27,9 @@
 -include("rt.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
+-define(SERVICES,rt_config:get(rt_services, [riak_kv])).
+-define(CONSOLE, rt_config:get(rt_console, riak_kv_console)).
+
 -compile(export_all).
 -export([
          admin/2,
@@ -299,7 +302,7 @@ get_https_conn_info(Node) ->
 %%      nodes deployed.
 %% @todo Re-add -spec after adding multi-version support
 deploy_nodes(Versions) when is_list(Versions) ->
-    deploy_nodes(Versions, [riak_kv]);
+    deploy_nodes(Versions, ?SERVICES);
 deploy_nodes(NumNodes) when is_integer(NumNodes) ->
     deploy_nodes([ current || _ <- lists:seq(1, NumNodes)]).
 
@@ -307,7 +310,7 @@ deploy_nodes(NumNodes) when is_integer(NumNodes) ->
 %%      `InitialConfig', returning a list of the nodes deployed.
 -spec deploy_nodes(NumNodes :: integer(), any()) -> [node()].
 deploy_nodes(NumNodes, InitialConfig) when is_integer(NumNodes) ->
-    deploy_nodes(NumNodes, InitialConfig, [riak_kv]);
+    deploy_nodes(NumNodes, InitialConfig, ?SERVICES);
 deploy_nodes(Versions, Services) ->
     NodeConfig = [ version_to_config(Version) || Version <- Versions ],
     Nodes = ?HARNESS:deploy_nodes(NodeConfig),
@@ -462,11 +465,11 @@ leave(Node) ->
 %% @doc Have `Node' remove `OtherNode' from the cluster
 remove(Node, OtherNode) ->
     ?assertEqual(ok,
-                 rpc:call(Node, riak_kv_console, remove, [[atom_to_list(OtherNode)]])).
+                 rpc:call(Node, ?CONSOLE, remove, [[atom_to_list(OtherNode)]])).
 
 %% @doc Have `Node' mark `OtherNode' as down
 down(Node, OtherNode) ->
-    rpc:call(Node, riak_kv_console, down, [[atom_to_list(OtherNode)]]).
+    rpc:call(Node, ?CONSOLE, down, [[atom_to_list(OtherNode)]]).
 
 %% @doc partition the `P1' from `P2' nodes
 %%      note: the nodes remained connected to riak_test@local,
@@ -652,7 +655,7 @@ wait_until_status_ready(Node) ->
     lager:info("Wait until status ready in ~p", [Node]),
     ?assertEqual(ok, wait_until(Node,
                                 fun(_) ->
-                                        case rpc:call(Node, riak_kv_console, status, [[]]) of
+                                        case rpc:call(Node, ?CONSOLE, status, [[]]) of
                                             ok ->
                                                 true;
                                             Res ->
@@ -826,7 +829,7 @@ wait_until_partitioned(P1, P2) ->
       end || Node <- P2 ].
 
 is_partitioned(Node, Peers) ->
-    AvailableNodes = rpc:call(Node, riak_core_node_watcher, nodes, [riak_kv]),
+    AvailableNodes = rpc:call(Node, riak_core_node_watcher, nodes, ?SERVICES),
     lists:all(fun(Peer) -> not lists:member(Peer, AvailableNodes) end, Peers).
 
 % when you just can't wait


### PR DESCRIPTION
As mentioned in #260 I had another change to riak_test I needed to perform, following
@Licenser's blog article to adapt it to my current riak_core based project. This PR reflects
that change. In summary it

* Makes the riak services that riak_test ensures are started configurable. This defaults to [riak_kv]
* Makes the riak console module configurable. This defaults to riak_kv_console.
* Adds an rt_services configuration variable
* Adds an rt_console configuration variable

The defaults remain unchanged so there should be no breaking introduced.

With this change it should be possible to precompile a self contained riak_test escript and
include it in a project in much the same way as rebar or relx. In this way the riak_core based
project can provide its own rt_harness and configuration and will have a reduced need to use
a forked version of riak_test. @loucash is already using riak_test a compiled escript and this
works well for his project.

A PR based on or derived from this PR would allow us to whack our riak_test forks and use
basho's riak_test vanilla out of the box without changes.

FYI @cmeiklejohn - The only different then to the lasp usage of riak_test would be using a self-contained riak_test escript to drive the tests rather than a local installation. So we may even be able to run riak_test under travis!