### PR TITLE
Force use of UTF8 for cert fields to avoid OpenSSL incompatibility issues.

### DIFF
--- a/src/make_certs.erl
+++ b/src/make_certs.erl
@@ -326,7 +326,9 @@ req_cnf(DN) ->
      "RANDFILE		= $ROOTDIR/RAND\n"
      "encrypt_key	= no\n"
      "default_md	= sha1\n"
-     "#string_mask	= pkix\n"
+     %% use string_mask to force the use of UTF8 for CN fields, as some OpenSSL installs
+     %% end up creating 'teletexString' fields, which nobody supports any more (since 2003)
+     "string_mask	= utf8only\n"
      "x509_extensions	= ca_ext\n"
      "prompt		= no\n"
      "distinguished_name= name\n"


### PR DESCRIPTION
Update and uncomment string_mask to ensure we create supported certificate fields. Without, certain automated builders will create subject CN fields that are of type “teletexString” which has been deprecated since 2003.