### PR TITLE
Allow devrels to be specified as atoms or string

### DIFF
--- a/src/rt.erl
+++ b/src/rt.erl
@@ -102,7 +102,6 @@
          pbc_put_dir/3,
          pbc_put_file/4,
          pbc_really_deleted/3,
-         pmap/2,
          post_result/2,
          product/1,
          priv_dir/0,
@@ -977,7 +976,7 @@ all_aae_trees_built(Node, Partitions) ->
     %% Notice that the process locking is spawned by the
     %% pmap. That's important! as it should die eventually
     %% so the lock is released and the test can lock the tree.
-    IndexBuilts = rt:pmap(index_built_fun(Node), Partitions),
+    IndexBuilts = rt_util:pmap(index_built_fun(Node), Partitions),
     BadOnes = [R || R <- IndexBuilts, R /= true],
     case BadOnes of
         [] ->
@@ -1728,20 +1727,6 @@ log_to_nodes(Nodes0, LFmt, LArgs) ->
                _  -> [info, Meta, "---riak_test--- " ++ LFmt, LArgs]
            end,
     [rpc:call(Node, Module, Function, Args) || Node <- lists:flatten(Nodes)].
-
-%% @private utility function
-pmap(F, L) ->
-    Parent = self(),
-    lists:foldl(
-      fun(X, N) ->
-              spawn_link(fun() ->
-                            Parent ! {pmap, N, F(X)}
-                    end),
-              N+1
-      end, 0, L),
-    L2 = [receive {pmap, N, R} -> {N,R} end || _ <- L],
-    {_, L3} = lists:unzip(lists:keysort(1, L2)),
-    L3.
 
 %% @private
 setup_harness(Test, Args) ->

--- a/src/rt_bench.erl
+++ b/src/rt_bench.erl
@@ -25,7 +25,7 @@ bench(Config, NodeList, TestName, Runners, Drop) ->
                         lager:info("Dropped cache for node: ~p ret: ~p",
                                    [Node, R])
                 end,
-            rt:pmap(Fun, NodeList);
+            rt_util:pmap(Fun, NodeList);
         _ -> ok
     end,
 

--- a/src/rt_cover.erl
+++ b/src/rt_cover.erl
@@ -346,7 +346,7 @@ write_coverage(CoverModules, CoverDir) ->
     erlang:group_leader(Pid, whereis(cover_server)),
     % First write a file per module
     prepare_output_dir(CoverDir),
