### PR TITLE
Bugfix/jdm/cluster does not converge race

### DIFF
--- a/src/rt.erl
+++ b/src/rt.erl
@@ -328,6 +328,9 @@ deploy_nodes(Versions, Services) ->
                                               Service <- Services ],
     Nodes.
 
+deploy_nodes(NumNodes, InitialConfig, Services) when is_list(hd(InitialConfig)), is_integer(NumNodes) ->
+    NodeConfig = [{current, Config} || Config <- InitialConfig],
+    deploy_nodes(NodeConfig, Services);
 deploy_nodes(NumNodes, InitialConfig, Services) when is_integer(NumNodes) ->
     NodeConfig = [{current, InitialConfig} || _ <- lists:seq(1,NumNodes)],
     deploy_nodes(NodeConfig, Services).

--- a/src/rt.erl
+++ b/src/rt.erl
@@ -328,9 +328,6 @@ deploy_nodes(Versions, Services) ->
                                               Service <- Services ],
     Nodes.
 
-deploy_nodes(NumNodes, InitialConfig, Services) when is_list(hd(InitialConfig)), is_integer(NumNodes) ->
-    NodeConfig = [{current, Config} || Config <- InitialConfig],
-    deploy_nodes(NodeConfig, Services);
 deploy_nodes(NumNodes, InitialConfig, Services) when is_integer(NumNodes) ->
     NodeConfig = [{current, InitialConfig} || _ <- lists:seq(1,NumNodes)],
     deploy_nodes(NodeConfig, Services).

--- a/src/rt.erl
+++ b/src/rt.erl
@@ -411,19 +411,15 @@ join(Node, PNode) ->
     ?assertEqual(ok, R),
     ok.
 
-retry_if_join_error({error, node_still_starting}, _Fun, 0) ->
-    {error, too_many_retries};
-retry_if_join_error({error, node_still_starting}, Fun, RetryCount) ->
-    lager:warning("Join error because node is not yet ready, retrying in 500ms"),
-    timer:sleep(500),
-    retry_if_join_error(Fun(), Fun, RetryCount - 1);
-retry_if_join_error(ok, _Fun, _RetryCount) ->
-    ok.
-
 %% @doc Have `Node' send a join request to `PNode'
 staged_join(Node, PNode) ->
-    F = fun() -> rpc:call(Node, riak_core, staged_join, [PNode]) end,
-    R = retry_if_join_error(F(), F, 5),
+    %% `riak_core:staged_join/1' can now return an `{error,
+    %% node_still_starting}' tuple which indicates retry. `wait_until'
+    %% isn't smart enough to retry only on that tuple, but it's good
+    %% enough
+    R = wait_until(fun() -> lager:info("Trying staged_join"),
+                            rpc:call(Node, riak_core, staged_join,
+                                     [PNode]) == ok end),
     lager:info("[join] ~p to (~p): ~p", [Node, PNode, R]),
     ?assertEqual(ok, R),
     ok.

