### PR TITLE
Don't hardcode with riak_kv.

### DIFF
--- a/src/rt.erl
+++ b/src/rt.erl
@@ -1112,7 +1112,9 @@ join_cluster(Nodes) ->
 
     %% Potential fix for BTA-116 and other similar "join before nodes ready" issues.
     %% TODO: Investigate if there is an actual race in Riak relating to cluster joins.
-    [ok = wait_for_service(Node, riak_kv) || Node <- Nodes],
+    Service = rt_config:get(rt_wait_for_service, riak_kv),
+    lager:info("Waiting for service to start: ~p", [Service]),
+    [ok = wait_for_service(Node, Service) || Node <- Nodes],
 
     %% Join nodes
     [Node1|OtherNodes] = Nodes,


### PR DESCRIPTION
Riak Core based applications, like Lasp, don't use riak_kv, and
therefore can't use riak_test if it's wiating for riak_kv to come
online.

Add support so the user can override the service the test/app is waiting
for.

Reverts breaking change in: b128e474f9961dacb6a85fcbd04078deab8f7610.