### PR TITLE
Fix riak_control and riak_control_authentication for Riak 2.1+

### DIFF
--- a/src/rt.erl
+++ b/src/rt.erl
@@ -72,6 +72,7 @@
          get_replica/5,
          get_ring/1,
          get_version/0,
+         get_version/1,
          heal/1,
          http_url/1,
          https_url/1,
@@ -1655,6 +1656,12 @@ get_backend(AppConfigProplist) ->
         [] -> error;
         Backend -> Backend
     end.
+
+%% @doc Gets the string flavor of the version tag specified
+%% (e.g. current, legacy, previous, etc).
+-spec(get_version(atom()) -> binary()).
+get_version(Vsn) ->
+    ?HARNESS:get_version(Vsn).
 
 %% @doc Gets the current version under test. In the case of an upgrade test
 %%      or something like that, it's the version you're upgrading to.

--- a/src/rtdev.erl
+++ b/src/rtdev.erl
@@ -727,11 +727,18 @@ set_backend(Backend, OtherOpts) ->
     update_app_config(all, [{riak_kv, Opts}]),
     get_backends().
 
-get_version() ->
-    case file:read_file(relpath(current) ++ "/VERSION") of
+%% @doc Read the VERSION file from an arbitrarily tagged
+%% version (e.g. current,
+-spec(get_version(atom()) -> binary()).
+get_version(Vsn) ->
+    case file:read_file(relpath(Vsn) ++ "/VERSION") of
         {error, enoent} -> unknown;
         {ok, Version} -> Version
     end.
+
+%% @doc Read the VERSION file for the `current` version
+get_version() ->
+    get_version(current).
 
 teardown() ->
     rt_cover:maybe_stop_on_nodes(),

--- a/tests/riak_control.erl
+++ b/tests/riak_control.erl
@@ -86,21 +86,6 @@ verify_upgrade_fold({FromVsn, Node}, VersionedNodes0) ->
 
     VersionedNodes.
 
-verify_control({current, Node}, VersionedNodes) ->
-    lager:info("Verifying control on node ~p vsn current.", [Node]),
-
-    %% Verify node resource.
-    {struct,
-     [{<<"nodes">>, Nodes}]} = verify_resource(Node, "/admin/nodes"),
-    validate_nodes(Node, Nodes, VersionedNodes, any),
-
-    %% Verify partitions resource.
-    {struct,
-     [{<<"partitions">>, Partitions},
-      {<<"default_n_val">>, _}]} = verify_resource(Node, "/admin/partitions"),
-    validate_partitions({current, Node}, Partitions, VersionedNodes),
-
-    ok;
 verify_control({Vsn, Node}, VersionedNodes) ->
     lager:info("Verifying control on node ~p vsn ~p.", [Vsn, Node]),
 
@@ -110,11 +95,27 @@ verify_control({Vsn, Node}, VersionedNodes) ->
     validate_nodes(Node, Nodes, VersionedNodes, any),
 
     %% Verify partitions resource.
-    {struct,
-     [{<<"partitions">>, Partitions}]} = verify_resource(Node, "/admin/partitions"),
+    VersionBinary = rt:get_version(Vsn),
+    Partitions = case VersionBinary of
+        <<"riak_ee-2.", _/binary>> ->
+            {struct,
+                [{<<"partitions">>, NodePartitions},
+                 {<<"default_n_val">>, _}]} = verify_resource(Node, "/admin/partitions"),
+                NodePartitions;
+        <<"riak-2.", _/binary>> ->
+            {struct,
+                [{<<"partitions">>, NodePartitions},
+                 {<<"default_n_val">>, _}]} = verify_resource(Node, "/admin/partitions"),
+            NodePartitions;
+        _ ->
+            {struct,
+                [{<<"partitions">>, NodePartitions}]} = verify_resource(Node, "/admin/partitions"),
+            NodePartitions
+    end,
     validate_partitions({previous, Node}, Partitions, VersionedNodes),
 
     ok.
+
 verify_control(VersionedNodes) ->
     [verify_control(NodeVsn, VersionedNodes) || NodeVsn <- VersionedNodes].
 
@@ -184,33 +185,39 @@ wait_for_control_cycle(Node) when is_atom(Node) ->
         end).
 
 %% @doc Validate partitions response.