--- a/tests/verify_build_cluster_caps_race.erl
+++ b/tests/verify_build_cluster_caps_race.erl
@@ -1,0 +1,85 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2012 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(verify_build_cluster_caps_race).
+-behavior(riak_test).
+-export([confirm/0]).
+-include_lib("eunit/include/eunit.hrl").
+
+-import(rt, [wait_until_nodes_ready/1,
+             wait_until_no_pending_changes/1]).
+
+-define(NEVER_LIMIT, {0, 1000000000}).
+-define(ONCE_LIMIT, {1, 1000000000}).
+-define(STORM_LIMIT, {1000, 10000}). % 1000 / 10 secs
+
+confirm() ->
+    %% Deploy a set of new nodes
+    lager:info("Deploying nodes"),
+
+    %% Disable gossip by starving it of tokens.
+    %% Gossip messages can be triggered by sending 'reset_tokens'
+    %% message to riak_core_gossip
+
+    Config = [{riak_core, [{gossip_limit, ?NEVER_LIMIT}]}], 
+    [Node1, Node2] = Nodes = rt:deploy_nodes(2, Config),
+
+    %% Speed failure up a bit
+    rt_config:set(rt_max_wait_time, timer:seconds(120)),
+    rt_config:set(rt_retry_delay, 500),
+
+    lager:info("joining Node 2 to the cluster and limiting gossip..."),
+    ok = rt:staged_join(Node2, Node1),
+    give_token(Node2), % allow the join message to reach
+    ok = rt:plan_and_commit(Node1),
+
+    lager:info("setting bogus capability on both sides"),
+    [set_bogus_cap(N) || N <- Nodes],
+
+    %% Make sure the ring is *not* ready on all nodes
+    [?assertEqual(false, rt:is_ring_ready(N)) || N <- Nodes],
+
+    lager:info("re-enabling gossip"),
+    [set_gossip_limit(N, ?STORM_LIMIT) || N <- Nodes],
+
+    %% Look for a happy cluster
+    ?assertEqual(ok, rt:wait_until_nodes_ready(Nodes)),
+    ?assertEqual(ok, rt:wait_until_nodes_agree_about_ownership(Nodes)),
+    ?assertEqual(ok, wait_until_no_pending_changes(Nodes)),
+
+    pass.
+
+%% gossip(From, To) ->
+%%     %% First, give the lucky node a token
+%%     ok = give_token(From),
+
+%%     %% Then trigger the gossip
+%%     rpc:call(From, riak_core_gossip, send_ring_to, [From, To]).
+
+give_token(From) ->
+    set_gossip_limit(From, ?ONCE_LIMIT),
+    ok.
+
+set_gossip_limit(Node, Limit) ->
+    lager:info("Setting ~p gossip limit to ~p\n", [Node, Limit]),
+    ok = rpc:call(Node, application, set_env, [riak_core, gossip_limit, Limit]),
+    reset_tokens = rpc:call(Node, erlang, send, [{riak_core_gossip, Node}, reset_tokens]).
+
+set_bogus_cap(Node) ->
+    ok = rpc:call(Node, riak_core_capability, register, [{riak_core, herding},[goats,cats],cats]).

--- a/tests/verify_build_cluster_caps_race.erl
+++ b/tests/verify_build_cluster_caps_race.erl
@@ -37,8 +37,11 @@ confirm() ->
     %% Gossip messages can be triggered by sending 'reset_tokens'
     %% message to riak_core_gossip
 
-    Config = [{riak_core, [{gossip_limit, ?NEVER_LIMIT}]}], 
-    [Node1, Node2] = Nodes = rt:deploy_nodes(2, Config),
+    Configs = [
+               [{riak_core, [{gossip_limit, ?NEVER_LIMIT}]}],
+               [{riak_core, [{gossip_limit, ?NEVER_LIMIT},{delayed_start, 2500}]}]
+              ],
+    [Node1, Node2] = Nodes = rt:deploy_nodes(2, Configs),
 
     %% Speed failure up a bit
     rt_config:set(rt_max_wait_time, timer:seconds(120)),
@@ -49,8 +52,8 @@ confirm() ->
     give_token(Node2), % allow the join message to reach
     ok = rt:plan_and_commit(Node1),
 
-    lager:info("setting bogus capability on both sides"),
-    [set_bogus_cap(N) || N <- Nodes],
+    %% lager:info("setting bogus capability on both sides"),
+    %% [set_bogus_cap(N) || N <- Nodes],
 
     %% Make sure the ring is *not* ready on all nodes
     [?assertEqual(false, rt:is_ring_ready(N)) || N <- Nodes],
@@ -81,5 +84,5 @@ set_gossip_limit(Node, Limit) ->
     ok = rpc:call(Node, application, set_env, [riak_core, gossip_limit, Limit]),
     reset_tokens = rpc:call(Node, erlang, send, [{riak_core_gossip, Node}, reset_tokens]).
 
-set_bogus_cap(Node) ->
-    ok = rpc:call(Node, riak_core_capability, register, [{riak_core, herding},[goats,cats],cats]).
+%% set_bogus_cap(Node) ->
+%%     ok = rpc:call(Node, riak_core_capability, register, [{riak_core, herding},[goats,cats],cats]).

--- a/tests/verify_build_cluster_caps_race.erl
+++ b/tests/verify_build_cluster_caps_race.erl
@@ -25,64 +25,31 @@
 -import(rt, [wait_until_nodes_ready/1,
              wait_until_no_pending_changes/1]).
 
--define(NEVER_LIMIT, {0, 1000000000}).
--define(ONCE_LIMIT, {1, 1000000000}).
--define(STORM_LIMIT, {1000, 10000}). % 1000 / 10 secs
+%% We have to define our own deploy_nodes to force a race condition
+-define(HARNESS, (rt_config:get(rt_harness))).
+
+deploy_nodes(InitialConfig) ->
+    NodeConfig = [{current, Config} || Config <- InitialConfig],
+    Nodes = ?HARNESS:deploy_nodes(NodeConfig),
+    lager:info("Start nodes ~p without waiting for services", [Nodes]),
+    Nodes.
+
+staged_join(InitiatingNode, DestinationNode) ->
+    rpc:call(InitiatingNode, riak_core, staged_join,
+             [DestinationNode]).
 
 confirm() ->
     %% Deploy a set of new nodes
     lager:info("Deploying nodes"),
 
