### PR TITLE
Added explicit wait_for_service riak_pipe on pipe* tests

### DIFF
--- a/tests/pipe_verify_basics.erl
+++ b/tests/pipe_verify_basics.erl
@@ -42,6 +42,8 @@ confirm() ->
     lager:info("Build ~b node cluster", [?NODE_COUNT]),
     Nodes = rt:build_cluster(?NODE_COUNT),
 
+    [rt:wait_for_service(Node, riak_pipe) || Node <- Nodes],
+
     rt:load_modules_on_nodes([?MODULE], Nodes),
 
     verify_order(Nodes),

--- a/tests/pipe_verify_examples.erl
+++ b/tests/pipe_verify_examples.erl
@@ -30,7 +30,9 @@
 confirm() ->
     lager:info("Build ~b node cluster", [?NODE_COUNT]),
     Nodes = rt:build_cluster(?NODE_COUNT),
-    
+
+    [rt:wait_for_service(Node, riak_pipe) || Node <- Nodes],
+
     verify_example(Nodes),
     verify_example_transform(Nodes),
     verify_example_reduce(Nodes),

--- a/tests/pipe_verify_exceptions.erl
+++ b/tests/pipe_verify_exceptions.erl
@@ -47,6 +47,8 @@ confirm() ->
     lager:info("Build ~b node cluster", [?NODE_COUNT]),
     Nodes = rt:build_cluster(?NODE_COUNT),
 
+    [rt:wait_for_service(Node, riak_pipe) || Node <- Nodes],
+
     rt:load_modules_on_nodes([?MODULE, rt_pipe], Nodes),
 
     verify_xbad1(Nodes),

--- a/tests/pipe_verify_restart_input_forwarding.erl
+++ b/tests/pipe_verify_restart_input_forwarding.erl
@@ -54,6 +54,8 @@ confirm() ->
     lager:info("Build ~b node cluster", [?NODE_COUNT]),
     Nodes = rt:build_cluster(?NODE_COUNT),
 
+    [rt:wait_for_service(Node, riak_pipe) || Node <- Nodes],
+
     rt:load_modules_on_nodes([?MODULE, rt_pipe], Nodes),
 
     verify_worker_restart_failure_input_forwarding(Nodes),

--- a/tests/pipe_verify_sink_types.erl
+++ b/tests/pipe_verify_sink_types.erl
@@ -41,6 +41,8 @@ confirm() ->
     lager:info("Build ~b node cluster", [?NODE_COUNT]),
     Nodes = rt:build_cluster(?NODE_COUNT),
 
+    [rt:wait_for_service(Node, riak_pipe) || Node <- Nodes],
+
     verify_raw(Nodes),
     verify_fsm(Nodes),
     verify_fsm_timeout(Nodes),


### PR DESCRIPTION
Some of the pipe tests use the arity-1 version of `rt:deploy_nodes`, which doesn't implicitly wait for any Riak services (so it's possible for them to race on pipe being available). This patch adds an explicit wait for all nodes to those tests.