### PR TITLE
Use correct shutdown.

### DIFF
--- a/tests/riak_control_authentication.erl
+++ b/tests/riak_control_authentication.erl
@@ -99,7 +99,9 @@ confirm() ->
 
     %% Verify authentication userlist, without SSL and then with SSL.
     verify_authentication(current,  ?RC_AUTH_USERLIST_CONFIG_FORCE_SSL),
-    verify_authentication(current,  ?RC_AUTH_USERLIST_CONFIG_NO_FORCE_SSL).
+    verify_authentication(current,  ?RC_AUTH_USERLIST_CONFIG_NO_FORCE_SSL),
+
+    pass.
 
 %% @doc Verify the disabled authentication method works.
 verify_authentication(Vsn, ?RC_AUTH_NONE_CONFIG) ->
@@ -112,6 +114,8 @@ verify_authentication(Vsn, ?RC_AUTH_NONE_CONFIG) ->
     Command = io_lib:format("curl -sL -w %{http_code} ~s~p -o /dev/null", 
                             [rt:http_url(Node), "/admin"]),
     ?assertEqual("200", os:cmd(Command)),
+
+    rt:stop_and_wait(Node),
 
     pass;
 %% @doc Verify the disabled authentication method works with force SSL.
@@ -133,6 +137,8 @@ verify_authentication(current, ?RC_AUTH_NONE_CONFIG_FORCE_SSL) ->
     % AccessCommand = io_lib:format("curl --insecure -sL -w %{http_code} ~s~p", 
     %                               [rt:https_url(Node), "/admin"]),
     % ?assertEqual("200", os:cmd(AccessCommand)),
+
+    rt:stop_and_wait(Node),
 
     pass;
 %% @doc Verify the userlist authentication method works.
@@ -158,6 +164,8 @@ verify_authentication(Vsn, ?RC_AUTH_USERLIST_CONFIG) ->
     AuthCommand = io_lib:format("curl -u user:pass --insecure -sL -w %{http_code} ~s~p -o /dev/null", 
                                 [rt:https_url(Node), "/admin"]),
     ?assertEqual("200", os:cmd(AuthCommand)),
+
+    rt:stop_and_wait(Node),
 
     pass;
 %% @doc Verify the userlist authentication method works.
@@ -186,6 +194,8 @@ verify_authentication(current, ?RC_AUTH_USERLIST_CONFIG_FORCE_SSL) ->
     %                             [rt:https_url(Node), "/admin"]),
     % ?assertEqual("200", os:cmd(AuthCommand)),
 
+    rt:stop_and_wait(Node),
+
     pass;
 %% @doc Verify the userlist authentication method works.
 verify_authentication(current, ?RC_AUTH_USERLIST_CONFIG_NO_FORCE_SSL) ->
@@ -205,6 +215,8 @@ verify_authentication(current, ?RC_AUTH_USERLIST_CONFIG_NO_FORCE_SSL) ->
                                 [rt:http_url(Node), "/admin"]),
     ?assertEqual("200", os:cmd(AuthCommand)),
 
+    rt:stop_and_wait(Node),
+
     pass.
 
 %% @doc Build a one node cluster.
@@ -217,7 +229,6 @@ build_singleton_cluster(Vsn, Config) ->
     %% the supervisor starts, we need to restart to ensure settings
     %% take effect.
     Node = lists:nth(1, Nodes),
-    rt:stop_and_wait(Node),
     rt:start_and_wait(Node),
     rt:wait_for_service(Node, riak_kv),
 


### PR DESCRIPTION
No longer use the shutdown command when starting, which causes the use
of the incorrect version of shutdown (shutdown from current, not
previous) which generates an error.

```
{badrpc,{'EXIT',{{badfun,#Fun<erl_eval.20.80484245>},
                 [{erlang,apply,2,[]},
                  {rpc,'-handle_call_call/6-fun-0-',5,
                       [{file,"rpc.erl"},{line,203}]}]}}}
```