### PR TITLE
Test fix for bad_match during handoff with write_once buckets

### DIFF
--- a/intercepts/riak_core_handoff_sender_intercepts.erl
+++ b/intercepts/riak_core_handoff_sender_intercepts.erl
@@ -6,3 +6,12 @@
 delayed_visit_item_3(K, V, Acc) ->
     timer:sleep(100),
     ?M:visit_item_orig(K, V, Acc).
+
+delayed_visit_item_3_1ms(K, V, Acc) ->
+    timer:sleep(1),
+    ?M:visit_item_orig(K, V, Acc).
+
+start_fold_global_send(TargetNode, Module, {Type, Opts}, ParentPid, SslOpts) ->
+    Return = ?M:start_fold_orig(TargetNode, Module, {Type, Opts}, ParentPid, SslOpts),
+    catch global:send(start_fold_started_proc, start),
+    Return.

--- a/intercepts/riak_core_handoff_sender_intercepts.erl
+++ b/intercepts/riak_core_handoff_sender_intercepts.erl
@@ -6,3 +6,7 @@
 delayed_visit_item_3(K, V, Acc) ->
     timer:sleep(100),
     ?M:visit_item_orig(K, V, Acc).
+
+slightly_delayed_visit_item_3(K, V, Acc) ->
+    timer:sleep(1),
+    ?M:visit_item_orig(K, V, Acc).

--- a/intercepts/riak_core_handoff_sender_intercepts.erl
+++ b/intercepts/riak_core_handoff_sender_intercepts.erl
@@ -6,7 +6,3 @@
 delayed_visit_item_3(K, V, Acc) ->
     timer:sleep(100),
     ?M:visit_item_orig(K, V, Acc).
-
-slightly_delayed_visit_item_3(K, V, Acc) ->
-    timer:sleep(1),
-    ?M:visit_item_orig(K, V, Acc).

--- a/intercepts/riak_core_handoff_sender_intercepts.erl
+++ b/intercepts/riak_core_handoff_sender_intercepts.erl
@@ -6,12 +6,3 @@
 delayed_visit_item_3(K, V, Acc) ->
     timer:sleep(100),
     ?M:visit_item_orig(K, V, Acc).
-
-delayed_visit_item_3_1ms(K, V, Acc) ->
-    timer:sleep(1),
-    ?M:visit_item_orig(K, V, Acc).
-
-start_fold_global_send(TargetNode, Module, {Type, Opts}, ParentPid, SslOpts) ->
-    Return = ?M:start_fold_orig(TargetNode, Module, {Type, Opts}, ParentPid, SslOpts),
-    catch global:send(start_fold_started_proc, start),
-    Return.

--- a/intercepts/riak_kv_vnode_intercepts.erl
+++ b/intercepts/riak_kv_vnode_intercepts.erl
@@ -39,8 +39,9 @@ slow_handle_coverage(Req, Filter, Sender, State) ->
     ?M:handle_coverage_orig(Req, Filter, Sender, State).
 
 count_handoff_w1c_puts(#riak_kv_w1c_put_req_v1{}=Req, Sender, State) ->
+    Val = ?M:handle_handoff_command_orig(Req, Sender, State),
     ets:update_counter(intercepts_tab, w1c_put_counter, 1),
-    ?M:handle_handoff_command_orig(Req, Sender, State);
+    Val;
 count_handoff_w1c_puts(Req, Sender, State) ->
     ?M:handle_handoff_command_orig(Req, Sender, State).
 

--- a/intercepts/riak_kv_vnode_intercepts.erl
+++ b/intercepts/riak_kv_vnode_intercepts.erl
@@ -9,6 +9,10 @@
     type :: primary | fallback
     % start_time :: non_neg_integer(), Jon to add?
 }).
+-record(riak_kv_w1c_put_reply_v1, {
+    reply :: ok | {error, term()},
+    type :: primary | fallback
+}).
 
 -define(M, riak_kv_vnode_orig).
 
@@ -38,12 +42,28 @@ slow_handle_coverage(Req, Filter, Sender, State) ->
     timer:sleep(Rand),
     ?M:handle_coverage_orig(Req, Filter, Sender, State).
 