-validate_partitions({current, _}, _ResponsePartitions, _VersionedNodes) ->
+validate_partitions({ControlVsn, _}, ResponsePartitions, VersionedNodes) ->
+    VersionBinary = rt:get_version(ControlVsn),
     %% The newest version of the partitions display can derive the
     %% partition state without relying on data from rpc calls -- it can
     %% use just the ring to do this.  Don't test anything specific here
     %% yet.
-    ok;
-validate_partitions({ControlVsn, _}, ResponsePartitions, VersionedNodes) ->
-    MixedCluster = mixed_cluster(VersionedNodes),
-    lager:info("Mixed cluster: ~p.", [MixedCluster]),
+    case VersionBinary of
+        <<"riak_ee-2.", _/binary>> ->
+            ok;
+        <<"riak-2.", _/binary>> ->
+            ok;
+        _ ->
+            MixedCluster = mixed_cluster(VersionedNodes),
+            lager:info("Mixed cluster: ~p.", [MixedCluster]),
 
-    lists:map(fun({struct, Partition}) ->
+            lists:map(fun({struct, Partition}) ->
 
-                %% Parse JSON further.
-                BinaryName = proplists:get_value(<<"node">>, Partition),
-                Status = proplists:get_value(<<"status">>, Partition),
-                Name = list_to_existing_atom(binary_to_list(BinaryName)),
+                        %% Parse JSON further.
+                        BinaryName = proplists:get_value(<<"node">>, Partition),
+                        Status = proplists:get_value(<<"status">>, Partition),
+                        Name = list_to_existing_atom(binary_to_list(BinaryName)),
 
-                %% Find current Vsn of node we are validating, and the
-                %% vsn of the node running Riak Control that we've
-                %% queried.
-                {NodeVsn, _} = lists:keyfind(Name, 2, VersionedNodes),
+                        %% Find current Vsn of node we are validating, and the
+                        %% vsn of the node running Riak Control that we've
+                        %% queried.
+                        {NodeVsn, _} = lists:keyfind(Name, 2, VersionedNodes),
 
-                %% Validate response.
-                ?assertEqual(true,
-                             valid_status(MixedCluster, ControlVsn,
-                                          NodeVsn, Status))
-        end, ResponsePartitions).
+                        %% Validate response.
+                        ?assertEqual(true,
+                                     valid_status(MixedCluster, ControlVsn,
+                                                  NodeVsn, Status))
+                end, ResponsePartitions)
+    end.
 
 %% @doc Validate status based on Vsn.
 valid_status(false, current, current, <<"incompatible">>) ->

--- a/tests/riak_control_authentication.erl
+++ b/tests/riak_control_authentication.erl
@@ -85,21 +85,45 @@
 %% @doc Confirm all authentication methods work for the three supported
 %%      releases.
 confirm() ->
-    %% Verify authentication method 'none'.
-    verify_authentication(legacy,   ?RC_AUTH_NONE_CONFIG),
-    verify_authentication(previous, ?RC_AUTH_NONE_CONFIG),
+    TestVersions = [current, previous, legacy],
+    [determine_test_suite(Vsn) || Vsn <- TestVersions],
+    pass.
 
-    %% Verify authentication method 'userlist'.
-    verify_authentication(legacy,   ?RC_AUTH_USERLIST_CONFIG),
-    verify_authentication(previous, ?RC_AUTH_USERLIST_CONFIG),
+%% @doc Determine if current, legacy or previous is a Riak 2.0+
+%% version or not and test accordingly.
+-spec(determine_test_suite(atom()) -> fun()).
+determine_test_suite(Vsn) ->
+    VersionBinary = rt:get_version(Vsn),
+    case VersionBinary of
+        <<"riak_ee-2.", _/binary>> ->
+            verify_authentication_post20(Vsn);
+        <<"riak-2.", _/binary>> ->
+            verify_authentication_post20(Vsn);
+        _ ->
+            verify_authentication_pre20(Vsn)
+    end.
 
+%% @doc Test authentication methods for versions since Riak 2.0
+-spec(verify_authentication_post20(atom()) -> ok).
+verify_authentication_post20(Vsn) ->
     %% Verify authentication none, and then with forced SSL.
-    verify_authentication(current,  ?RC_AUTH_NONE_CONFIG),
-    verify_authentication(current,  ?RC_AUTH_NONE_CONFIG_FORCE_SSL),
+    verify_authentication(Vsn, ?RC_AUTH_NONE_CONFIG),
+    verify_authentication(Vsn, ?RC_AUTH_NONE_CONFIG_FORCE_SSL),
 
     %% Verify authentication userlist, without SSL and then with SSL.
