### PR TITLE
Revert "Set proper exit status"

### DIFF
--- a/src/riak_test_escript.erl
+++ b/src/riak_test_escript.erl
@@ -181,7 +181,7 @@ main(Args) ->
 
     Teardown = not proplists:get_value(keep, ParsedArgs, false),
     maybe_teardown(Teardown, TestResults, Coverage, Verbose),
-    proper_exit_status(TestResults).
+    ok.
 
 maybe_teardown(false, TestResults, Coverage, Verbose) ->
     print_summary(TestResults, Coverage, Verbose),
@@ -372,15 +372,6 @@ print_summary(TestResults, CoverResult, Verbose) ->
              || {App, Cov, _} <- AppCov]
     end,
     ok.
-
-proper_exit_status(TestResults) ->
-    Failed = [X || X <- TestResults, proplists:get_value(status, X) =:= fail],
-    case Failed of
-        [] ->
-            ok;
-        _ ->
-            halt(1)
-    end.
 
 test_name_width(Results) ->
     lists:max([ length(X) || [X | _T] <- Results ]).


### PR DESCRIPTION
Reverts basho/riak_test#754

The new world being created by @jburwell @javajolt uses specific exit codes for specific failure types. Reverting so as not to screw up their work. Sorry @loucash.