### PR TITLE
Add string_mask=utf8only to CA as well, since "basho" and "basho" don't match

### DIFF
--- a/src/make_certs.erl
+++ b/src/make_certs.erl
@@ -367,6 +367,7 @@ ca_cnf(CA) ->
      "crl		= $dir/crl.pem\n"
      "crlnumber		= $dir/crlnumber\n"
      "private_key	= $dir/private/key.pem\n"
+     "string_mask	= utf8only\n"
      "RANDFILE	        = $dir/private/RAND\n"
      "\n"
      "x509_extensions   = user_cert\n"


### PR DESCRIPTION
when one is UTF8 and the other is still teletex.