-    verify_authentication(current,  ?RC_AUTH_USERLIST_CONFIG_FORCE_SSL),
-    verify_authentication(current,  ?RC_AUTH_USERLIST_CONFIG_NO_FORCE_SSL).
+    verify_authentication(Vsn, ?RC_AUTH_USERLIST_CONFIG_FORCE_SSL),
+    verify_authentication(Vsn, ?RC_AUTH_USERLIST_CONFIG_NO_FORCE_SSL),
+    ok.
+
+%% @doc Test authentication methods for versions before Riak 2.0
+-spec(verify_authentication_pre20(atom()) -> ok).
+verify_authentication_pre20(Vsn) ->
+    %% Verify authentication method 'none'.
+    verify_authentication(Vsn, ?RC_AUTH_NONE_CONFIG),
+
+    %% Verify authentication method 'userlist'.
+    verify_authentication(Vsn, ?RC_AUTH_USERLIST_CONFIG),
+    ok.
 
 %% @doc Verify the disabled authentication method works.
 verify_authentication(Vsn, ?RC_AUTH_NONE_CONFIG) ->
@@ -115,9 +139,9 @@ verify_authentication(Vsn, ?RC_AUTH_NONE_CONFIG) ->
 
     pass;
 %% @doc Verify the disabled authentication method works with force SSL.
-verify_authentication(current, ?RC_AUTH_NONE_CONFIG_FORCE_SSL) ->
-    lager:info("Verifying auth 'none', 'force_ssl' 'true', current."),
-    Nodes =   build_singleton_cluster(current, 
+verify_authentication(Vsn, ?RC_AUTH_NONE_CONFIG_FORCE_SSL) ->
+    lager:info("Verifying auth 'none', 'force_ssl' 'true', ~p.", [Vsn]),
+    Nodes =   build_singleton_cluster(Vsn,
                                       ?RC_AUTH_NONE_CONFIG_FORCE_SSL),
     Node =    lists:nth(1, Nodes),
 
@@ -161,9 +185,9 @@ verify_authentication(Vsn, ?RC_AUTH_USERLIST_CONFIG) ->
 
     pass;
 %% @doc Verify the userlist authentication method works.
-verify_authentication(current, ?RC_AUTH_USERLIST_CONFIG_FORCE_SSL) ->
-    lager:info("Verifying auth 'userlist', 'force_ssl' 'true', current."),
-    Nodes =   build_singleton_cluster(current, ?RC_AUTH_USERLIST_CONFIG_FORCE_SSL),
+verify_authentication(Vsn, ?RC_AUTH_USERLIST_CONFIG_FORCE_SSL) ->
+    lager:info("Verifying auth 'userlist', 'force_ssl' 'true', ~p.", [Vsn]),
+    Nodes =   build_singleton_cluster(Vsn, ?RC_AUTH_USERLIST_CONFIG_FORCE_SSL),
     Node =    lists:nth(1, Nodes),
 
     %% Assert that we get redirected if we hit the HTTP port.
@@ -188,9 +212,9 @@ verify_authentication(current, ?RC_AUTH_USERLIST_CONFIG_FORCE_SSL) ->
 
     pass;
 %% @doc Verify the userlist authentication method works.
-verify_authentication(current, ?RC_AUTH_USERLIST_CONFIG_NO_FORCE_SSL) ->
-    lager:info("Verifying auth 'userlist', 'force_ssl' 'false', current."),
-    Nodes =   build_singleton_cluster(current, ?RC_AUTH_USERLIST_CONFIG_NO_FORCE_SSL),
+verify_authentication(Vsn, ?RC_AUTH_USERLIST_CONFIG_NO_FORCE_SSL) ->
+    lager:info("Verifying auth 'userlist', 'force_ssl' 'false', ~p.", [Vsn]),
+    Nodes =   build_singleton_cluster(Vsn, ?RC_AUTH_USERLIST_CONFIG_NO_FORCE_SSL),
     Node =    lists:nth(1, Nodes),
 
     %% Assert that we can access resource over the SSL port.


### PR DESCRIPTION
- Use the actual version string (e.g. riak_ee-2.1.2) of devrel
  instead of "current", "previous", "legacy" to determine which
  tests to run
- Add rt:get_version/1 to find the version of devrels other than
  "current"