### PR TITLE
Make hwm 250 for easier debugging

### DIFF
--- a/src/riak_test_escript.erl
+++ b/src/riak_test_escript.erl
@@ -110,6 +110,7 @@ main(Args) ->
             notice
     end,
 
+    application:set_env(lager, error_logger_hwm, 250), %% helpful for debugging
     application:set_env(lager, handlers, [{lager_console_backend, ConsoleLagerLevel},
                                           {lager_file_backend, [{file, "log/test.log"},
                                                                 {level, ConsoleLagerLevel}]}]),


### PR DESCRIPTION
This change sets lager to only drop messages from error_logger if they exceed 250 messages per second.  It should help us not lose messages when trying to debug some kind of messy application start up issue.