### PR TITLE
Add Script to Install Arbitrary devrel in Git repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,12 @@ to a release number, e.g. `2.0.0`.  It will automatically be prefixed with
 the repo name, e.g. `riak_ee-2.0.0`.  To use `riak_ee` instead of `riak` set [`$RT_USE_EE`](https://github.com/basho/riak_test/blob/master/bin/rtdev-setup-releases.sh#L23)
 to any non-empty string.
 
+### rtdev-install.sh
+
+`rtdev-install.sh` is exactly the same as `rtdev-current.sh`, however,
+you can use arbitrary names like `riak-2.1.2` instead of just `current`.
+The single argument supplied to this script is that directory name.
+
 ####  reset-current-env.sh
 
 `reset-current-env.sh` resets test environments setup using `rtdev-current.sh`

--- a/bin/rtdev-current.sh
+++ b/bin/rtdev-current.sh
@@ -1,38 +1,4 @@
 #!/usr/bin/env bash
-
-# bail out if things go south
-set -e
-
-: ${RT_DEST_DIR:="$HOME/rt/riak"}
-# If RT_CURRENT_TAG is specified, it will use that version number
-# otherwise the last annotated tag will be used
-: ${RT_CURRENT_TAG:=""}
-
-echo "Making $(pwd) the current release:"
-cwd=$(pwd)
-echo -n " - Determining version: "
-if [ -n "$RT_CURRENT_TAG" ]; then
-	VERSION=$RT_CURRENT_TAG
-elif [ -f $cwd/dependency_manifest.git ]; then
-    VERSION=`cat $cwd/dependency_manifest.git | awk '/^-/ { print $NF }'`
-else
-    VERSION="$(git describe --tags)-$(git branch | awk '/\*/ {print $2}')"
-fi
-echo $VERSION
-cd $RT_DEST_DIR
-echo " - Resetting existing $RT_DEST_DIR"
-export GIT_WORK_TREE="$RT_DEST_DIR"
-git reset HEAD --hard > /dev/null
-git clean -fd > /dev/null
-echo " - Removing and recreating $RT_DEST_DIR/current"
-rm -rf $RT_DEST_DIR/current
-mkdir $RT_DEST_DIR/current
-cd $cwd
-echo " - Copying devrel to $RT_DEST_DIR/current"
-cp -p -P -R dev $RT_DEST_DIR/current
-echo " - Writing $RT_DEST_DIR/current/VERSION"
-echo -n $VERSION > $RT_DEST_DIR/current/VERSION
-cd $RT_DEST_DIR
-echo " - Reinitializing git state"
-git add .
-git commit -a -m "riak_test init" --amend > /dev/null
+SCRIPT=$0
+DIR=${SCRIPT%/*}
+$DIR/rtdev-install.sh current

--- a/bin/rtdev-install.sh
+++ b/bin/rtdev-install.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# bail out if things go south
+set -e
+
+: ${RT_DEST_DIR:="$HOME/rt/riak"}
+if [[ $# < 1 ]]; then
+    echo "Missing release directory as argument, e.g. riak_ee-2.1.2"
+    exit 1
+fi
+RELEASE=$1
+
+echo "Making $(pwd) the $RELEASE release:"
+cwd=$(pwd)
+echo -n " - Determining version: "
+if [ -f $cwd/dependency_manifest.git ]; then
+    VERSION=`cat $cwd/dependency_manifest.git | awk '/^-/ { print $NF }'`
+else
+    VERSION="$(git describe --tags)-$(git branch | awk '/\*/ {print $2}')"
+fi
+if [[ "$RELEASE" == "current" && ! -z "$RT_CURRENT_TAG" ]]; then
+    VERSION=$RT_CURRENT_TAG
+fi
+echo $VERSION
+cd $RT_DEST_DIR
+echo " - Resetting existing $RT_DEST_DIR"
+export GIT_WORK_TREE="$RT_DEST_DIR"
+git reset HEAD --hard > /dev/null
+git clean -fd > /dev/null
+echo " - Removing and recreating $RT_DEST_DIR/$RELEASE"
+rm -rf $RT_DEST_DIR/$RELEASE
+mkdir $RT_DEST_DIR/$RELEASE
+cd $cwd
+echo " - Copying devrel to $RT_DEST_DIR/$RELEASE"
+cp -p -P -R dev $RT_DEST_DIR/$RELEASE
+echo " - Writing $RT_DEST_DIR/$RELEASE/VERSION"
+echo -n $VERSION > $RT_DEST_DIR/$RELEASE/VERSION
+cd $RT_DEST_DIR
+echo " - Reinitializing git state"
+git add .
+git commit -a -m "riak_test init" --amend > /dev/null


### PR DESCRIPTION
Currently `rtdev-current.sh` will conveniently copy the current devrel into the local riak_test git repository.  This new script, `rtdev-install.sh`, will allow it to be put in an arbitrary directory, e.g. `riak-2.0.6`.