### PR TITLE
Version-specific YZ upgrade tests

### DIFF
--- a/tests/yz_default_bucket_type_upgrade.erl
+++ b/tests/yz_default_bucket_type_upgrade.erl
@@ -43,8 +43,9 @@
         ]).
 
 confirm() ->
-    TestMetaData = riak_test_runner:metadata(),
-    OldVsn = proplists:get_value(upgrade_version, TestMetaData, previous),
+    %% This test explicitly requires an upgrade from 2.0.5 to test a
+    %% new capability
+    OldVsn = "2.0.5",
 
     [_, Node|_] = Cluster = rt:build_cluster(lists:duplicate(4, {OldVsn, ?CFG})),
     rt:wait_for_cluster_service(Cluster, yokozuna),

--- a/tests/yz_default_bucket_type_upgrade.erl
+++ b/tests/yz_default_bucket_type_upgrade.erl
@@ -17,6 +17,13 @@
 %% under the License.
 %%
 %%--------------------------------------------------------------------
+
+%% @doc Test that checks to make sure that default bucket_types
+%%      do not lose data when expiring/clearing AAE trees when
+%%      trees are rebuilt for comparison.
+%% @end
+
+
 -module(yz_default_bucket_type_upgrade).
 -compile(export_all).
 -include_lib("eunit/include/eunit.hrl").

--- a/tests/yz_extractors.erl
+++ b/tests/yz_extractors.erl
@@ -18,6 +18,10 @@
 %%
 %%-------------------------------------------------------------------
 
+%% @doc Test that checks if we're caching the extractor map and that
+%%      creating custom extractors is doable via protobufs.
+%% @end
+
 -module(yz_extractors).
 -compile(export_all).
 -include_lib("eunit/include/eunit.hrl").

--- a/tests/yz_extractors.erl
+++ b/tests/yz_extractors.erl
@@ -54,8 +54,9 @@
         ]).
 
 confirm() ->
-    TestMetaData = riak_test_runner:metadata(),
-    OldVsn = proplists:get_value(upgrade_version, TestMetaData, previous),
+    %% This test explicitly requires an upgrade from 2.0.5 to test a
+    %% new capability
+    OldVsn = "2.0.5",
 
     [_, Node|_] = Cluster = rt:build_cluster(lists:duplicate(4, {OldVsn, ?CFG})),
     rt:wait_for_cluster_service(Cluster, yokozuna),


### PR DESCRIPTION
Per discussions in releases channel, we need these upgrade tests run against versions of Riak that lack the specified capability. Relying on `previous` is fatally flawed.

Build servers have already been updated in anticipation of this.

This probably also needs to be applied against another branch for 2.1 (and others?)

/cc @zeeshanlakhani @fadushin 