### PR TITLE
Make verify_membackend work with Riak 2.1

### DIFF
--- a/tests/verify_membackend.erl
+++ b/tests/verify_membackend.erl
@@ -281,6 +281,14 @@ get_used_space(VNode, Node) ->
                 TwoOhMulti;
             {<<"riak_ee-2.0",_/binary>>, multi} ->
                 TwoOhMulti;
+            {<<"riak-2.1",_/binary>>, regular} ->
+                TwoOhReg;
+            {<<"riak_ee-2.1",_/binary>>, regular} ->
+                TwoOhReg;
+            {<<"riak-2.1",_/binary>>, multi} ->
+                TwoOhMulti;
+            {<<"riak_ee-2.1",_/binary>>, multi} ->
+                TwoOhMulti;
             _Else ->
                 lager:error("didn't understand version/mode tuple ~p",
                             [{Version, Mode}]),


### PR DESCRIPTION
Two key changes:
- The path into the `kv_vnode` state under 2.1
- The target memory values are off by 4 bytes

Going to look into the latter, but the values are predictable through the test run.
