### PR TITLE
Verify cluster stats in SNMP

### DIFF
--- a/tests/verify_snmp_repl.erl
+++ b/tests/verify_snmp_repl.erl
@@ -24,11 +24,17 @@
 -include_lib("eunit/include/eunit.hrl").
 -compile({parse_transform, rt_intercept_pt}).
 
+-define(FIRST_CLUSTER, "cluster-1").
+-define(OTHER_CLUSTERS, ["cluster-2", "cluster-3"]).
+-define(CLUSTERS, [?FIRST_CLUSTER] ++ ?OTHER_CLUSTERS).
+
 confirm() ->
-    Clusters = make_clusters(["cluster-1", "cluster-2", "cluster-3"], 1),
+    Clusters = make_clusters(?CLUSTERS, 1),
     [{_, Leader, _}|_] = Clusters,
     intercept_riak_snmp_stat_poller(Leader),
-    wait_for_snmp_stat_poller().
+    wait_for_snmp_stat_poller(),
+    verify_snmp_cluster_stats(Clusters),
+    pass.
 
 make_clusters(Names, NodeCount) ->
     ClusterCount = length(Names),
@@ -97,4 +103,18 @@ enable_realtime([{_, Node, _}|OtherClusters]) ->
             timer:sleep(1000)
         end,
         OtherClusters).
+
+%% snmpwalk gives the following output containing the OIDs we're interested in:
+%%   SNMPv2-SMI::enterprises.31130.200.1.1.1.99.108.117.115.116.101.114.45.50 = STRING: "cluster-2"
+%%   SNMPv2-SMI::enterprises.31130.200.1.1.1.99.108.117.115.116.101.114.45.51 = STRING: "cluster-3"
+-define(CLUSTER_OIDS,
+        [[1,3,6,1,4,1,31130,200,1,1,1,99,108,117,115,116,101,114,45] ++ [Tail]
+         || Tail <- [50, 51]]).
+
+verify_snmp_cluster_stats(Clusters) ->
+    [{_Name, Leader, [_Nodes]} | _Rest] = Clusters,
+    rpc:call(Leader, riak_core, wait_for_application, [snmp]),
+    rpc:call(Leader, riak_core, wait_for_application, [riak_snmp]),
+    ClusterJoins = rpc:call(Leader, snmpa, get, [snmp_master_agent, ?CLUSTER_OIDS]),
+    ?assertEqual(?OTHER_CLUSTERS, ClusterJoins).
 


### PR DESCRIPTION
Update verify_snmp_repl test to prove that cluster stats are correctly
recorded in SNMP.