-    ModCovList0 = rt:pmap(fun(Mod) -> process_module(Mod, CoverDir) end,
+    ModCovList0 = rt_util:pmap(fun(Mod) -> process_module(Mod, CoverDir) end,
                           CoverModules),
     % Create data struct with total, per app and per module coverage
     ModCovList = lists:filter(fun not_empty_file/1, ModCovList0),

--- a/src/rt_cs_dev.erl
+++ b/src/rt_cs_dev.erl
@@ -35,7 +35,7 @@ setup_harness(_Test, _Args) ->
     confirm_build_type(rt_config:get(build_type, oss)),
     Path = relpath(root),
     %% Stop all discoverable nodes, not just nodes we'll be using for this test.
-    rt:pmap(fun(X) -> stop_all(X ++ "/dev") end, devpaths()),
+    rt_util:pmap(fun(X) -> stop_all(X ++ "/dev") end, devpaths()),
 
     %% Reset nodes to base state
     lager:info("Resetting nodes to fresh state"),
@@ -43,7 +43,7 @@ setup_harness(_Test, _Args) ->
     rtdev:run_git(Path, "clean -fd"),
 
     lager:info("Cleaning up lingering pipe directories"),
-    rt:pmap(fun(Dir) ->
+    rt_util:pmap(fun(Dir) ->
                     %% when joining two absolute paths, filename:join intentionally
                     %% throws away the first one. ++ gets us around that, while
                     %% keeping some of the security of filename:join.
@@ -197,7 +197,7 @@ add_default_node_config(Nodes) ->
     case rt_config:get(rt_default_config, undefined) of
         undefined -> ok;
         Defaults when is_list(Defaults) ->
-            rt:pmap(fun(Node) ->
+            rt_util:pmap(fun(Node) ->
                             update_app_config(Node, Defaults)
                     end, Nodes),
             ok;
@@ -225,7 +225,7 @@ deploy_nodes(NodeConfig) ->
 
     %% Set initial config
     add_default_node_config(Nodes),
-    rt:pmap(fun({_, default}) ->
+    rt_util:pmap(fun({_, default}) ->
                     ok;
                ({Node, Config}) ->
                     update_app_config(Node, Config)
@@ -237,7 +237,7 @@ deploy_nodes(NodeConfig) ->
 
     %% Start nodes
     %%[run_riak(N, relpath(node_version(N)), "start") || N <- Nodes],
-    rt:pmap(fun(N) -> rtdev:run_riak(N, relpath(node_version(N)), "start") end, NodesN),
+    rt_util:pmap(fun(N) -> rtdev:run_riak(N, relpath(node_version(N)), "start") end, NodesN),
 
     %% Ensure nodes started
     [ok = rt:wait_until_pingable(N) || N <- Nodes],
@@ -480,7 +480,7 @@ get_version() ->
 
 teardown() ->
     %% Stop all discoverable nodes, not just nodes we'll be using for this test.
-    rt:pmap(fun(X) -> stop_all(X ++ "/dev") end,
+    rt_util:pmap(fun(X) -> stop_all(X ++ "/dev") end,
             devpaths()).
 
 whats_up() ->

--- a/src/rt_intercept.erl
+++ b/src/rt_intercept.erl
@@ -46,8 +46,8 @@ load_intercepts(Nodes, Globs) ->
             ok;
         true ->
             Intercepts = rt_config:get(intercepts, []),
-            rt:pmap(fun(N) -> load_code(N, Globs) end, Nodes),
-            rt:pmap(fun(N) -> add(N, Intercepts) end, Nodes),
+            rt_util:pmap(fun(N) -> load_code(N, Globs) end, Nodes),
+            rt_util:pmap(fun(N) -> add(N, Intercepts) end, Nodes),
             ok
     end.
 

--- a/src/rt_util.erl
+++ b/src/rt_util.erl
@@ -1,0 +1,141 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(rt_util).
+-include_lib("eunit/include/eunit.hrl").
+
+-export([convert_to_atom/1,
+         convert_to_atom_list/1,
+         convert_to_string/1,
+         find_atom_or_string/2,
+         find_atom_or_string_dict/2,
+         pmap/2]).
+
+%% @doc Look up values by both atom and by string
+find_atom_or_string(Key, Table) ->
+    case {Key, proplists:get_value(Key, Table)} of
+        {_, undefined} when is_atom(Key) ->
+            proplists:get_value(atom_to_list(Key), Table);
+        {_, undefined} when is_list(Key) ->
+            proplists:get_value(list_to_atom(Key), Table);
+        {Key, Value} ->
+            Value
+    end.
+
+%% @doc Look up values in an orddict by both atom and by string
+-spec find_atom_or_string(term(), orddict:orddict()) -> term() | undefined.
+find_atom_or_string_dict(Key, Dict) ->
+    case {Key, orddict:is_key(Key, Dict)} of
+        {_, false} when is_atom(Key) ->
+            case orddict:is_key(atom_to_list(Key), Dict) of
+                true -> orddict:fetch(atom_to_list(Key), Dict);
+                _ -> undefined
+            end;
+        {_, false} when is_list(Key) ->
+            case orddict:is_key(list_to_atom(Key), Dict) of
+                true -> orddict:fetch(list_to_atom(Key), Dict);
+                _ -> undefined
+            end;
+        {_, true} ->
+            orddict:fetch(Key, Dict)
+    end.
+
+%% @doc: Convert an atom to a string if it is not already
+-spec convert_to_string(string()|atom()) -> string().
+convert_to_string(Val) when is_atom(Val) ->
+    atom_to_list(Val);
+convert_to_string(Val) when is_list(Val) ->
+    Val.
+
+%% @doc: Convert a string to an atom if it is not already
+-spec convert_to_atom(string()|atom()) -> atom().
+convert_to_atom(Val) when is_list(Val) ->
+    list_to_atom(Val);
+convert_to_atom(Val) ->
+    Val.
+
+%% @doc Convert string or atom to list of atoms
+-spec convert_to_atom_list(atom()|string()) -> undefined | list().
+convert_to_atom_list(undefined) ->
+    undefined;
+convert_to_atom_list(Values) when is_atom(Values) ->
+    ListOfValues = atom_to_list(Values),
+    case lists:member($, , ListOfValues) of
+        true ->
+            [list_to_atom(X) || X <- string:tokens(ListOfValues, ", ")];
+        _ ->
+            [Values]
+    end;
+convert_to_atom_list(Values) when is_list(Values) ->
+    case lists:member($, , Values) of
+        true ->
+            [list_to_atom(X) || X <- string:tokens(Values, ", ")];
+        _ ->
+            [list_to_atom(Values)]
+    end.
+
+%% @doc Parallel Map: Runs function F for each item in list L, then
+%%      returns the list of results
+-spec pmap(F :: fun(), L :: list()) -> list().
+pmap(F, L) ->
+    Parent = self(),
+    lists:foldl(
+    fun(X, N) ->
+          spawn_link(fun() ->
+                        Parent ! {pmap, N, F(X)}
+                end),
+          N+1
+    end, 0, L),
+    L2 = [receive {pmap, N, R} -> {N,R} end || _ <- L],
+    {_, L3} = lists:unzip(lists:keysort(1, L2)),
+    L3.
+
+-ifdef(TEST).
+
+%% Look up values in a proplist by either a string or atom
+find_atom_to_string_test() ->
+    ?assertEqual(undefined, find_atom_or_string(value, [{a,1},{b,2}])),
+    ?assertEqual(undefined, find_atom_or_string("value", [{a,1},{b,2}])),
+    ?assertEqual(1, find_atom_or_string(a, [{a,1},{b,2}])),
+    ?assertEqual(1, find_atom_or_string("a", [{a,1},{b,2}])).
+
+%% Look up values in an orddict by either a string or atom
+find_atom_to_string_dict_test() ->
+    Dict = [{a,"a"},{"b",b}],
+    ?assertEqual(undefined, find_atom_or_string_dict(value, Dict)),
+    ?assertEqual(undefined, find_atom_or_string_dict("value", Dict)),
+    ?assertEqual("a", find_atom_or_string(a, Dict)),
+    ?assertEqual(b, find_atom_or_string("b", Dict)).
+
+%% Convert a string to an atom, otherwise it remains unchanged
+convert_to_atom_test() ->
+    ?assertEqual(a, convert_to_atom(a)),
+    ?assertEqual(a, convert_to_atom("a")),
+    ?assertEqual(1, convert_to_atom(1)).
+
+%% Properly covert backends to atoms
+convert_to_atom_list_test() ->
+    ?assertEqual(undefined, convert_to_atom_list(undefined)),
+    ?assertEqual([memory], convert_to_atom_list(memory)),
+    ?assertEqual([memory], convert_to_atom_list("memory")),
+    ?assertEqual([bitcask, eleveldb, memory], lists:sort(convert_to_atom_list("memory, bitcask,eleveldb"))),
+    ?assertEqual([bitcask, eleveldb, memory], lists:sort(convert_to_atom_list('memory, bitcask,eleveldb'))).
+
+-endif.

--- a/src/rtperf.erl
+++ b/src/rtperf.erl
@@ -323,7 +323,7 @@ deploy_nodes(NodeConfig, Hosts) ->
         orddict:from_list(
             orddict:to_list(rt_config:get(rt_versions, orddict:new())) ++ VersionMap)),
 
-    rt:pmap(fun({Node, _}) ->
+    rt_util:pmap(fun({Node, _}) ->
                 {ok,
                  {_, _, _, _, _, [IP0|_]}} = inet:gethostbyname(
                         rtssh:node_to_host(Node)),
@@ -336,7 +336,7 @@ deploy_nodes(NodeConfig, Hosts) ->
         end, lists:zip(Nodes, Configs)),
     timer:sleep(500),
 
-    rt:pmap(fun({_, default}) ->
+    rt_util:pmap(fun({_, default}) ->
                 lager:info("Default configuration detected!"),
                 ok;
                ({Node, {cuttlefish, Config}}) ->
@@ -351,7 +351,7 @@ deploy_nodes(NodeConfig, Hosts) ->
 
     case rt_config:get(cuttle, true) of
         false ->
-            rt:pmap(fun(Node) ->
+            rt_util:pmap(fun(Node) ->
                             Host = rtssh:get_host(Node),
                             Config = [{riak_api,
                                        [{pb, fun([{_, Port}]) ->
@@ -369,7 +369,7 @@ deploy_nodes(NodeConfig, Hosts) ->
 
             timer:sleep(500),
 
-            rt:pmap(fun(Node) ->
+            rt_util:pmap(fun(Node) ->
                             rtssh:update_vm_args(Node,
                                                 [{"-name", Node},
                                                  {"-zddbl", "65535"},
@@ -382,7 +382,7 @@ deploy_nodes(NodeConfig, Hosts) ->
 
     rtssh:create_dirs(Nodes),
 
-    rt:pmap(fun start/1, Nodes),
+    rt_util:pmap(fun start/1, Nodes),
 
     %% Ensure nodes started
     [ok = rt:wait_until_pingable(N) || N <- Nodes],

--- a/tests/overload.erl
+++ b/tests/overload.erl
@@ -107,7 +107,7 @@ test_vnode_protection(Nodes, BKV, ConsistentType) ->
     lager:info("Setting vnode check interval to 1"),
     Config = [{riak_core, [{vnode_overload_threshold, ?THRESHOLD},
                            {vnode_check_interval, 1}]}],
-    rt:pmap(fun(Node) ->
+    rt_util:pmap(fun(Node) ->
                     rt:update_app_config(Node, Config)
             end, Nodes),
     ProcFun = build_predicate_lt(test_vnode_protection, (?NUM_REQUESTS+1), "ProcFun", "Procs"),
@@ -139,7 +139,7 @@ test_fsm_protection(Nodes, BKV, ConsistentType) ->
     lager:info("Testing with coordinator protection enabled"),
     lager:info("Setting FSM limit to ~b", [?THRESHOLD]),
     Config = [{riak_kv, [{fsm_limit, ?THRESHOLD}]}],
-    rt:pmap(fun(Node) ->
+    rt_util:pmap(fun(Node) ->
                     rt:update_app_config(Node, Config)
             end, Nodes),
     ProcFun = build_predicate_lt(test_fsm_protection, (?NUM_REQUESTS),
@@ -159,7 +159,7 @@ test_cover_queries_overload(Nodes, _, false) ->
     Config = [{riak_core, [{vnode_overload_threshold, ?THRESHOLD},
                            {vnode_request_check_interval, 2},
                            {vnode_check_interval, 1}]}],
-    rt:pmap(fun(Node) ->
+    rt_util:pmap(fun(Node) ->
                     rt:update_app_config(Node, Config)
             end, Nodes),
 


### PR DESCRIPTION
Also add `rt_util.erl` with various utilities and move `pmap/2` into `rt_util`:
- `spec find_atom_or_string(term(), orddict:orddict()) -> term() | undefined.`
- `spec convert_to_string(string()|atom()) -> string().`
- `spec convert_to_atom(string()|atom()) -> atom().`
- `spec convert_to_atom_list(atom()|string()) -> undefined | list().`
- `spec pmap(F :: fun(), L :: list()) -> list().`