### PR TITLE
Add new test for schema reload/overwrite

### DIFF
--- a/include/yokozuna_rt.hrl
+++ b/include/yokozuna_rt.hrl
@@ -18,4 +18,6 @@
 %%
 %% -------------------------------------------------------------------
 -type index_name() :: binary().
+-type schema_name() :: string().
+-type raw_schema() :: binary().
 -type bucket() :: bucket() | {bucket(), bucket()}.

--- a/src/rt.erl
+++ b/src/rt.erl
@@ -173,9 +173,13 @@
          wait_until_bucket_type_status/3,
          whats_up/0
         ]).
+-export_type([interfaces/0,
+              conn_info/0,
+              predicate/1]).
 
 -type strings() :: [string(),...] | [].
 -type capability() :: atom() | {atom(), tuple()}.
+-type predicate(A) :: fun((A) -> boolean()).
 -define(HARNESS, (rt_config:get(rt_harness))).
 -define(RT_ETS, rt_ets).
 -define(RT_ETS_OPTS, [public, named_table, {write_concurrency, true}]).

--- a/src/yokozuna_rt.erl
+++ b/src/yokozuna_rt.erl
@@ -22,13 +22,36 @@
 -include_lib("eunit/include/eunit.hrl").
 -include("yokozuna_rt.hrl").
 
