### PR TITLE
wrap contents of tests/proxy_overload_recovery in -ifdef(EQC)

### DIFF
--- a/tests/proxy_overload_recovery.erl
+++ b/tests/proxy_overload_recovery.erl
@@ -31,6 +31,8 @@
 %% 2) Remove the riak_kv dependency so it's a pure riak_core test.
 
 -module(proxy_overload_recovery).
+-behaviour(riak_test).
+
 -ifdef(EQC).
 -include_lib("eqc/include/eqc.hrl").
 -include_lib("eqc/include/eqc_statem.hrl").

--- a/tests/proxy_overload_recovery.erl
+++ b/tests/proxy_overload_recovery.erl
@@ -31,6 +31,7 @@
 %% 2) Remove the riak_kv dependency so it's a pure riak_core test.
 
 -module(proxy_overload_recovery).
+-ifdef(EQC).
 -include_lib("eqc/include/eqc.hrl").
 -include_lib("eqc/include/eqc_statem.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -444,3 +445,13 @@ add_eqc_apps(Nodes) ->
              end
      end || App <- Apps, Node <- Nodes],
     ok.
+
+-else.  %% no EQC
+
+-export([confirm/0]).
+
+confirm() ->
+    lager:info("EQC not enabled, skipping test"),
+    pass.
+
+-endif.


### PR DESCRIPTION
andalso, provide the missing `-behaviour(riak_test).`.