### PR TITLE
Bugfix/BTA-183

### DIFF
--- a/src/rt.erl
+++ b/src/rt.erl
@@ -853,21 +853,34 @@ capability(Node, Capability, Default) ->
 wait_until_capability(Node, Capability, Value) ->
     rt:wait_until(Node,
                   fun(_) ->
-                          cap_equal(Value, capability(Node, Capability))
+                      Cap = capability(Node, Capability),
+                      lager:info("Capability on node ~p is ~p~n",[Node, Cap]),
+                      cap_equal(Value, Cap)
                   end).
 
 wait_until_capability(Node, Capability, Value, Default) ->
     rt:wait_until(Node,
                   fun(_) ->
                           Cap = capability(Node, Capability, Default),
-                io:format("capability is ~p ~p",[Node, Cap]),
+                          lager:info("Capability on node ~p is ~p~n",[Node, Cap]),
                           cap_equal(Value, Cap)
                   end).
+
+wait_until_capability_contains(Node, Capability, Value) ->
+    rt:wait_until(Node,
+                fun(_) ->
+                    Cap = capability(Node, Capability),
+                    lager:info("Capability on node ~p is ~p~n",[Node, Cap]),
+                    cap_subset(Value, Cap)
+                end).
 
 cap_equal(Val, Cap) when is_list(Cap) ->
     lists:sort(Cap) == lists:sort(Val);
 cap_equal(Val, Cap) ->
     Val == Cap.
+
+cap_subset(Val, Cap) when is_list(Cap) ->
+    sets:is_subset(sets:from_list(Val), sets:from_list(Cap)).
 
 wait_until_owners_according_to(Node, Nodes) ->
     SortedNodes = lists:usort(Nodes),

--- a/tests/verify_counter_capability.erl
+++ b/tests/verify_counter_capability.erl
@@ -40,7 +40,7 @@ confirm() ->
     %% Get put on all nodes
     Config = [],
     [Legacy, Previous] = Nodes = rt:build_cluster([{legacy, Config}, {previous, Config}]),
-    ?assertEqual(ok, rt:wait_until_capability(Previous, {riak_kv, crdt}, [pncounter])),
+    ?assertEqual(ok, rt:wait_until_capability_contains(Previous, {riak_kv, crdt}, [pncounter])),
     verify_counter_converge:set_allow_mult_true(Nodes),
 
     {LegacyPB, LegacyHttp} = get_clients(Legacy),
@@ -63,7 +63,7 @@ confirm() ->
 
     PrevPB2 = rt:pbc(Legacy),
 
-    ?assertEqual(ok, rt:wait_until_capability(Previous, {riak_kv, crdt}, [pncounter,riak_dt_pncounter,riak_dt_orswot,riak_dt_map])),
+    ?assertEqual(ok, rt:wait_until_capability_contains(Previous, {riak_kv, crdt}, [pncounter,riak_dt_pncounter,riak_dt_orswot,riak_dt_map])),
 
     ?assertMatch(ok, rhc:counter_incr(LegacyHttp, ?BUCKET, ?KEY, 1)),
     ?assertMatch({ok, 5}, rhc:counter_val(LegacyHttp, ?BUCKET, ?KEY)),

--- a/tests/verify_counter_capability.erl
+++ b/tests/verify_counter_capability.erl
@@ -63,7 +63,7 @@ confirm() ->
 
     PrevPB2 = rt:pbc(Legacy),
 
-    ?assertEqual(ok, rt:wait_until_capability(Previous, {riak_kv, crdt}, [pncounter])),
+    ?assertEqual(ok, rt:wait_until_capability(Previous, {riak_kv, crdt}, [pncounter,riak_dt_pncounter,riak_dt_orswot,riak_dt_map])),
 
     ?assertMatch(ok, rhc:counter_incr(LegacyHttp, ?BUCKET, ?KEY, 1)),
     ?assertMatch({ok, 5}, rhc:counter_val(LegacyHttp, ?BUCKET, ?KEY)),

--- a/tests/verify_crdt_capability.erl
+++ b/tests/verify_crdt_capability.erl
@@ -61,8 +61,9 @@ confirm() ->
 
     rt:upgrade(Previous, current),
     lager:info("Upgrayded!!"),
+    ?assertEqual(ok, rt:wait_until_ready(Current)),
+    ?assertEqual(ok, rt:wait_until_ready(Previous)),
     ?assertEqual(ok, rt:wait_until_capability_contains(Current, {riak_kv, crdt}, [riak_dt_pncounter, riak_dt_orswot, riak_dt_map, pncounter])),
-
     ?assertMatch(ok, rhc:counter_incr(PrevHttp, ?BUCKET, ?KEY, 1)),
     ?assertMatch({ok, 5}, rhc:counter_val(PrevHttp, ?BUCKET, ?KEY)),
 

--- a/tests/verify_crdt_capability.erl
+++ b/tests/verify_crdt_capability.erl
@@ -39,7 +39,7 @@ confirm() ->
     %% Get put on all nodes
     Config = [],
     [Previous, Current]=Nodes = rt:build_cluster([{previous, Config}, {current, Config}]),
-    ?assertEqual(ok, rt:wait_until_capability(Current, {riak_kv, crdt}, [pncounter])),
+    ?assertEqual(ok, rt:wait_until_capability(Current, {riak_kv, crdt}, [pncounter,riak_dt_pncounter,riak_dt_orswot,riak_dt_map])),
 
     verify_counter_converge:set_allow_mult_true(Nodes),
 

--- a/tests/verify_crdt_capability.erl
+++ b/tests/verify_crdt_capability.erl
@@ -39,7 +39,7 @@ confirm() ->
     %% Get put on all nodes
     Config = [],
     [Previous, Current]=Nodes = rt:build_cluster([{previous, Config}, {current, Config}]),
-    ?assertEqual(ok, rt:wait_until_capability(Current, {riak_kv, crdt}, [pncounter,riak_dt_pncounter,riak_dt_orswot,riak_dt_map])),
+    ?assertEqual(ok, rt:wait_until_capability_contains(Current, {riak_kv, crdt}, [pncounter])),
 
     verify_counter_converge:set_allow_mult_true(Nodes),
 
@@ -61,7 +61,7 @@ confirm() ->
 
     rt:upgrade(Previous, current),
     lager:info("Upgrayded!!"),
-    ?assertEqual(ok, rt:wait_until_capability(Current, {riak_kv, crdt}, [riak_dt_pncounter, riak_dt_orswot, riak_dt_map, pncounter])),
+    ?assertEqual(ok, rt:wait_until_capability_contains(Current, {riak_kv, crdt}, [riak_dt_pncounter, riak_dt_orswot, riak_dt_map, pncounter])),
 
     ?assertMatch(ok, rhc:counter_incr(PrevHttp, ?BUCKET, ?KEY, 1)),
     ?assertMatch({ok, 5}, rhc:counter_val(PrevHttp, ?BUCKET, ?KEY)),


### PR DESCRIPTION
Fixed two capability tests (verify_counter_capabilty and verify_crd_capability) to work with previous, 2.0.5 and legacy 1.4.12.  Both tests had assumptions about capabilities in previous point releases, which are no longer valid assumptions.  Also relaxed the requirement for capability checking by checking for subsets instead of exact matches (in case new capabilities are added in the future).