### PR TITLE
Merge branch `riak/2.0` into `master` w/ some updates to yz_extractors along the way

### DIFF
--- a/src/yokozuna_rt.erl
+++ b/src/yokozuna_rt.erl
@@ -25,6 +25,7 @@
 -export([check_exists/2,
          commit/2,
          expire_trees/1,
+         gen_keys/1,
          host_entries/1,
          override_schema/5,
          remove_index_dirs/2,
@@ -35,6 +36,7 @@
          search_expect/5,
          search_expect/6,
          search_expect/7,
+         assert_search/6,
          verify_num_found_query/3,
          wait_for_aae/1,
          wait_for_full_exchange_round/2,
@@ -55,6 +57,14 @@
 -spec host_entries(rt:conn_info()) -> [{host(), portnum()}].
 host_entries(ClusterConnInfo) ->
     [riak_http(I) || {_,I} <- ClusterConnInfo].
+
+%% @doc Generate `SeqMax' keys. Yokozuna supports only UTF-8 compatible keys.
+-spec gen_keys(pos_integer()) -> list().
+gen_keys(SeqMax) ->
+    [<<N:64/integer>> || N <- lists:seq(1, SeqMax),
+                         not lists:any(
+                               fun(E) -> E > 127 end,
+                               binary_to_list(<<N:64/integer>>))].
 
 %% @doc Write `Keys' via the PB inteface to a `Bucket' and have them
 %%      searchable in an `Index'.
@@ -263,6 +273,20 @@ search_expect(solr, {Host, Port}, Index, Name0, Term0, Shards, Expect)
     Opts = [{response_format, binary}],
     {ok, "200", _, R} = ibrowse:send_req(URL, [], get, [], Opts),
     verify_count_http(Expect, R).
+
+assert_search(Pid, Cluster, Index, Search, SearchExpect, Params) ->
+    F = fun(_) ->
+                lager:info("Searching ~p and asserting it exists",
+                           [SearchExpect]),
+                {ok,{search_results,[{_Index,Fields}], _Score, Found}} =
+                    riakc_pb_socket:search(Pid, Index, Search, Params),
+                ?assert(lists:member(SearchExpect, Fields)),
+                case Found of
+                    1 -> true;
+                    0 -> false
+                end
+        end,
+    rt:wait_until(Cluster, F).
 
 search(HP, Index, Name, Term) ->
     search(yokozuna, HP, Index, Name, Term).

--- a/tests/verify_snmp_repl.erl
+++ b/tests/verify_snmp_repl.erl
@@ -24,11 +24,17 @@
 -include_lib("eunit/include/eunit.hrl").
 -compile({parse_transform, rt_intercept_pt}).
 
+-define(FIRST_CLUSTER, "cluster-1").
+-define(OTHER_CLUSTERS, ["cluster-2", "cluster-3"]).
+-define(CLUSTERS, [?FIRST_CLUSTER] ++ ?OTHER_CLUSTERS).
+
 confirm() ->
-    Clusters = make_clusters(["cluster-1", "cluster-2", "cluster-3"], 1),
+    Clusters = make_clusters(?CLUSTERS, 1),
     [{_, Leader, _}|_] = Clusters,
     intercept_riak_snmp_stat_poller(Leader),
-    wait_for_snmp_stat_poller().
+    wait_for_snmp_stat_poller(),
+    verify_snmp_cluster_stats(Clusters),
+    pass.
 
 make_clusters(Names, NodeCount) ->
     ClusterCount = length(Names),
@@ -106,4 +112,18 @@ enable_realtime([{_, Node, _}|OtherClusters]) ->
             timer:sleep(1000)
         end,
         OtherClusters).
+
+%% snmpwalk gives the following output containing the OIDs we're interested in:
+%%   SNMPv2-SMI::enterprises.31130.200.1.1.1.99.108.117.115.116.101.114.45.50 = STRING: "cluster-2"
+%%   SNMPv2-SMI::enterprises.31130.200.1.1.1.99.108.117.115.116.101.114.45.51 = STRING: "cluster-3"
+-define(CLUSTER_OIDS,
+        [[1,3,6,1,4,1,31130,200,1,1,1,99,108,117,115,116,101,114,45] ++ [Tail]
+         || Tail <- [50, 51]]).
+
+verify_snmp_cluster_stats(Clusters) ->
+    [{_Name, Leader, [_Nodes]} | _Rest] = Clusters,
+    rpc:call(Leader, riak_core, wait_for_application, [snmp]),
+    rpc:call(Leader, riak_core, wait_for_application, [riak_snmp]),
+    ClusterJoins = rpc:call(Leader, snmpa, get, [snmp_master_agent, ?CLUSTER_OIDS]),
+    ?assertEqual(?OTHER_CLUSTERS, ClusterJoins).
 

--- a/tests/verify_snmp_repl.erl
+++ b/tests/verify_snmp_repl.erl
@@ -102,7 +102,8 @@ wait_until_leader_converge({_Name, Nodes}) ->
 enable_realtime([{_, Node, _}|OtherClusters]) ->
     lists:foreach(
         fun({Cluster, _, _}) ->
-            repl_util:enable_realtime(Node, Cluster)
+            repl_util:enable_realtime(Node, Cluster),
+            timer:sleep(1000)
         end,
         OtherClusters).
 

--- a/tests/yz_core_properties_create_unload.erl
+++ b/tests/yz_core_properties_create_unload.erl
@@ -67,7 +67,7 @@ confirm() ->
     %% Write keys and wait for soft commit
     lager:info("Writing ~p keys", [KeyCount]),
     [ok = rt:pbc_write(Pid, ?BUCKET, Key, Key, "text/plain") || Key <- Keys],
-    timer:sleep(1100),
+    yokozuna_rt:commit(Cluster, ?INDEX),
 
     verify_count(Pid, KeyCount),
 
@@ -87,7 +87,7 @@ test_core_props_removal(Cluster, RandNodes, KeyCount, Pid) ->
 
     lager:info("Write one more piece of data"),
     ok = rt:pbc_write(Pid, ?BUCKET, <<"foo">>, <<"foo">>, "text/plain"),
-    timer:sleep(1100),
+    yokozuna_rt:commit(Cluster, ?INDEX),
 
     verify_count(Pid, KeyCount + 1).
 
@@ -102,7 +102,7 @@ test_remove_index_dirs(Cluster, RandNodes, KeyCount, Pid) ->
 
     lager:info("Write second piece of data"),
     ok = rt:pbc_write(Pid, ?BUCKET, <<"food">>, <<"foody">>, "text/plain"),
-    timer:sleep(1100),
+    yokozuna_rt:commit(Cluster, ?INDEX),
 
     verify_count(Pid, KeyCount + 2).
 
@@ -121,7 +121,7 @@ test_remove_segment_infos_and_rebuild(Cluster, RandNodes, KeyCount, Pid) ->
 
     lager:info("Write third piece of data"),
     ok = rt:pbc_write(Pid, ?BUCKET, <<"baz">>, <<"bar">>, "text/plain"),
-    timer:sleep(1100),
+    yokozuna_rt:commit(Cluster, ?INDEX),
 
     verify_count(Pid, KeyCount + 3).
 

--- a/tests/yz_crdt.erl
+++ b/tests/yz_crdt.erl
@@ -59,8 +59,7 @@ confirm() ->
            ?KEY,
            riakc_map:to_op(Map2)),
 
-    %% Wait for yokozuna index to trigger.
-    timer:sleep(1000),
+    yokozuna_rt:commit(Nodes, ?INDEX),
 
     %% Perform simple queries, check for register, set fields.
     {ok, {search_results, Results1a, _, _}} = riakc_pb_socket:search(

--- a/tests/yz_default_bucket_type_upgrade.erl
+++ b/tests/yz_default_bucket_type_upgrade.erl
@@ -59,11 +59,7 @@ confirm() ->
 
     [rt:assert_capability(ANode, ?YZ_CAP, {unknown_capability, ?YZ_CAP}) || ANode <- Cluster],
 
-    %% Generate keys, YZ only supports UTF-8 compatible keys
-    GenKeys = [<<N:64/integer>> || N <- lists:seq(1, ?SEQMAX),
-                                  not lists:any(
-                                        fun(E) -> E > 127 end,
-                                        binary_to_list(<<N:64/integer>>))],
+    GenKeys = yokozuna_rt:gen_keys(?SEQMAX),
     KeyCount = length(GenKeys),
     lager:info("KeyCount ~p", [KeyCount]),
 

--- a/tests/yz_default_bucket_type_upgrade.erl
+++ b/tests/yz_default_bucket_type_upgrade.erl
@@ -70,8 +70,7 @@ confirm() ->
     OldPid = rt:pbc(Node),
 
     yokozuna_rt:write_data(Cluster, OldPid, ?INDEX, ?BUCKET, GenKeys),
-    %% wait for solr soft commit
-    timer:sleep(1100),
+    yokozuna_rt:commit(Cluster, ?INDEX),
 
     yokozuna_rt:verify_num_found_query(Cluster, ?INDEX, KeyCount),
 
@@ -86,7 +85,7 @@ confirm() ->
     lager:info("Write one more piece of data"),
     Pid = rt:pbc(Node),
     ok = rt:pbc_write(Pid, ?BUCKET, <<"foo">>, <<"foo">>, "text/plain"),
-    timer:sleep(1100),
+    yokozuna_rt:commit(Cluster, ?INDEX),
 
     yokozuna_rt:expire_trees(Cluster),
     yokozuna_rt:verify_num_found_query(Cluster, ?INDEX, KeyCount + 1),

--- a/tests/yz_extractors.erl
+++ b/tests/yz_extractors.erl
@@ -163,11 +163,7 @@ confirm() ->
 
     OldPid = rt:pbc(Node),
 
-    %% Generate keys, YZ only supports UTF-8 compatible keys
-    GenKeys = [<<N:64/integer>> || N <- lists:seq(1, ?SEQMAX),
-                                  not lists:any(
-                                        fun(E) -> E > 127 end,
-                                        binary_to_list(<<N:64/integer>>))],
+    GenKeys = yokozuna_rt:gen_keys(?SEQMAX),
     KeyCount = length(GenKeys),
 
     rt:count_calls(Cluster, [?GET_MAP_RING_MFA, ?GET_MAP_MFA]),

--- a/tests/yz_extractors.erl
+++ b/tests/yz_extractors.erl
@@ -27,10 +27,95 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("riakc/include/riakc.hrl").
 
+-define(FMT(S, Args), lists:flatten(io_lib:format(S, Args))).
 -define(INDEX1, <<"test_idx1">>).
 -define(BUCKET1, <<"test_bkt1">>).
 -define(INDEX2, <<"test_idx2">>).
 -define(BUCKET2, <<"test_bkt2">>).
+-define(SCHEMANAME, <<"test">>).
+-define(TEST_SCHEMA,
+<<"<schema name=\"test\" version=\"1.5\">
+<fields>
+   <dynamicField name=\"*_foo_register\" type=\"_yz_str\" indexed=\"true\" stored=\"true\" multiValued=\"false\"/>
+   <dynamicField name=\"*\" type=\"ignored\"/>
+
+   <field name=\"_yz_id\" type=\"_yz_str\" indexed=\"true\" stored=\"true\" required=\"true\" multiValued=\"false\"/>
+   <field name=\"_yz_ed\" type=\"_yz_str\" indexed=\"true\" multiValued=\"false\"/>
+   <field name=\"_yz_pn\" type=\"_yz_str\" indexed=\"true\" multiValued=\"false\"/>
+   <field name=\"_yz_fpn\" type=\"_yz_str\" indexed=\"true\" multiValued=\"false\"/>
+   <field name=\"_yz_vtag\" type=\"_yz_str\" indexed=\"true\" multiValued=\"false\"/>
+   <field name=\"_yz_rt\" type=\"_yz_str\" indexed=\"true\" stored=\"true\" multiValued=\"false\"/>
+   <field name=\"_yz_rk\" type=\"_yz_str\" indexed=\"true\" stored=\"true\" multiValued=\"false\"/>
+   <field name=\"_yz_rb\" type=\"_yz_str\" indexed=\"true\" stored=\"true\" multiValued=\"false\"/>
+   <field name=\"_yz_err\" type=\"_yz_str\" indexed=\"true\" stored=\"true\" multiValued=\"false\"/>
+   <field name=\"text\" type=\"text_general\" indexed=\"true\" stored=\"false\" multiValued=\"true\"/>
+   <field name=\"age\" type=\"int\" indexed=\"true\" stored=\"true\" multiValued=\"false\"/>
+   <field name=\"host\" type=\"string\" indexed=\"true\" stored=\"true\" multiValued=\"false\"/>
+</fields>
+<uniqueKey>_yz_id</uniqueKey>
+<types>
+    <fieldType name=\"ignored\" indexed=\"false\" stored=\"false\" multiValued=\"false\" class=\"solr.StrField\" />
+
+    <fieldType name=\"_yz_str\" class=\"solr.StrField\" sortMissingLast=\"true\" />
+    <fieldType name=\"string\" class=\"solr.StrField\" sortMissingLast=\"true\" />
+    <fieldType name=\"int\" class=\"solr.TrieIntField\" precisionStep=\"0\" positionIncrementGap=\"0\" />
+    <fieldType name=\"text_general\" class=\"solr.TextField\" positionIncrementGap=\"100\">
+      <analyzer type=\"index\">
+        <tokenizer class=\"solr.StandardTokenizerFactory\"/>
+        <filter class=\"solr.StopFilterFactory\" ignoreCase=\"true\" words=\"stopwords.txt\" enablePositionIncrements=\"true\" />
+        <filter class=\"solr.LowerCaseFilterFactory\"/>
+      </analyzer>
+      <analyzer type=\"query\">
+        <tokenizer class=\"solr.StandardTokenizerFactory\"/>
+        <filter class=\"solr.StopFilterFactory\" ignoreCase=\"true\" words=\"stopwords.txt\" enablePositionIncrements=\"true\" />
+        <filter class=\"solr.SynonymFilterFactory\" synonyms=\"synonyms.txt\" ignoreCase=\"true\" expand=\"true\"/>
+        <filter class=\"solr.LowerCaseFilterFactory\"/>
+      </analyzer>
+    </fieldType>
+</types>
+</schema>">>).
+-define(TEST_SCHEMA_UPGRADE,
+<<"<schema name=\"test\" version=\"1.5\">
+<fields>
+   <dynamicField name=\"*_foo_register\" type=\"_yz_str\" indexed=\"true\" stored=\"true\" multiValued=\"false\"/>
+   <dynamicField name=\"*\" type=\"ignored\"/>
+
+   <field name=\"_yz_id\" type=\"_yz_str\" indexed=\"true\" stored=\"true\" required=\"true\" multiValued=\"false\"/>
+   <field name=\"_yz_ed\" type=\"_yz_str\" indexed=\"true\" multiValued=\"false\"/>
+   <field name=\"_yz_pn\" type=\"_yz_str\" indexed=\"true\" multiValued=\"false\"/>
+   <field name=\"_yz_fpn\" type=\"_yz_str\" indexed=\"true\" multiValued=\"false\"/>
+   <field name=\"_yz_vtag\" type=\"_yz_str\" indexed=\"true\" multiValued=\"false\"/>
+   <field name=\"_yz_rt\" type=\"_yz_str\" indexed=\"true\" stored=\"true\" multiValued=\"false\"/>
+   <field name=\"_yz_rk\" type=\"_yz_str\" indexed=\"true\" stored=\"true\" multiValued=\"false\"/>
+   <field name=\"_yz_rb\" type=\"_yz_str\" indexed=\"true\" stored=\"true\" multiValued=\"false\"/>
+   <field name=\"_yz_err\" type=\"_yz_str\" indexed=\"true\" stored=\"true\" multiValued=\"false\"/>
+   <field name=\"text\" type=\"text_general\" indexed=\"true\" stored=\"false\" multiValued=\"true\"/>
+   <field name=\"age\" type=\"int\" indexed=\"true\" stored=\"true\" multiValued=\"false\"/>
+   <field name=\"host\" type=\"string\" indexed=\"true\" stored=\"true\" multiValued=\"false\"/>
+   <field name=\"method\" type=\"string\" indexed=\"true\" stored=\"true\" multiValued=\"false\"/>
+</fields>
+<uniqueKey>_yz_id</uniqueKey>
+<types>
+    <fieldType name=\"ignored\" indexed=\"false\" stored=\"false\" multiValued=\"false\" class=\"solr.StrField\" />
+
+    <fieldType name=\"_yz_str\" class=\"solr.StrField\" sortMissingLast=\"true\" />
+    <fieldType name=\"string\" class=\"solr.StrField\" sortMissingLast=\"true\" />
+    <fieldType name=\"int\" class=\"solr.TrieIntField\" precisionStep=\"0\" positionIncrementGap=\"0\" />
+    <fieldType name=\"text_general\" class=\"solr.TextField\" positionIncrementGap=\"100\">
+      <analyzer type=\"index\">
+        <tokenizer class=\"solr.StandardTokenizerFactory\"/>
+        <filter class=\"solr.StopFilterFactory\" ignoreCase=\"true\" words=\"stopwords.txt\" enablePositionIncrements=\"true\" />
+        <filter class=\"solr.LowerCaseFilterFactory\"/>
+      </analyzer>
+      <analyzer type=\"query\">
+        <tokenizer class=\"solr.StandardTokenizerFactory\"/>
+        <filter class=\"solr.StopFilterFactory\" ignoreCase=\"true\" words=\"stopwords.txt\" enablePositionIncrements=\"true\" />
+        <filter class=\"solr.SynonymFilterFactory\" synonyms=\"synonyms.txt\" ignoreCase=\"true\" expand=\"true\"/>
+        <filter class=\"solr.LowerCaseFilterFactory\"/>
+      </analyzer>
+    </fieldType>
+</types>
+</schema>">>).
 -define(YZ_CAP, {yokozuna, extractor_map_in_cmd}).
 -define(GET_MAP_RING_MFA, {yz_extractor, get_map, 1}).
 -define(GET_MAP_MFA, {yz_extractor, get_map, 0}).
@@ -38,6 +123,8 @@
 -define(YZ_META_EXTRACTORS, {yokozuna, extractors}).
 -define(YZ_EXTRACTOR_MAP, yokozuna_extractor_map).
 -define(NEW_EXTRACTOR, {"application/httpheader", yz_noop_extractor}).
+-define(EXTRACTOR_CT, element(1, ?NEW_EXTRACTOR)).
+-define(EXTRACTOR_MOD, element(2, ?NEW_EXTRACTOR)).
 -define(DEFAULT_MAP, [{default, yz_noop_extractor},
                       {"application/json",yz_json_extractor},
                       {"application/riak_counter", yz_dt_extractor},
@@ -51,6 +138,13 @@
 -define(SEQMAX, 20).
 -define(CFG,
         [
+         {riak_kv,
+          [
+           %% allow AAE to build trees and exchange rapidly
+           {anti_entropy_build_limit, {100, 1000}},
+           {anti_entropy_concurrency, 8},
+           {anti_entropy_tick, 1000}
+          ]},
          {yokozuna,
           [
            {enabled, true}
@@ -78,12 +172,11 @@ confirm() ->
 
     rt:count_calls(Cluster, [?GET_MAP_RING_MFA, ?GET_MAP_MFA]),
 
-    yokozuna_rt:write_data(Cluster, OldPid, ?INDEX1, ?BUCKET1, GenKeys),
+    yokozuna_rt:write_data(Cluster, OldPid, ?INDEX1,
+                           {?SCHEMANAME, ?TEST_SCHEMA}, ?BUCKET1, GenKeys),
+    yokozuna_rt:commit(Cluster, ?INDEX1),
 
     ok = rt:stop_tracing(),
-
-    %% wait for solr soft commit
-    timer:sleep(1100),
 
     {ok, BProps} = riakc_pb_socket:get_bucket(OldPid, ?BUCKET1),
     N = proplists:get_value(n_val, BProps),
@@ -108,9 +201,8 @@ confirm() ->
 
     ?assertEqual(?DEFAULT_MAP, get_map(Node)),
 
-    %% Custom Register
-    ExtractMap = register_extractor(Node, element(1, ?NEW_EXTRACTOR),
-                                    element(2, ?NEW_EXTRACTOR)),
+    %% %% Custom Register
+    ExtractMap = register_extractor(Node, ?EXTRACTOR_CT, ?EXTRACTOR_MOD),
 
     ?assertEqual(?EXTRACTMAPEXPECT, ExtractMap),
 
@@ -118,7 +210,8 @@ confirm() ->
     yokozuna_rt:rolling_upgrade(Cluster, current),
 
     [rt:assert_capability(ANode, ?YZ_CAP, true) || ANode <- Cluster],
-    [rt:assert_supported(rt:capability(ANode, all), ?YZ_CAP, [true, false]) || ANode <- Cluster],
+    [rt:assert_supported(rt:capability(ANode, all), ?YZ_CAP, [true, false]) ||
+        ANode <- Cluster],
 
     %% test query count again
     yokozuna_rt:verify_num_found_query(Cluster, ?INDEX1, KeyCount),
@@ -128,13 +221,13 @@ confirm() ->
     rt:count_calls(Cluster, [?GET_MAP_RING_MFA, ?GET_MAP_MFA,
                              ?GET_MAP_READTHROUGH_MFA]),
 
-    yokozuna_rt:write_data(Cluster, Pid, ?INDEX2, ?BUCKET2, GenKeys),
-    riakc_pb_socket:stop(Pid),
+    yokozuna_rt:write_data(Cluster, Pid, ?INDEX2, {?SCHEMANAME, ?TEST_SCHEMA},
+                           ?BUCKET2, GenKeys),
+    yokozuna_rt:commit(Cluster, ?INDEX2),
 
     ok = rt:stop_tracing(),
 
-    %% wait for solr soft commit
-    timer:sleep(1100),
+    riakc_pb_socket:stop(Pid),
 
     CurrGetMapRingCC = rt:get_call_count(Cluster, ?GET_MAP_RING_MFA),
     CurrGetMapCC = rt:get_call_count(Cluster, ?GET_MAP_MFA),
@@ -148,7 +241,7 @@ confirm() ->
     ?assert(CurrGetMapCC =< PrevGetMapCC),
     lager:info("Number of calls to get_map_read_through/0: ~p~n, Number of calls to get_map/0: ~p~n",
               [CurrGetMapRTCC, CurrGetMapCC]),
-    ?assert(CurrGetMapRTCC < CurrGetMapCC),
+    ?assert(CurrGetMapRTCC =< CurrGetMapCC),
 
     {_RingVal2, MDVal2} = get_ring_and_cmd_vals(Node, ?YZ_META_EXTRACTORS,
                                                 ?YZ_EXTRACTOR_MAP),
@@ -156,17 +249,11 @@ confirm() ->
     ?assertEqual(?EXTRACTMAPEXPECT, MDVal2),
     ?assertEqual(?EXTRACTMAPEXPECT, get_map(Node)),
 
-    rt_intercept:add(Node, {yz_noop_extractor,
-                            [{{extract, 1}, extract_httpheader}]}),
-    rt_intercept:wait_until_loaded(Node),
+    Packet =  <<"GET http://www.google.com HTTP/1.1\n">>,
+    test_extractor_works(Cluster, Packet),
+    test_extractor_with_aae_expire(Cluster, ?INDEX2, ?BUCKET2, Packet),
 
-    ExpectedExtraction = [{method,'GET'},
-                          {host,<<"www.google.com">>},
-                          {uri,<<"/">>}],
-    ?assertEqual(ExpectedExtraction,
-                 verify_extractor(Node,
-                                  <<"GET http://www.google.com HTTP/1.1\n">>,
-                                  element(2, ?NEW_EXTRACTOR))),
+    rt:clean_cluster(Cluster),
 
     pass.
 
@@ -194,3 +281,65 @@ get_map(Node) ->
 
 verify_extractor(Node, PacketData, Mod) ->
     rpc:call(Node, yz_extractor, run, [PacketData, Mod]).
+
+bucket_url({Host,Port}, BName, Key) ->
+    ?FMT("http://~s:~B/buckets/~s/keys/~s",
+         [Host, Port, BName, Key]).
+
+test_extractor_works(Cluster, Packet) ->
+    [rt_intercept:add(ANode, {yz_noop_extractor,
+                              [{{extract, 1}, extract_httpheader}]}) ||
+        ANode <- Cluster],
+    [rt_intercept:wait_until_loaded(ANode) || ANode <- Cluster],
+
+    ExpectedExtraction = [{method, 'GET'},
+                          {host, <<"www.google.com">>},
+                          {uri, <<"/">>}],
+    ?assertEqual(ExpectedExtraction,
+                 verify_extractor(rt:select_random(Cluster), Packet, ?EXTRACTOR_MOD)).
+
+test_extractor_with_aae_expire(Cluster, Index, Bucket, Packet) ->
+    %% Now make sure we register extractor across all nodes
+    [register_extractor(ANode, ?EXTRACTOR_CT, ?EXTRACTOR_MOD) ||
+        ANode <- Cluster],
+
+    Key = <<"google">>,
+
+    {Host, Port} = rt:select_random(yokozuna_rt:host_entries(
+                                               rt:connection_info(
+                                                 Cluster))),
+    URL = bucket_url({Host, Port}, mochiweb_util:quote_plus(Bucket),
+                     mochiweb_util:quote_plus(Key)),
+
+    CT = ?EXTRACTOR_CT,
+    {ok, "204", _, _} = ibrowse:send_req(
+                          URL, [{"Content-Type", CT}], put, Packet),
+
+    yokozuna_rt:commit(Cluster, Index),
+
+    yokozuna_rt:search_expect({Host, Port}, Index, <<"host">>,
+                              <<"www*">>, 1),
+
+    yokozuna_rt:expire_trees(Cluster),
+    yokozuna_rt:wait_for_full_exchange_round(Cluster, erlang:now()),
+
+    yokozuna_rt:search_expect({Host, Port}, Index, <<"host">>,
+                              <<"www*">>, 1),
+
+    APid = rt:pbc(rt:select_random(Cluster)),
+    yokozuna_rt:override_schema(APid, Cluster, Index, ?SCHEMANAME,
+                                ?TEST_SCHEMA_UPGRADE),
+
+    {ok, "204", _, _} = ibrowse:send_req(
+                          URL, [{"Content-Type", CT}], put, Packet),
+    yokozuna_rt:commit(Cluster, Index),
+
+    yokozuna_rt:search_expect({Host, Port}, Index, <<"method">>,
+                              <<"GET">>, 1),
+
+    yokozuna_rt:expire_trees(Cluster),
+    yokozuna_rt:wait_for_full_exchange_round(Cluster, erlang:now()),
+
+    yokozuna_rt:search_expect({Host, Port}, Index, <<"method">>,
+                              <<"GET">>, 1),
+    riakc_pb_socket:stop(APid).

--- a/tests/yz_handoff.erl
+++ b/tests/yz_handoff.erl
@@ -78,7 +78,7 @@ confirm() ->
 
     Pid = rt:pbc(Node2),
     yokozuna_rt:write_data(Nodes, Pid, ?INDEX, ?BUCKET, Keys),
-    timer:sleep(1100),
+    yokozuna_rt:commit(Nodes, ?INDEX),
 
     %% Separate out shards for multiple runs
     [Shard1|Shards2Rest] = Shards,

--- a/tests/yz_handoff.erl
+++ b/tests/yz_handoff.erl
@@ -99,8 +99,7 @@ confirm() ->
                            join_node = Node1,
                            admin_node = Node2}],
 
-    %% Run Shell Script to count/test # of replicas and leave/join
-    %% nodes from the cluster
+    %% Run set of leave/join trials and count/test #'s from the cluster
     [[begin
           check_data(Nodes, KeyCount, BucketURL, SearchURL, State),
           check_counts(Pid, KeyCount, BucketURL)


### PR DESCRIPTION
Part of this merge is a forward-merge for #863 into riak_test `master`. The relevant changes are in `src/yokozuna_rt.erl` and `tests/verify_snmp_repl.erl`. The remaining changes are yokozuna tests that have not yet been forward-merged into `master` and were taken along for the ride.

##### Zeeshan's notes 10/9, per commit: 844ee9cdb20bd2f476d28fe7ef80967e23d09046

After some env work, I no longer ran into the issue I was having w/ the race from https://github.com/basho/riak_kv/issues/872 (another issue for another time). 

I've updated yokozuna_rt and the extractors test here to actually test the issue in https://github.com/basho/yokozuna/issues/547, as I finally gathered what was going on. 

Please review @jvoegele @fadushin and run the extractors test off 2.1, and rec using https://github.com/basho/yokozuna/pull/572 branch off of 2.1.