-    %% Disable gossip by starving it of tokens.
-    %% Gossip messages can be triggered by sending 'reset_tokens'
-    %% message to riak_core_gossip
-
+    %% We want riak_core to be slow to start on node 2 to verify that
+    %% the join will be disallowed if init is not yet complete
     Configs = [
-               [{riak_core, [{gossip_limit, ?NEVER_LIMIT}]}],
-               [{riak_core, [{gossip_limit, ?NEVER_LIMIT},{delayed_start, 2500}]}]
+               [{riak_core, []}],
+               [{riak_core, [{delayed_start, 2500}]}]
               ],
-    [Node1, Node2] = Nodes = rt:deploy_nodes(2, Configs),
+    [Node1, Node2] = deploy_nodes(Configs),
 
-    %% Speed failure up a bit
-    rt_config:set(rt_max_wait_time, timer:seconds(120)),
-    rt_config:set(rt_retry_delay, 500),
-
-    lager:info("joining Node 2 to the cluster and limiting gossip..."),
-    ok = rt:staged_join(Node2, Node1),
-    give_token(Node2), % allow the join message to reach
-    ok = rt:plan_and_commit(Node1),
-
-    %% lager:info("setting bogus capability on both sides"),
-    %% [set_bogus_cap(N) || N <- Nodes],
-
-    %% Make sure the ring is *not* ready on all nodes
-    [?assertEqual(false, rt:is_ring_ready(N)) || N <- Nodes],
-
-    lager:info("re-enabling gossip"),
-    [set_gossip_limit(N, ?STORM_LIMIT) || N <- Nodes],
-
-    %% Look for a happy cluster
-    ?assertEqual(ok, rt:wait_until_nodes_ready(Nodes)),
-    ?assertEqual(ok, rt:wait_until_nodes_agree_about_ownership(Nodes)),
-    ?assertEqual(ok, wait_until_no_pending_changes(Nodes)),
-
+    lager:info("joining Node 2 to the cluster..."),
+    ?assertMatch({error, _}, staged_join(Node2, Node1)),
     pass.
-
-%% gossip(From, To) ->
-%%     %% First, give the lucky node a token
-%%     ok = give_token(From),
-
-%%     %% Then trigger the gossip
-%%     rpc:call(From, riak_core_gossip, send_ring_to, [From, To]).
-
-give_token(From) ->
-    set_gossip_limit(From, ?ONCE_LIMIT),
-    ok.
-
-set_gossip_limit(Node, Limit) ->
-    lager:info("Setting ~p gossip limit to ~p\n", [Node, Limit]),
-    ok = rpc:call(Node, application, set_env, [riak_core, gossip_limit, Limit]),
-    reset_tokens = rpc:call(Node, erlang, send, [{riak_core_gossip, Node}, reset_tokens]).
-
-%% set_bogus_cap(Node) ->
-%%     ok = rpc:call(Node, riak_core_capability, register, [{riak_core, herding},[goats,cats],cats]).

--- a/tests/verify_build_cluster_caps_race.erl
+++ b/tests/verify_build_cluster_caps_race.erl
@@ -28,6 +28,7 @@
 %% We have to define our own deploy_nodes to force a race condition
 -define(HARNESS, (rt_config:get(rt_harness))).
 
+
 deploy_nodes(InitialConfig) ->
     NodeConfig = [{current, Config} || Config <- InitialConfig],
     Nodes = ?HARNESS:deploy_nodes(NodeConfig),
@@ -46,8 +47,9 @@ confirm() ->
     %% the join will be disallowed if init is not yet complete
     Configs = [
                [{riak_core, []}],
-               [{riak_core, [{delayed_start, 2500}]}]
+               [{riak_core, [{delayed_start, 20000}]}]
               ],
+
     [Node1, Node2] = deploy_nodes(Configs),
 
     lager:info("joining Node 2 to the cluster..."),


### PR DESCRIPTION
Two changes:
* Test for race condition identified in riak_core#764
* Use new error tuple created in riak_core#764 to recognize premature join and retry
