### PR TITLE
Backport PR #791 to address disconnection in riak667_mixed

### DIFF
--- a/tests/riak667_mixed.erl
+++ b/tests/riak667_mixed.erl
@@ -85,7 +85,7 @@ confirm() ->
 
     %% Create PB connection.
     Pid2 = rt:pbc(Node2),
-    riakc_pb_socket:set_options(Pid2, [queue_if_disconnected]),
+    riakc_pb_socket:set_options(Pid2, [queue_if_disconnected, auto_reconnect]),
 
     %% Read value.
     ?assertMatch({error, <<"Error processing incoming message: error:{badrecord,dict}", _/binary>>},


### PR DESCRIPTION
This is simply a backport of https://github.com/basho/riak_test/pull/791 to the `riak/2.0` branch.