### PR TITLE
Added case clause for case in which we are calling get on a 2.0 or later node

### DIFF
--- a/tests/repl_bucket_types.erl
+++ b/tests/repl_bucket_types.erl
@@ -434,6 +434,8 @@ assert_bucket_not_found(Pid, Bucket, Key) ->
     case riakc_pb_socket:get(Pid, Bucket, Key) of
         {error, notfound} ->
             true;
+        {error, <<"no_type">>} ->
+            true;
         {ok, Res} ->
             lager:error("Found bucket:~p and key:~p on sink when we should not have", [Res, Key]),
             false


### PR DESCRIPTION
The previous behavior was targeted for pre-2.0 (pre-bucket type) behavior.