### PR TITLE
update yz_handoff test for swiftness via single leave-state check... need to extend this w/ aggressive settings and more states

### DIFF
--- a/tests/yz_handoff.erl
+++ b/tests/yz_handoff.erl
@@ -34,7 +34,6 @@
          {riak_core,
           [
            {ring_creation_size, 16},
-           {handoff_concurrency, 11},
            {claimant_tick, 1000}
           ]},
          {yokozuna,


### PR DESCRIPTION
was failing on the builder on the **join** state. I ran into the same issue on a fresh env intermittently when using aggressive settings. Need to spend some more time w/ this and getting it working and waiting for transfers correctly on join and allowing for env speedups. Relates to YZ's extended work w/ AAE, which is coming up this week.

Fixes BTA-176 **for now**.

@aberghage will review and test on the builder too, before +1'ing. 