### PR TITLE
Refactor some Yokozuna tests to eliminate duplication

### DIFF
--- a/src/yokozuna_rt.erl
+++ b/src/yokozuna_rt.erl
@@ -59,7 +59,7 @@ host_entries(ClusterConnInfo) ->
     [riak_http(I) || {_,I} <- ClusterConnInfo].
 
 %% @doc Generate `SeqMax' keys. Yokozuna supports only UTF-8 compatible keys.
--spec gen_keys(pos_integer()) -> list().
+-spec gen_keys(pos_integer()) -> [binary()].
 gen_keys(SeqMax) ->
     [<<N:64/integer>> || N <- lists:seq(1, SeqMax),
                          not lists:any(
@@ -278,12 +278,16 @@ assert_search(Pid, Cluster, Index, Search, SearchExpect, Params) ->
     F = fun(_) ->
                 lager:info("Searching ~p and asserting it exists",
                            [SearchExpect]),
-                {ok,{search_results,[{_Index,Fields}], _Score, Found}} =
-                    riakc_pb_socket:search(Pid, Index, Search, Params),
-                ?assert(lists:member(SearchExpect, Fields)),
-                case Found of
-                    1 -> true;
-                    0 -> false
+                case riakc_pb_socket:search(Pid, Index, Search, Params) of
+                    {ok,{search_results,[{_Index,Fields}], _Score, Found}} ->
+                        ?assert(lists:member(SearchExpect, Fields)),
+                        case Found of
+                            1 -> true;
+                            0 -> false
+                        end;
+                    {ok, {search_results, [], _Score, 0}} ->
+                        lager:info("Search for multivalued_field has not yet yielded data"),
+                        false
                 end
         end,
     rt:wait_until(Cluster, F).

--- a/src/yokozuna_rt.erl
+++ b/src/yokozuna_rt.erl
@@ -286,7 +286,7 @@ assert_search(Pid, Cluster, Index, Search, SearchExpect, Params) ->
                             0 -> false
                         end;
                     {ok, {search_results, [], _Score, 0}} ->
-                        lager:info("Search for multivalued_field has not yet yielded data"),
+                        lager:info("Search has not yet yielded data"),
                         false
                 end
         end,

--- a/src/yokozuna_rt.erl
+++ b/src/yokozuna_rt.erl
@@ -25,6 +25,7 @@
 -export([check_exists/2,
          commit/2,
          expire_trees/1,
+         gen_keys/1,
          host_entries/1,
          override_schema/5,
          remove_index_dirs/2,
@@ -35,6 +36,7 @@
          search_expect/5,
          search_expect/6,
          search_expect/7,
+         assert_search/6,
          verify_num_found_query/3,
          wait_for_aae/1,
          wait_for_full_exchange_round/2,
@@ -55,6 +57,14 @@
 -spec host_entries(rt:conn_info()) -> [{host(), portnum()}].
 host_entries(ClusterConnInfo) ->
     [riak_http(I) || {_,I} <- ClusterConnInfo].
+
+%% @doc Generate `SeqMax' keys. Yokozuna supports only UTF-8 compatible keys.
+-spec gen_keys(pos_integer()) -> list().
+gen_keys(SeqMax) ->
+    [<<N:64/integer>> || N <- lists:seq(1, SeqMax),
+                         not lists:any(
+                               fun(E) -> E > 127 end,
+                               binary_to_list(<<N:64/integer>>))].
 
 %% @doc Write `Keys' via the PB inteface to a `Bucket' and have them
 %%      searchable in an `Index'.
@@ -263,6 +273,20 @@ search_expect(solr, {Host, Port}, Index, Name0, Term0, Shards, Expect)
     Opts = [{response_format, binary}],
     {ok, "200", _, R} = ibrowse:send_req(URL, [], get, [], Opts),
     verify_count_http(Expect, R).
+
+assert_search(Pid, Cluster, Index, Search, SearchExpect, Params) ->
+    F = fun(_) ->
+                lager:info("Searching ~p and asserting it exists",
+                           [SearchExpect]),
+                {ok,{search_results,[{_Index,Fields}], _Score, Found}} =
+                    riakc_pb_socket:search(Pid, Index, Search, Params),
+                ?assert(lists:member(SearchExpect, Fields)),
+                case Found of
+                    1 -> true;
+                    0 -> false
+                end
+        end,
+    rt:wait_until(Cluster, F).
 
 search(HP, Index, Name, Term) ->
     search(yokozuna, HP, Index, Name, Term).

--- a/tests/yz_default_bucket_type_upgrade.erl
+++ b/tests/yz_default_bucket_type_upgrade.erl
@@ -59,11 +59,7 @@ confirm() ->
 
     [rt:assert_capability(ANode, ?YZ_CAP, {unknown_capability, ?YZ_CAP}) || ANode <- Cluster],
 
-    %% Generate keys, YZ only supports UTF-8 compatible keys
-    GenKeys = [<<N:64/integer>> || N <- lists:seq(1, ?SEQMAX),
-                                  not lists:any(
-                                        fun(E) -> E > 127 end,
-                                        binary_to_list(<<N:64/integer>>))],
+    GenKeys = yokozuna_rt:gen_keys(?SEQMAX),
     KeyCount = length(GenKeys),
     lager:info("KeyCount ~p", [KeyCount]),
 

--- a/tests/yz_extractors.erl
+++ b/tests/yz_extractors.erl
@@ -163,11 +163,7 @@ confirm() ->
 
     OldPid = rt:pbc(Node),
 
-    %% Generate keys, YZ only supports UTF-8 compatible keys
-    GenKeys = [<<N:64/integer>> || N <- lists:seq(1, ?SEQMAX),
-                                  not lists:any(
-                                        fun(E) -> E > 127 end,
-                                        binary_to_list(<<N:64/integer>>))],
+    GenKeys = yokozuna_rt:gen_keys(?SEQMAX),
     KeyCount = length(GenKeys),
 
     rt:count_calls(Cluster, [?GET_MAP_RING_MFA, ?GET_MAP_MFA]),


### PR DESCRIPTION
Specifically, introduce the `gen_keys/1` and `assert_search/6` functions into the yokozuna_rt module and refactor tests to use them instead of copied and pasted code fragments.