### PR TITLE
BTA-186 verify_crdt_capability

### DIFF
--- a/tests/verify_crdt_capability.erl
+++ b/tests/verify_crdt_capability.erl
@@ -63,6 +63,7 @@ confirm() ->
     lager:info("Upgrayded!!"),
     ?assertEqual(ok, rt:wait_until_ready(Current)),
     ?assertEqual(ok, rt:wait_until_ready(Previous)),
+    rt:wait_for_service(Previous, riak_kv), 
     ?assertEqual(ok, rt:wait_until_capability_contains(Current, {riak_kv, crdt}, [riak_dt_pncounter, riak_dt_orswot, riak_dt_map, pncounter])),
     ?assertMatch(ok, rhc:counter_incr(PrevHttp, ?BUCKET, ?KEY, 1)),
     ?assertMatch({ok, 5}, rhc:counter_val(PrevHttp, ?BUCKET, ?KEY)),


### PR DESCRIPTION
Added a wait for riak_kv to start before polling http interface.

This seems to address a timing issue on Linux, that does not seem to show on OS X.