--export([expire_trees/1,
+-export([check_exists/2,
+         expire_trees/1,
+         host_entries/1,
+         remove_index_dirs/2,
          rolling_upgrade/2,
          rolling_upgrade/3,
+         search/4,
+         search/5,
+         search_expect/5,
+         search_expect/6,
+         search_expect/7,
          verify_num_found_query/3,
          wait_for_aae/1,
          wait_for_full_exchange_round/2,
-         write_data/5]).
+         wait_for_index/2,
+         wait_for_schema/2,
+         wait_for_schema/3,
+         write_data/5,
+         write_data/6]).
+
+-type host() :: string().
+-type portnum() :: integer().
+-type count() :: non_neg_integer().
+-type json_string() :: atom | string() | binary().
+
+-define(FMT(S, Args), lists:flatten(io_lib:format(S, Args))).
+
+-spec host_entries(rt:conn_info()) -> [{host(), portnum()}].
+host_entries(ClusterConnInfo) ->
+    [riak_http(I) || {_,I} <- ClusterConnInfo].
 
 %% @doc Write `Keys' via the PB inteface to a `Bucket' and have them
 %%      searchable in an `Index'.
@@ -36,13 +59,23 @@
 write_data(Cluster, Pid, Index, Bucket, Keys) ->
     riakc_pb_socket:set_options(Pid, [queue_if_disconnected]),
 
-    %% Create a search index and associate with a bucket
-    riakc_pb_socket:create_search_index(Pid, Index),
+    create_and_set_index(Cluster, Pid, Index, Bucket),
+    timer:sleep(1000),
 
-    %% For possible legacy upgrade reasons, wrap create index in a wait
-    wait_for_index(Cluster, Index),
+    %% Write keys
+    lager:info("Writing ~p keys", [length(Keys)]),
+    [ok = rt:pbc_write(Pid, Bucket, Key, Key, "text/plain") || Key <- Keys],
+    ok.
 
-    ok = riakc_pb_socket:set_search_index(Pid, Bucket, Index),
+-spec write_data([node()], pid(), index_name(), {schema_name(), raw_schema()},
+                 bucket(), [binary()]) -> ok.
+write_data(Cluster, Pid, Index, {SchemaName, SchemaData},
+           Bucket, Keys) ->
+    riakc_pb_socket:set_options(Pid, [queue_if_disconnected]),
+
+    riakc_pb_socket:create_search_schema(Pid, SchemaName, SchemaData),
+
+    create_and_set_index(Cluster, Pid, Bucket, Index, SchemaName),
     timer:sleep(1000),
 
     %% Write keys
@@ -78,21 +111,6 @@ rolling_upgrade(Cluster, Vsn, YZCfgChanges) ->
          rt:wait_for_service(Node, yokozuna)
      end || {SolrPort, Node} <- Cluster2],
     ok.
-
--spec config_merge(proplists:proplist(), proplists:proplist()) ->
-                          orddict:orddict() | proplists:proplist().
-config_merge(DefaultCfg, NewCfg) when NewCfg /= [] ->
-    orddict:update(yokozuna,
-                   fun(V) ->
-                           orddict:merge(fun(_, _X, Y) -> Y end,
-                                         orddict:from_list(V),
-                                         orddict:from_list(
-                                           orddict:fetch(
-                                             yokozuna, NewCfg)))
-                   end,
-                   DefaultCfg);
-config_merge(DefaultCfg, _NewCfg) ->
-    DefaultCfg.
 
 %% @doc Use AAE status to verify that exchange has occurred for all
 %%      partitions since the time this function was invoked.
@@ -151,6 +169,38 @@ wait_for_index(Cluster, Index) ->
     [?assertEqual(ok, rt:wait_until(Node, IsIndexUp)) || Node <- Cluster],
     ok.
 
+%% @see wait_for_schema/3
+wait_for_schema(Cluster, Name) ->
+    wait_for_schema(Cluster, Name, ignore).
+
+%% @doc Wait for the schema `Name' to be read by all nodes in
+%% `Cluster' before returning.  If `Content' is binary data when
+%% verify the schema bytes exactly match `Content'.
+-spec wait_for_schema([node()], schema_name(), ignore | raw_schema()) -> ok.
+wait_for_schema(Cluster, Name, Content) ->
+    F = fun(Node) ->
+                lager:info("Attempt to read schema ~s from node ~p",
+                           [Name, Node]),
+                {Host, Port} = riak_pb(hd(rt:connection_info([Node]))),
+                {ok, PBConn} = riakc_pb_socket:start_link(Host, Port),
+                R = riakc_pb_socket:get_search_schema(PBConn, Name),
+                riakc_pb_socket:stop(PBConn),
+                case R of
+                    {ok, PL} ->
+                        case Content of
+                            ignore ->
+                                Name == proplists:get_value(name, PL);
+                            _ ->
+                                (Name == proplists:get_value(name, PL)) and
+                                    (Content == proplists:get_value(content, PL))
+                        end;
+                    _ ->
+                        false
+                end
+        end,
+    rt:wait_until(Cluster,  F),
+    ok.
+
 %% @doc Expire YZ trees
 -spec expire_trees([node()]) -> ok.
 expire_trees(Cluster) ->
@@ -162,6 +212,27 @@ expire_trees(Cluster) ->
     timer:sleep(100),
     ok.
 
+%% @doc Remove index directories, removing the index.
+-spec remove_index_dirs([node()], index_name()) -> ok.
+remove_index_dirs(Nodes, IndexName) ->
+    IndexDirs = [rpc:call(Node, yz_index, index_dir, [IndexName]) ||
+                    Node <- Nodes],
+    lager:info("Remove index dirs: ~p, on nodes: ~p~n",
+               [IndexDirs, Nodes]),
+    [rt:stop(ANode) || ANode <- Nodes],
+    [rt:del_dir(binary_to_list(IndexDir)) || IndexDir <- IndexDirs],
+    [rt:start(ANode) || ANode <- Nodes],
+    ok.
+
+%% @doc Check if index/core exists in metadata, disk via yz_index:exists.
+-spec check_exists([node()], index_name()) -> ok.
+check_exists(Nodes, IndexName) ->
+    rt:wait_until(Nodes,
+                  fun(N) ->
+                          rpc:call(N, yz_index, exists, [IndexName])
+                  end).
+
+-spec verify_num_found_query([node()], index_name(), count()) -> ok.
 verify_num_found_query(Cluster, Index, ExpectedCount) ->
     F = fun(Node) ->
                 Pid = rt:pbc(Node),
@@ -172,3 +243,120 @@ verify_num_found_query(Cluster, Index, ExpectedCount) ->
         end,
     rt:wait_until(Cluster, F),
     ok.
+
+search_expect(HP, Index, Name, Term, Expect) ->
+    search_expect(yokozuna, HP, Index, Name, Term, Expect).
+
+search_expect(Type, HP, Index, Name, Term, Expect) ->
+    {ok, "200", _, R} = search(Type, HP, Index, Name, Term),
+    verify_count_http(Expect, R).
+
+search_expect(solr, {Host, Port}, Index, Name0, Term0, Shards, Expect)
+  when is_list(Shards), length(Shards) > 0 ->
+    Name = quote_unicode(Name0),
+    Term = quote_unicode(Term0),
+    URL = internal_solr_url(Host, Port, Index, Name, Term, Shards),
+    lager:info("Run search ~s", [URL]),
+    Opts = [{response_format, binary}],
+    {ok, "200", _, R} = ibrowse:send_req(URL, [], get, [], Opts),
+    verify_count_http(Expect, R).
+
+search(HP, Index, Name, Term) ->
+    search(yokozuna, HP, Index, Name, Term).
+
+search(Type, {Host, Port}, Index, Name, Term) when is_integer(Port) ->
+    search(Type, {Host, integer_to_list(Port)}, Index, Name, Term);
+
+search(Type, {Host, Port}, Index, Name0, Term0) ->
+    Name = quote_unicode(Name0),
+    Term = quote_unicode(Term0),
+    FmtStr = case Type of
+                 solr ->
+                     "http://~s:~s/internal_solr/~s/select?q=~s:~s&wt=json";
+                 yokozuna ->
+                     "http://~s:~s/search/query/~s?q=~s:~s&wt=json"
+             end,
+    URL = ?FMT(FmtStr, [Host, Port, Index, Name, Term]),
+    lager:info("Run search ~s", [URL]),
+    Opts = [{response_format, binary}],
+    ibrowse:send_req(URL, [], get, [], Opts).
+
+%%%===================================================================
+%%% Private
+%%%===================================================================
+
+-spec verify_count_http(count(), json_string()) -> boolean().
+verify_count_http(Expected, Resp) ->
+    Count = get_count_http(Resp),
+    lager:info("Expected: ~p, Actual: ~p", [Expected, Count]),
+    Expected == Count.
+
+-spec get_count_http(json_string()) -> count().
+get_count_http(Resp) ->
+    Struct = mochijson2:decode(Resp),
+    kvc:path([<<"response">>, <<"numFound">>], Struct).
+
+-spec riak_http({node(), rt:interfaces()} | rt:interfaces()) ->
+                       {host(), portnum()}.
+riak_http({_Node, ConnInfo}) ->
+    riak_http(ConnInfo);
+riak_http(ConnInfo) ->
+    proplists:get_value(http, ConnInfo).
+
+-spec riak_pb({node(), rt:interfaces()} | rt:interfaces()) ->
+                     {host(), portnum()}.
+riak_pb({_Node, ConnInfo}) ->
+    riak_pb(ConnInfo);
+riak_pb(ConnInfo) ->
+    proplists:get_value(pb, ConnInfo).
+
+-spec config_merge(proplists:proplist(), proplists:proplist()) ->
+                          orddict:orddict() | proplists:proplist().
+config_merge(DefaultCfg, NewCfg) when NewCfg /= [] ->
+    orddict:update(yokozuna,
+                   fun(V) ->
+                           orddict:merge(fun(_, _X, Y) -> Y end,
+                                         orddict:from_list(V),
+                                         orddict:from_list(
+                                           orddict:fetch(
+                                             yokozuna, NewCfg)))
+                   end,
+                   DefaultCfg);
+config_merge(DefaultCfg, _NewCfg) ->
+    DefaultCfg.
+
+-spec create_and_set_index([node()], pid(), bucket(), index_name()) -> ok.
+create_and_set_index(Cluster, Pid, Bucket, Index) ->
+    %% Create a search index and associate with a bucket
+    lager:info("Create a search index ~s and associate it with bucket ~s",
+               [Index, Bucket]),
+    ok = riakc_pb_socket:create_search_index(Pid, Index),
+    %% For possible legacy upgrade reasons, wrap create index in a wait
+    wait_for_index(Cluster, Index),
+    set_index(Pid, Bucket, Index).
+-spec create_and_set_index([node()], pid(), bucket(), index_name(),
+                           schema_name()) -> ok.
+create_and_set_index(Cluster, Pid, Bucket, Index, Schema) ->
+    %% Create a search index and associate with a bucket
+    lager:info("Create a search index ~s with a custom schema named ~s and
+               associate it with bucket ~s", [Index, Schema, Bucket]),
+    ok = riakc_pb_socket:create_search_index(Pid, Index, Schema, []),
+    %% For possible legacy upgrade reasons, wrap create index in a wait
+    wait_for_index(Cluster, Index),
+    set_index(Pid, Bucket, Index).
+
+-spec set_index(pid(), bucket(), index_name()) -> ok.
+set_index(Pid, Bucket, Index) ->
+    ok = riakc_pb_socket:set_search_index(Pid, Bucket, Index).
+
+internal_solr_url(Host, Port, Index) ->
+    ?FMT("http://~s:~B/internal_solr/~s", [Host, Port, Index]).
+internal_solr_url(Host, Port, Index, Name, Term, Shards) ->
+    Ss = [internal_solr_url(Host, ShardPort, Index)
+          || {_, ShardPort} <- Shards],
+    ?FMT("http://~s:~B/internal_solr/~s/select?wt=json&q=~s:~s&shards=~s",
+         [Host, Port, Index, Name, Term, string:join(Ss, ",")]).
+
+quote_unicode(Value) ->
+    mochiweb_util:quote_plus(binary_to_list(
+                               unicode:characters_to_binary(Value))).

--- a/tests/yz_core_properties_create_unload.erl
+++ b/tests/yz_core_properties_create_unload.erl
@@ -25,7 +25,7 @@
                [
                 %% allow AAE to build trees and exchange rapidly
                 {anti_entropy_build_limit, {100, 1000}},
-                {anti_entropy_concurrency, 4}
+                {anti_entropy_concurrency, 8}
                ]},
               {yokozuna,
                [
@@ -83,7 +83,7 @@ test_core_props_removal(Cluster, RandNodes, KeyCount, Pid) ->
     lager:info("Remove core.properties file in each index data dir"),
     remove_core_props(RandNodes, ?INDEX),
 
-    check_exists(Cluster, ?INDEX),
+    yokozuna_rt:check_exists(Cluster, ?INDEX),
 
     lager:info("Write one more piece of data"),
     ok = rt:pbc_write(Pid, ?BUCKET, <<"foo">>, <<"foo">>, "text/plain"),
@@ -93,9 +93,9 @@ test_core_props_removal(Cluster, RandNodes, KeyCount, Pid) ->
 
 test_remove_index_dirs(Cluster, RandNodes, KeyCount, Pid) ->
     lager:info("Remove index directories on each node and let them recreate/reindex"),
-    remove_index_dirs(RandNodes, ?INDEX),
+    yokozuna_rt:remove_index_dirs(RandNodes, ?INDEX),
 
-    check_exists(Cluster, ?INDEX),
+    yokozuna_rt:check_exists(Cluster, ?INDEX),
 
     yokozuna_rt:expire_trees(Cluster),
     yokozuna_rt:wait_for_aae(Cluster),
@@ -112,9 +112,9 @@ test_remove_segment_infos_and_rebuild(Cluster, RandNodes, KeyCount, Pid) ->
 
     lager:info("To fix, we remove index directories on each node and let them recreate/reindex"),
 
-    remove_index_dirs(RandNodes, ?INDEX),
+    yokozuna_rt:remove_index_dirs(RandNodes, ?INDEX),
 
-    check_exists(Cluster, ?INDEX),
+    yokozuna_rt:check_exists(Cluster, ?INDEX),
 
     yokozuna_rt:expire_trees(Cluster),
     yokozuna_rt:wait_for_aae(Cluster),
@@ -146,23 +146,6 @@ remove_core_props(Nodes, IndexName) ->
                [PropsFiles, Nodes]),
     [file:delete(PropsFile) || PropsFile <- PropsFiles],
     ok.
-
-%% @doc Check if index/core exists in metadata, disk via yz_index:exists.
-check_exists(Nodes, IndexName) ->
-    rt:wait_until(Nodes,
-                  fun(N) ->
-                          rpc:call(N, yz_index, exists, [IndexName])
-                  end).
-
-%% @doc Remove index directories, removing the index.
-remove_index_dirs(Nodes, IndexName) ->
-    IndexDirs = [rpc:call(Node, yz_index, index_dir, [IndexName]) ||
-                    Node <- Nodes],
-    lager:info("Remove index dirs: ~p, on nodes: ~p~n",
-               [IndexDirs, Nodes]),
-    [rt:stop(ANode) || ANode <- Nodes],
-    [rt:del_dir(binary_to_list(IndexDir)) || IndexDir <- IndexDirs],
-    [rt:start(ANode) || ANode <- Nodes].
 
 %% @doc Remove lucence segment info files to check if reindexing will occur
 %%      on re-creation/re-indexing.

--- a/tests/yz_schema_change_reset.erl
+++ b/tests/yz_schema_change_reset.erl
@@ -1,0 +1,315 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2015 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%%--------------------------------------------------------------------
+-module(yz_schema_change_reset).
+-compile(export_all).
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("riakc/include/riakc.hrl").
+
+-define(GET(K,L), proplists:get_value(K, L)).
+-define(INDEX, <<"test_schema_change_reset">>).
+-define(TYPE, <<"test_schema_change">>).
+-define(BUCKET1, <<"test_schema_change_reset">>).
+-define(BUCKET2, {?TYPE, <<"test_schema_change_reset_2">>}).
+-define(SCHEMANAME, <<"test">>).
+
+-define(TEST_SCHEMA,
+<<"<schema name=\"test\" version=\"1.5\">
+<fields>
+   <dynamicField name=\"*_foo_register\" type=\"_yz_str\" indexed=\"true\" stored=\"true\" multiValued=\"false\"/>
+   <dynamicField name=\"*\" type=\"ignored\"/>
+
+   <field name=\"_yz_id\" type=\"_yz_str\" indexed=\"true\" stored=\"true\" required=\"true\" multiValued=\"false\"/>
+   <field name=\"_yz_ed\" type=\"_yz_str\" indexed=\"true\" multiValued=\"false\"/>
+   <field name=\"_yz_pn\" type=\"_yz_str\" indexed=\"true\" multiValued=\"false\"/>
+   <field name=\"_yz_fpn\" type=\"_yz_str\" indexed=\"true\" multiValued=\"false\"/>
+   <field name=\"_yz_vtag\" type=\"_yz_str\" indexed=\"true\" multiValued=\"false\"/>
+   <field name=\"_yz_rt\" type=\"_yz_str\" indexed=\"true\" stored=\"true\" multiValued=\"false\"/>
+   <field name=\"_yz_rk\" type=\"_yz_str\" indexed=\"true\" stored=\"true\" multiValued=\"false\"/>
+   <field name=\"_yz_rb\" type=\"_yz_str\" indexed=\"true\" stored=\"true\" multiValued=\"false\"/>
+   <field name=\"_yz_err\" type=\"_yz_str\" indexed=\"true\" stored=\"true\" multiValued=\"false\"/>
+   <field name=\"text\" type=\"text_general\" indexed=\"true\" stored=\"false\" multiValued=\"true\"/>
+   <field name=\"age\" type=\"int\" indexed=\"true\" stored=\"true\" multiValued=\"false\"/>
+</fields>
+<uniqueKey>_yz_id</uniqueKey>
+<types>
+    <fieldType name=\"ignored\" indexed=\"false\" stored=\"false\" multiValued=\"false\" class=\"solr.StrField\" />
+
+    <fieldType name=\"_yz_str\" class=\"solr.StrField\" sortMissingLast=\"true\" />
+    <fieldType name=\"string\" class=\"solr.StrField\" sortMissingLast=\"true\" />
+    <fieldType name=\"int\" class=\"solr.TrieIntField\" precisionStep=\"0\" positionIncrementGap=\"0\" />
+    <fieldType name=\"text_general\" class=\"solr.TextField\" positionIncrementGap=\"100\">
+      <analyzer type=\"index\">
+        <tokenizer class=\"solr.StandardTokenizerFactory\"/>
+        <filter class=\"solr.StopFilterFactory\" ignoreCase=\"true\" words=\"stopwords.txt\" enablePositionIncrements=\"true\" />
+        <filter class=\"solr.LowerCaseFilterFactory\"/>
+      </analyzer>
+      <analyzer type=\"query\">
+        <tokenizer class=\"solr.StandardTokenizerFactory\"/>
+        <filter class=\"solr.StopFilterFactory\" ignoreCase=\"true\" words=\"stopwords.txt\" enablePositionIncrements=\"true\" />
+        <filter class=\"solr.SynonymFilterFactory\" synonyms=\"synonyms.txt\" ignoreCase=\"true\" expand=\"true\"/>
+        <filter class=\"solr.LowerCaseFilterFactory\"/>
+      </analyzer>
+    </fieldType>
+</types>
+</schema>">>).
+-define(TEST_SCHEMA_UPDATE,
+<<"<schema name=\"test\" version=\"1.5\">
+<fields>
+   <dynamicField name=\"*_foo_register\" type=\"_yz_str\" indexed=\"true\" stored=\"true\" multiValued=\"false\"/>
+   <dynamicField name=\"*_baz_counter\" type=\"int\" indexed=\"true\" stored=\"true\" multiValued=\"false\"/>
+   <dynamicField name=\"paths.*\" type=\"int\" indexed=\"true\" stored=\"true\" multiValued=\"false\"/>
+   <dynamicField name=\"*\" type=\"ignored\"/>
+
+   <field name=\"_yz_id\" type=\"_yz_str\" indexed=\"true\" stored=\"true\" required=\"true\" multiValued=\"false\"/>
+   <field name=\"_yz_ed\" type=\"_yz_str\" indexed=\"true\" multiValued=\"false\"/>
+   <field name=\"_yz_pn\" type=\"_yz_str\" indexed=\"true\" multiValued=\"false\"/>
+   <field name=\"_yz_fpn\" type=\"_yz_str\" indexed=\"true\" multiValued=\"false\"/>
+   <field name=\"_yz_vtag\" type=\"_yz_str\" indexed=\"true\" multiValued=\"false\"/>
+   <field name=\"_yz_rt\" type=\"_yz_str\" indexed=\"true\" stored=\"true\" multiValued=\"false\"/>
+   <field name=\"_yz_rk\" type=\"_yz_str\" indexed=\"true\" stored=\"true\" multiValued=\"false\"/>
+   <field name=\"_yz_rb\" type=\"_yz_str\" indexed=\"true\" stored=\"true\" multiValued=\"false\"/>
+   <field name=\"_yz_err\" type=\"_yz_str\" indexed=\"true\" stored=\"true\" multiValued=\"false\"/>
+   <field name=\"text\" type=\"text_general\" indexed=\"true\" stored=\"false\" multiValued=\"true\"/>
+   <field name=\"age\" type=\"string\" indexed=\"true\" stored=\"true\" multiValued=\"false\"/>
+   <field name=\"hello_i\" type=\"int\" indexed=\"true\" stored=\"true\" multiValued=\"false\"/>
+</fields>
+<uniqueKey>_yz_id</uniqueKey>
+<types>
+    <fieldType name=\"ignored\" indexed=\"false\" stored=\"false\" multiValued=\"false\" class=\"solr.StrField\" />
+    <fieldType name=\"_yz_str\" class=\"solr.StrField\" sortMissingLast=\"true\" />
+    <fieldType name=\"string\" class=\"solr.StrField\" sortMissingLast=\"true\" />
+    <fieldType name=\"int\" class=\"solr.TrieIntField\" precisionStep=\"0\" positionIncrementGap=\"0\" />
+    <fieldType name=\"text_general\" class=\"solr.TextField\" positionIncrementGap=\"100\">
+      <analyzer type=\"index\">
+        <tokenizer class=\"solr.StandardTokenizerFactory\"/>
+        <filter class=\"solr.StopFilterFactory\" ignoreCase=\"true\" words=\"stopwords.txt\" enablePositionIncrements=\"true\" />
+        <filter class=\"solr.LowerCaseFilterFactory\"/>
+      </analyzer>
+      <analyzer type=\"query\">
+        <tokenizer class=\"solr.StandardTokenizerFactory\"/>
+        <filter class=\"solr.StopFilterFactory\" ignoreCase=\"true\" words=\"stopwords.txt\" enablePositionIncrements=\"true\" />
+        <filter class=\"solr.SynonymFilterFactory\" synonyms=\"synonyms.txt\" ignoreCase=\"true\" expand=\"true\"/>
+        <filter class=\"solr.LowerCaseFilterFactory\"/>
+      </analyzer>
+    </fieldType>
+</types>
+</schema>">>).
+
+-define(SEQMAX, 20).
+-define(CFG,
+        [{riak_core,
+          [
+           {ring_creation_size, 16},
+           {anti_entropy_build_limit, {100, 1000}},
+           {anti_entropy_concurrency, 8}
+          ]},
+         {yokozuna,
+          [
+           {anti_entropy_tick, 1000},
+           {enabled, true}
+          ]}
+        ]).
+
+confirm() ->
+    [Node1|_RestNodes] = Cluster = rt:build_cluster(4, ?CFG),
+    rt:wait_for_cluster_service(Cluster, yokozuna),
+
+    %% Generate keys, YZ only supports UTF-8 compatible keys
+    GenKeys = [<<N:64/integer>> || N <- lists:seq(1, ?SEQMAX),
+                                  not lists:any(
+                                        fun(E) -> E > 127 end,
+                                        binary_to_list(<<N:64/integer>>))],
+    KeyCount = length(GenKeys),
+    lager:info("KeyCount ~p", [KeyCount]),
+
+    Pid = rt:pbc(rt:select_random(Cluster)),
+
+    lager:info("Write initial data to index ~p with schema ~p",
+               [?INDEX, ?SCHEMANAME]),
+
+    yokozuna_rt:write_data(Cluster, Pid, ?INDEX,
+                           {?SCHEMANAME, ?TEST_SCHEMA},
+                           ?BUCKET1, GenKeys),
+    timer:sleep(1100),
+
+    lager:info("Create and activate map-based bucket type ~s and tie it to search_index ~s",
+               [?TYPE, ?INDEX]),
+    rt:create_and_activate_bucket_type(Node1, ?TYPE, [{datatype, map},
+                                                      {search_index, ?INDEX}]),
+
+    lager:info("Write and check age at integer per original schema"),
+
+    NewObj1A = riakc_obj:new(?BUCKET1, <<"keyA">>,
+                             <<"{\"age\":26}">>,
+                             "application/json"),
+
+    NewObj1B = riakc_obj:new(?BUCKET1, <<"keyB">>,
+                             <<"{\"age\":99}">>,
+                             "application/json"),
+
+    {ok, _ObjA} = riakc_pb_socket:put(Pid, NewObj1A, [return_head]),
+    timer:sleep(1100),
+    {ok, _ObjB} = riakc_pb_socket:put(Pid, NewObj1B, [return_head]),
+    timer:sleep(1100),
+
+    yokozuna_rt:verify_num_found_query(Cluster, ?INDEX, KeyCount + 2),
+
+    assert_search(Pid, Cluster, <<"age:26">>, {<<"age">>, <<"26">>}, []),
+    assert_search(Pid, Cluster, <<"age:99">>, {<<"age">>, <<"99">>}, []),
+
+    Map1 = riakc_map:update(
+             {<<"0_foo">>, register},
+             fun(R) ->
+                     riakc_register:set(<<"44ab">>, R)
+             end, riakc_map:new()),
+    ok = riakc_pb_socket:update_type(
+           Pid,
+           ?BUCKET2,
+           <<"keyMap1">>,
+           riakc_map:to_op(Map1)),
+
+    {ok, Map2} = riakc_pb_socket:fetch_type(Pid, ?BUCKET2, <<"keyMap1">>),
+    Map3 = riakc_map:update(
+             {<<"1_baz">>, counter},
+             fun(R) ->
+                     riakc_counter:increment(10, R)
+             end, Map2),
+    ok = riakc_pb_socket:update_type(
+           Pid,
+           ?BUCKET2,
+           <<"keyMap1">>,
+           riakc_map:to_op(Map3)),
+
+    timer:sleep(1100),
+    assert_search(Pid, Cluster, <<"0_foo_register:44ab">>, {<<"0_foo_register">>,
+                                                            <<"44ab">>}, []),
+
+    lager:info("Expire and re-check count before updating schema"),
+
+    yokozuna_rt:expire_trees(Cluster),
+    yokozuna_rt:wait_for_aae(Cluster),
+
+    yokozuna_rt:verify_num_found_query(Cluster, ?INDEX, KeyCount + 3),
+
+    lager:info("Overwrite schema with updated schema"),
+    override_schema(Pid, Cluster, ?INDEX, ?SCHEMANAME, ?TEST_SCHEMA_UPDATE),
+
+    lager:info("Write and check hello_i at integer per schema update"),
+
+    NewObj2 = riakc_obj:new(?BUCKET1, <<"key2">>,
+                            <<"{\"hello_i\":36}">>,
+                            "application/json"),
+
+    {ok, _Obj2} = riakc_pb_socket:put(Pid, NewObj2, [return_head]),
+    timer:sleep(1100),
+
+    yokozuna_rt:verify_num_found_query(Cluster, ?INDEX, KeyCount + 4),
+    assert_search(Pid, Cluster, <<"hello_i:36">>, {<<"hello_i">>, <<"36">>}, []),
+
+    lager:info("Write and check age at string per schema update"),
+
+    NewObj3 = riakc_obj:new(?BUCKET1, <<"key3">>,
+                            <<"{\"age\":\"3jlkjkl\"}">>,
+                            "application/json"),
+
+    {ok, _Obj3} = riakc_pb_socket:put(Pid, NewObj3, [return_head]),
+
+    yokozuna_rt:verify_num_found_query(Cluster, ?INDEX, KeyCount + 5),
+    assert_search(Pid, Cluster, <<"age:3jlkjkl">>,
+                  {<<"age">>, <<"3jlkjkl">>}, []),
+
+    lager:info("Expire and re-check count to make sure we're correctly indexed
+               by the new schema"),
+
+    yokozuna_rt:expire_trees(Cluster),
+    yokozuna_rt:wait_for_aae(Cluster),
+
+    yokozuna_rt:verify_num_found_query(Cluster, ?INDEX, KeyCount + 5),
+
+    HP = rt:select_random(yokozuna_rt:host_entries(rt:connection_info(Cluster))),
+    yokozuna_rt:search_expect(HP, ?INDEX, <<"age">>, <<"*">>, 2),
+
+    lager:info("Re-Put because AAE won't find a diff even though the types
+               have changed, as it only compares based on bkey currently.
+               Also, this re-put will work as we have a default bucket (type)
+               with allow_mult=false... no siblings"),
+
+    {ok, _Obj4} = riakc_pb_socket:put(Pid, NewObj1A, [return_head]),
+    timer:sleep(1100),
+
+    assert_search(Pid, Cluster, <<"age:26">>, {<<"age">>, <<"26">>}, []),
+
+    lager:info("Re-Put Map data by dec/inc counter to account for *change* and
+               allow previously unindexed counter to be searchable"),
+
+    {ok, Map4} = riakc_pb_socket:fetch_type(Pid, ?BUCKET2, <<"keyMap1">>),
+    Map5 = riakc_map:update(
+             {<<"1_baz">>, counter},
+             fun(R) ->
+                     riakc_counter:decrement(0, R),
+                     riakc_counter:increment(0, R)
+             end, Map4),
+    ok = riakc_pb_socket:update_type(
+           Pid,
+           ?BUCKET2,
+           <<"keyMap1">>,
+           riakc_map:to_op(Map5)),
+
+    timer:sleep(1100),
+    assert_search(Pid, Cluster, <<"0_foo_register:44ab">>, {<<"0_foo_register">>,
+                                                            <<"44ab">>}, []),
+    assert_search(Pid, Cluster, <<"1_baz_counter:10">>, {<<"1_baz_counter">>,
+                                                         <<"10">>}, []),
+
+    lager:info("Test nested json searches w/ unsearched fields ignored"),
+
+    NewObj5 = riakc_obj:new(?BUCKET1, <<"key4">>,
+                            <<"{\"quip\":\"blashj3\",
+                                \"paths\":{\"quip\":\"88\"}}">>,
+                            "application/json"),
+    {ok, _Obj5} = riakc_pb_socket:put(Pid, NewObj5, [return_head]),
+
+    timer:sleep(1100),
+    assert_search(Pid, Cluster, <<"paths.quip:88">>,
+                  {<<"paths.quip">>, <<"88">>}, []),
+
+    riakc_pb_socket:stop(Pid),
+
+    pass.
+
+override_schema(Pid, Cluster, Index, Schema, RawUpdate) ->
+    ok = riakc_pb_socket:create_search_schema(Pid, Schema, RawUpdate),
+    yokozuna_rt:wait_for_schema(Cluster, Schema, RawUpdate),
+    [Node|_] = Cluster,
+    {ok, _} = rpc:call(Node, yz_index, reload, [Index]).
+
+assert_search(Pid, Cluster, Search, SearchExpect, Params) ->
+    F = fun(_) ->
+                lager:info("Searching ~p and asserting it exists",
+                           [SearchExpect]),
+                {ok,{search_results,[{_Index,Fields}], _Score, Found}} =
+                    riakc_pb_socket:search(Pid, ?INDEX, Search, Params),
+                ?assert(lists:member(SearchExpect, Fields)),
+                case Found of
+                    1 -> true;
+                    0 -> false
+                end
+        end,
+    rt:wait_until(Cluster, F).


### PR DESCRIPTION
* add new types for dialyzer
* add test to reload schema and overwrite it on type change
* clean-up yokozuna_rt for reusability
* test nested search (e.g. nested json objects)
* test re-putting fields, include crdt map workaround, discussed in
https://gist.github.com/sdebnath/36c235e042cb35db7d1f

Uses and adds to the changes to `yokozuna_rt.erl` in https://github.com/basho/yokozuna/pull/497, which we can just rebase correct on that branch after this is merged (figured this would merge first).