### PR TITLE
Fix occasional failures in ensemble_sync

### DIFF
--- a/intercepts/riak_ensemble_peer_intercepts.erl
+++ b/intercepts/riak_ensemble_peer_intercepts.erl
@@ -1,0 +1,17 @@
+-module(riak_ensemble_peer_intercepts).
+-compile(export_all).
+-include("intercept.hrl").
+
+-define(M, riak_ensemble_peer_orig).
+
+-define(INTERCEPT_TAB, intercept_leader_tick_counts).
+
+count_leader_ticks(State) ->
+    Result = ?M:leader_tick_orig(State),
+    case ets:lookup(?INTERCEPT_TAB, self()) of
+        [] ->
+            ets:insert(?INTERCEPT_TAB, {self(), 1});
+        _ ->
+            ets:update_counter(?INTERCEPT_TAB, self(), 1)
+    end,
+    Result.


### PR DESCRIPTION
This fixes some rare race conditions in ensemble_sync where we could sometimes run wait_for_stable prior to an ensemble actually becoming unstable, and then it would pass the wait but the ensemble could become unavailable during the next step in the test.

By waiting for the ensemble leader tick counts to increment, we can guarantee that any failures will have been "noticed" prior to our calling wait_for_stable, because the leader_tick function ensures a quorum is present when it executes, and steps down if it fails to get one.

Thanks to AJS for providing consultation on this one in a number of areas :+1: 