### PR TITLE
Fail by crashing test process instead of returning a tagged tuple

### DIFF
--- a/tests/verify_snmp_repl.erl
+++ b/tests/verify_snmp_repl.erl
@@ -68,14 +68,15 @@ wait_for_snmp_stat_poller() ->
             pass;
         {fail, Reason} ->
             lager:error("Failure in wait_for_snmp_stat_poller: ~p~n", [Reason]),
-            fail;
+            error({fail, Reason});
         X ->
             lager:error("Unknown failure in wait_for_snmp_stat_poller: ~p~n", [X]),
-            fail
+            error(X)
     after
         1000 ->
-            lager:error("Timeout failure in wait_for_snmp_stat_poller."),
-            fail
+            Message =  "Timeout waiting for snmp_stat_poller.",
+            lager:error(Message),
+            error({timeout, Message})
     end.
 
 make_nodes(NodeCount, ClusterCount, Config) ->

--- a/tests/verify_snmp_repl.erl
+++ b/tests/verify_snmp_repl.erl
@@ -64,11 +64,18 @@ intercept_riak_snmp_stat_poller(Node) ->
 
 wait_for_snmp_stat_poller() ->
     receive
-        pass -> pass;
-        {fail, Reason} -> {fail, Reason};
-        X -> {fail, {unknown, X}}
+        pass ->
+            pass;
+        {fail, Reason} ->
+            lager:error("Failure in wait_for_snmp_stat_poller: ~p~n", [Reason]),
+            fail;
+        X ->
+            lager:error("Unknown failure in wait_for_snmp_stat_poller: ~p~n", [X]),
+            fail
     after
-        1000 -> {fail, timeout}
+        1000 ->
+            lager:error("Timeout failure in wait_for_snmp_stat_poller."),
+            fail
     end.
 
 make_nodes(NodeCount, ClusterCount, Config) ->

--- a/tests/verify_snmp_repl.erl
+++ b/tests/verify_snmp_repl.erl
@@ -57,6 +57,7 @@ intercept_riak_snmp_stat_poller(Node) ->
                     RiakTestProcess ! pass
                 catch
                     Exception:Reason ->
+                        lager:error("Failure in riak_snmp_stat_poller_orig:set_rows_orig: ~p~n", [{Exception, Reason}]),
                         RiakTestProcess ! {fail, {Exception, Reason}},
                         error({Exception, Reason})
                 end


### PR DESCRIPTION
`riak_test_runner` does not support tagged tuples for failures. Fix verify_snmp_repl module so that it crashes when it fails, and write more detailed error messages to the log instead.