### PR TITLE
Fix riak_control to check the correct devrel version

### DIFF
--- a/tests/riak_control.erl
+++ b/tests/riak_control.erl
@@ -112,7 +112,7 @@ verify_control({Vsn, Node}, VersionedNodes) ->
                 [{<<"partitions">>, NodePartitions}]} = verify_resource(Node, "/admin/partitions"),
             NodePartitions
     end,
-    validate_partitions({previous, Node}, Partitions, VersionedNodes),
+    validate_partitions({Vsn, Node}, Partitions, VersionedNodes),
 
     ok.
 


### PR DESCRIPTION
Looks like this case worked for 2.1, but not for 2.0. This now should work for both.