+%% @doc Count how many times we call handle_handoff_command
 count_handoff_w1c_puts(#riak_kv_w1c_put_req_v1{}=Req, Sender, State) ->
     Val = ?M:handle_handoff_command_orig(Req, Sender, State),
     ets:update_counter(intercepts_tab, w1c_put_counter, 1),
     Val;
 count_handoff_w1c_puts(Req, Sender, State) ->
     ?M:handle_handoff_command_orig(Req, Sender, State).
+
+%% @doc Count how many times we handle syncchronous and asynchronous replies
+%% in handle_command when using w1c buckets
+count_w1c_handle_command(#riak_kv_w1c_put_req_v1{}=Req, Sender, State) ->
+    case ?M:handle_command_orig(Req, Sender, State) of
+        {noreply, NewState} ->
+            ets:update_counter(intercepts_tab, w1c_async_replies, 1),
+            {noreply, NewState};
+        {reply, #riak_kv_w1c_put_reply_v1{reply=ok, type=Type}, NewState} ->
+            ets:update_counter(intercepts_tab, w1c_sync_replies, 1),
+            {reply, #riak_kv_w1c_put_reply_v1{reply=ok, type=Type}, NewState};
+        Any -> Any
+    end;
+count_w1c_handle_command(Req, Sender, State) ->
+    ?M:handle_command_orig(Req, Sender, State).
 
 %% @doc Simulate dropped gets/network partitions byresponding with
 %%      noreply during get requests.

--- a/intercepts/riak_kv_worker_intercepts.erl
+++ b/intercepts/riak_kv_worker_intercepts.erl
@@ -17,7 +17,7 @@
 %
 handle_work_intercept({fold, FoldFun, FinishFun}, Sender, State) ->
     FinishWrapperFun = fun(X) ->
-        catch global:send(start_fold_started_proc, {write, self()}),
+        catch global:send(rt_ho_w1c_proc, {write, self()}),
         receive
             ok -> ok
         end,

--- a/intercepts/riak_kv_worker_intercepts.erl
+++ b/intercepts/riak_kv_worker_intercepts.erl
@@ -1,0 +1,26 @@
+-module(riak_kv_worker_intercepts).
+-compile(export_all).
+-include("intercept.hrl").
+-define(M, riak_kv_worker_orig).
+
+%
+% Okay, this is an interesting intercept.  The intention here is to insert some
+% code into the point where the vnode has completed its fold, but before it invokes the finish
+% command, which will inform the riak_core_vnode that handoff has completed for this node.
+% This is a magic time, when handoff is running, and the fold has completed.
+% In this case, we send a message to a process that is running in riak test
+% (see verify_handoff_write_once, for an example), which will do a write during this
+% magic time.  We wait for said process to return us an ok.
+%
+% The objective is to force the vnode to trigger a handle_handoff_command,
+% thus exercising the runtime/forwarding handoff logic in the vnode.
+%
+handle_work_intercept({fold, FoldFun, FinishFun}, Sender, State) ->
+    FinishWrapperFun = fun(X) ->
+        catch global:send(start_fold_started_proc, {write, self()}),
+        receive
+            ok -> ok
+        end,
+        FinishFun(X)
+    end,
+    ?M:handle_work_orig({fold, FoldFun, FinishWrapperFun}, Sender, State).

--- a/tests/verify_handoff_write_once.erl
+++ b/tests/verify_handoff_write_once.erl
@@ -91,7 +91,7 @@ run_test(Config, AsyncWrites) ->
         RootNode, {riak_kv_vnode, [
             %% Count everytime riak_kv_vnode:handle_handoff_command/3 is called with a write_once message
             {{handle_handoff_command, 3}, count_handoff_w1c_puts},
-            %% Count everytime riak_kv_vnode:handle_handoff_command/3 is called with a write_once message
+            %% Count everytime riak_kv_vnode:handle_command/3 is called with a write_once message
             {{handle_command, 3}, count_w1c_handle_command}
         ]}
     ),
@@ -116,7 +116,6 @@ run_test(Config, AsyncWrites) ->
     ?assertMatch(ok, rt:wait_until_nodes_ready(Cluster)),
     rt:wait_until_no_pending_changes(Cluster),
     rt:wait_until_transfers_complete(Cluster),
-    %TotalSent = stop_proc(),
     %%
     %% Verify the results
     %%
@@ -137,7 +136,6 @@ run_test(Config, AsyncWrites) ->
             ?assertEqual(0, W1CAsyncReplies),
             ?assertEqual(NTestItems + RingSize div 2, W1CSyncReplies)
     end,
-    %%
     Cluster.
 
 make_intercepts_tab(Node) ->

--- a/tests/verify_handoff_write_once.erl
+++ b/tests/verify_handoff_write_once.erl
@@ -22,150 +22,87 @@
 -export([confirm/0]).
 -include_lib("eunit/include/eunit.hrl").
 -define(BUCKET_TYPE, <<"write_once">>).
--define(BUCKET, {?BUCKET_TYPE, <<"write_once">>}).
--define(RING_SIZE, 8).
--define(NVAL, 1).
--define(CONFIG,
-    [
-        {riak_core, [
-            {default_bucket_props, [{n_val, ?NVAL}]},
-            {vnode_management_timer, 1000},
-            {ring_creation_size, ?RING_SIZE}]
-        },
-        {riak_kv, [
-            {anti_entropy_build_limit, {100, 1000}},
-            {anti_entropy_concurrency, 100},
-            {anti_entropy_tick, 100},
-            {anti_entropy, {on, []}},
-            {anti_entropy_timeout, 5000}
-        ]}
-    ]
-).
 
--record(state, {
-    sender, node, k, total = 0
-}).
-
-%%
-%% @doc This test is going to set up a 2-node cluster, with a write-once bucket with an nval
-%% of 1.  We also set up an intercept on the pref-list generation to ensure that all
-%% puts will go to exactly one of the nodes in the cluster.  (Note: there is some sensitivity
-%% in the intercept to the node name, which is not something we parameterize to the intercept.
-%% If something fundamental changes in the generation of node names (e.g., via make stagedevrel
-%% in riak/_ee, then this test may break).
-%% Once the cluster is set up, we write NTestItems to the cluster.
-%%
+%% We've got a separate test for capability negotiation and other mechanisms, so the test here is fairly
+%% straightforward: get a list of different versions of nodes and join them into a cluster, making sure that
+%% each time our data has been replicated:
 confirm() ->
-    NTestItems    = 1000,
-    NTestNodes    = 2,
+    NTestItems    = 1000,                                   %% How many test items to write/verify?
+    NTestNodes    = 2,                                      %% How many nodes to spin up for tests?
 
     run_test(NTestItems, NTestNodes),
 
-    lager:info("Test verify_handoff_write_once passed."),
+    lager:info("Test verify_handoff passed."),
     pass.
-
 
 run_test(NTestItems, NTestNodes) ->
     lager:info("Testing handoff (items ~p, encoding: default)", [NTestItems]),
-    %%
-    %% Build a 2-node cluster
-    %%
-    Cluster = rt:build_cluster(NTestNodes, ?CONFIG),
-    lager:info("Set up cluster: ~p", [Cluster]),
-    %%
-    %% Use the first node to create an immutable bucket (type)
-    %%
-    [Node1, Node2] = Cluster,
-    rt:wait_for_service(Node1, riak_kv),
-    rt:create_and_activate_bucket_type(Node1, ?BUCKET_TYPE, [{write_once, true}, {n_val, 1}]),
-    rt:wait_until_bucket_type_status(?BUCKET_TYPE, active, Cluster),
-    %%
-    %% Add intercepts:
-    %%    - slow down the handoff mechanism to trigger handloffs while removing nodes
-    %%    - count of the number of handoffs, and
-    %%    - force the preflist to send all puts to partition 0.
-    %%
-    make_intercepts_tab(Node1),
-    %% Insert delay into handoff folding
-    rt_intercept:add(Node1, {riak_core_handoff_sender, [{{visit_item, 3}, slightly_delayed_visit_item_3}]}),
 
-    rt_intercept:add(Node1, {riak_kv_vnode, [{{handle_handoff_command, 3}, count_handoff_w1c_puts}]}),
-    rt_intercept:add(Node1, {riak_core_apl, [{{get_apl_ann, 3}, force_dev1}]}),
-    rt_intercept:add(Node2, {riak_core_apl, [{{get_apl_ann, 3}, force_dev2}]}),
-    %%
-    %% Write NTestItems entries to a write_once bucket
-    %%
-    [] = rt:systest_write(Node1, 1, NTestItems, ?BUCKET, 1),
-    lager:info("Wrote ~p entries.", [NTestItems]),
-    %%
-    %% Evict Node1, and wait until handoff completes
-    %% Run some puts asynchronously to trigger handoff command
-    %% in the vnode.
-    %%
-    lager:info("Evicting Node1..."),
-    Pid = start_proc(Node1, NTestItems),
-    rt:leave(Node1),
-    timer:sleep(1001), % let the proc send some data
-    rt:wait_until_transfers_complete(Cluster),
-    lager:info("Transfers complete."),
-    %%
-    %%
-    %%
-    TotalSent = stop_proc(Pid),
-    lager:info("TotalSent: ~p", [TotalSent]),
-    [{_, Handoffs}] = rpc:call(Node1, ets, lookup, [intercepts_tab, w1c_put_counter]),
-    ?assert(Handoffs > 0),
-    lager:info("Looking Good. We handled ~p handoffs.", [Handoffs]),
-    %%
-    %% verify NumTestItems hits through handoff, and that NumTestItems are in the remaining cluster
-    %%
-    %rt:stop(Node1),
-    Results = rt:systest_read(Node2, 1, TotalSent, ?BUCKET, 1),
-    ?assertEqual(0, length(Results)),
-    lager:info("Data looks ok; we can retrieve ~p entries from the cluster.", [TotalSent]),
-    ok.
+    lager:info("Spinning up test nodes"),
+    [RootNode | TestNodes] = Nodes = deploy_test_nodes(NTestNodes),
 
+    rt:wait_for_service(RootNode, riak_kv),
+
+    make_intercepts_tab(RootNode),
+
+    %% Insert delay into handoff folding to test the efficacy of the
+    %% handoff heartbeat addition
+    [rt_intercept:add(N, {riak_core_handoff_sender,
+                          [{{visit_item, 3}, delayed_visit_item_3}]})
+     || N <- Nodes],
+
+    %% Count everytime riak_kv_vnode:handle_overload_command/3 is called with a
+    %% ts_puts tuple
+    [rt_intercept:add(N, {riak_kv_vnode,
+                          [{{handle_handoff_command, 3}, count_handoff_w1c_puts}]})
+     || N <- Nodes],
+
+    lager:info("Populating root node."),
+    %% write one object with a bucket type
+    rt:create_and_activate_bucket_type(RootNode, ?BUCKET_TYPE, [{write_once, true}]),
+    %% allow cluster metadata some time to propogate
+    rt:systest_write(RootNode, 1, NTestItems, {?BUCKET_TYPE, <<"bucket">>}, 1),
+
+    %% Test handoff on each node:
+    lager:info("Testing handoff for cluster."),
+    lists:foreach(fun(TestNode) -> test_handoff(RootNode, TestNode, NTestItems) end, TestNodes).
+
+%% See if we get the same data back from our new nodes as we put into the root node:
+test_handoff(RootNode, NewNode, NTestItems) ->
+
+    lager:info("Waiting for service on new node."),
+    rt:wait_for_service(NewNode, riak_kv),
+
+    %% Set the w1c_put counter to 0
+    true = rpc:call(RootNode, ets, insert, [intercepts_tab, {w1c_put_counter, 0}]),
+
+    lager:info("Joining new node with cluster."),
+    rt:join(NewNode, RootNode),
+    ?assertEqual(ok, rt:wait_until_nodes_ready([RootNode, NewNode])),
+    spawn(fun() ->
+              rt:systest_write(RootNode, NTestItems + 1, NTestItems + 1000, {?BUCKET_TYPE, <<"bucket">>}, 1)
+          end),
+    rt:wait_until_no_pending_changes([RootNode, NewNode]),
+
+    %% See if we get the same data back from the joined node that we added to the root node.
+    %%  Note: systest_read() returns /non-matching/ items, so getting nothing back is good:
+    lager:info("Validating data after handoff:"),
+    Results2 = rt:systest_read(NewNode, 1, NTestItems + 1000, {?BUCKET_TYPE, <<"bucket">>}, 1),
+    ?assertEqual(0, length(Results2)),
+    lager:info("Data looks ok."),
+    [{_, Count}] = rpc:call(RootNode, ets, lookup, [intercepts_tab, w1c_put_counter]),
+    ?assert(Count > 0),
+    lager:info("Looking Good. We handled ~p write_once puts during handoff.", [Count]).
+
+deploy_test_nodes(N) ->
+    Config = [{riak_core, [{default_bucket_props, [{n_val, 1}]},
+                           {ring_creation_size, 8},
+                           {handoff_acksync_threshold, 20},
+                           {handoff_concurrency, 2},
+                           {handoff_receive_timeout, 2000}]}],
+    rt:deploy_nodes(N, Config).
 
 make_intercepts_tab(Node) ->
     SupPid = rpc:call(Node, erlang, whereis, [sasl_safe_sup]),
-    intercepts_tab = rpc:call(
-        Node, ets, new,
-        [intercepts_tab, [named_table, public, set, {heir, SupPid, {}}]]
-    ),
-    rpc:call(Node, ets, insert, [intercepts_tab, {w1c_put_counter, 0}]).
-
-
-
-start_proc(Node, NTestItems) ->
-    Self = self(),
-    spawn_link(fun() -> loop(#state{sender=Self, node=Node, k=NTestItems}) end).
-
-
-loop(#state{sender=Sender, node=Node, k=K, total=Total} = State) ->
-    {Done, NewState} = receive
-        done ->
-            {true, Sender ! K}
-    after 2 ->
-        {
-            false,
-            if Total < 500 ->
-                case rt:systest_write(Node, K, K+1, ?BUCKET, 1) of
-                    [] -> State#state{k=K+1, total=Total+1};
-                    _ ->  State
-                end;
-            true ->
-                State
-            end
-        }
-    end,
-    case Done of
-        true ->  lager:info("Asynchronously added ~p entries.", [Total]), ok;
-        false -> loop(NewState)
-    end.
-
-
-stop_proc(Pid) ->
-    Pid ! done,
-    receive
-        K -> K
-    end.
+    intercepts_tab = rpc:call(Node, ets, new, [intercepts_tab, [named_table,
+                public, set, {heir, SupPid, {}}]]).

--- a/tests/verify_handoff_write_once.erl
+++ b/tests/verify_handoff_write_once.erl
@@ -114,6 +114,7 @@ run_test(Config, AsyncWrites) ->
     rt:join(NewNode, RootNode),
     TotalSent = wait_until_async_writes_complete(),
     ?assertMatch(ok, rt:wait_until_nodes_ready(Cluster)),
+    rt:wait_until_bucket_type_visible(Cluster, ?BUCKET_TYPE),
     rt:wait_until_no_pending_changes(Cluster),
     rt:wait_until_transfers_complete(Cluster),
     %%

--- a/tests/verify_handoff_write_once.erl
+++ b/tests/verify_handoff_write_once.erl
@@ -188,7 +188,7 @@ loop(#state{node=Node, sender=Sender, k=K} = State) ->
     end.
 
 stop_proc() ->
-    catch global:send(start_fold_started_proc, stop),
+    catch global:send(rt_ho_w1c_proc, stop),
     receive
         K -> K
     end.


### PR DESCRIPTION
This PR fixes the verify_handoff_write_once test to reliably exercise the riak_kv_vnode:handle_handoff_command, which is fixed under

https://github.com/basho/riak_kv/pull/1153

The test achieves this goal in inserting a new intercept into the riak_kv_worker which will force the test to write data into riak while handoff is running (but before the vnode is notified that handoff is complete).  This should address any race conditions that existed before this fix.