### PR TITLE
Backport #847 to fix issues with http_bucket_types

### DIFF
--- a/src/rt.erl
+++ b/src/rt.erl
@@ -1802,6 +1802,10 @@ create_and_activate_bucket_type(Node, Type, Props) ->
     ok = rpc:call(Node, riak_core_bucket_type, activate, [Type]),
     wait_until_bucket_type_status(Type, active, Node).
 
+create_activate_and_wait_for_bucket_type([Node|_Rest]=Cluster, Type, Props) ->
+    create_and_activate_bucket_type(Node, Type, Props),
+    wait_until_bucket_type_visible(Cluster, Type).
+
 wait_until_bucket_type_status(Type, ExpectedStatus, Nodes) when is_list(Nodes) ->
     [wait_until_bucket_type_status(Type, ExpectedStatus, Node) || Node <- Nodes];
 wait_until_bucket_type_status(Type, ExpectedStatus, Node) ->

--- a/tests/http_bucket_types.erl
+++ b/tests/http_bucket_types.erl
@@ -101,10 +101,7 @@ confirm() ->
 
     lager:info("custom type get/put test"),
     %% create a new type
-    ok = rt:create_and_activate_bucket_type(Node, <<"mytype">>, [{n_val,3}]),
-
-    %% allow cluster metadata some time to propogate
-    timer:sleep(1000),
+    ok = rt:create_activate_and_wait_for_bucket_type(Nodes, <<"mytype">>, [{n_val,3}]),
 
     lager:info("doing put"),
     ok = rhc:put(RHC, riakc_obj:new({<<"mytype">>, <<"bucket">>},
@@ -136,7 +133,7 @@ confirm() ->
 
     UCBBin = {UnicodeTypeBin, UnicodeBucketBin},
 
-    ok = rt:create_and_activate_bucket_type(Node, UnicodeTypeBin, [{n_val,3}]),
+    ok = rt:create_activate_and_wait_for_bucket_type(Nodes, UnicodeTypeBin, [{n_val,3}]),
 
     lager:info("doing put"),
     ok = rhc:put(RHC, riakc_obj:new(UCBBin,
@@ -225,9 +222,7 @@ confirm() ->
 
     %% make sure a newly created type is not affected either
     %% create a new type
-    ok = rt:create_and_activate_bucket_type(Node, <<"mynewtype">>, []),
-    %% allow cluster metadata some time to propogate
-    timer:sleep(1000),
+    ok = rt:create_activate_and_wait_for_bucket_type(Nodes, <<"mynewtype">>, []),
 
     {ok, BProps11} = rhc:get_bucket_type(RHC, <<"mynewtype">>),
 


### PR DESCRIPTION
Added rt:create_activate_and_wait_for_bucket_type so that the test canspecify it wants all nodes in the cluster to have the type before continuing. Update http_bucket_types to use said function.

(cherry picked from commit 31b1002b3ec59c224ec7acf5267a73bf8070836c)