### PR TITLE
Wait for ring properties to converge before testing new behavior.

### DIFF
--- a/tests/riak667_mixed.erl
+++ b/tests/riak667_mixed.erl
@@ -76,8 +76,10 @@ confirm() ->
             ?KEY,
             riakc_map:to_op(Map2)),
 
-    %% Upgrade one node.
+    %% Upgrade one node and wait until the ring has converged so the correct
+    %% capabilities will be negotiated
     upgrade(Node2, "2.0.4"),
+    rt:wait_until_ring_converged([Node1, Node2]),
 
     lager:notice("running mixed 2.0.2 and 2.0.4"),
 


### PR DESCRIPTION
Resolves commonly reproducible failure on my test box

```
================ riak667_mixed failure stack trace =====================
{{assertion_failed,[{module,riak667_mixed},
                    {line,252},
                    {expression,"map_contents_are_dicts ( UpObj1 )"},
                    {expected,true},
                    {value,false}]},
 [{riak667_mixed,'-confirm/0-fun-43-',1,
                 [{file,"tests/riak667_mixed.erl"},{line,252}]},
  {riak667_mixed,confirm,0,[{file,"tests/riak667_mixed.erl"},{line,252}]},
  {riak_test_runner,return_to_exit,3,
                    [{file,"src/riak_test_runner.erl"},{line,159}]}]}
========================================================================
```