### PR TITLE
Fix Pid Registration of riak_repl2_leader_intercepts:set_leader_node/1

### DIFF
--- a/intercepts/riak_repl2_leader_intercepts.erl
+++ b/intercepts/riak_repl2_leader_intercepts.erl
@@ -16,6 +16,7 @@ leader_server(Node) ->
 
 set_leader_node(Node) ->
     LeaderPid = spawn(?MODULE, leader_server, [Node]),
+    global:unregister_name(?NODE_KEY),
     global:register_name(?NODE_KEY, LeaderPid).
 
 set_leader_node(LocalPid, LeaderNode, LeaderPid) ->


### PR DESCRIPTION
If this interceptor is used in more than one test in a test suite it fails because it tries to reregister an existing Pid.  Now first always unregister before registering.