### PR TITLE
Fix Expected value in ts_A_select_pass module

### DIFF
--- a/tests/timeseries_util.erl
+++ b/tests/timeseries_util.erl
@@ -91,9 +91,9 @@ confirm_select(ClusterType, TestType, DDL, Data, Qry, Expected) ->
     ok = riakc_ts:put(C, Bucket, Data),
     
     io:format("3 - Now run the query ~p~n", [Qry]),
-    Got = riakc_ts:query(C, Qry), 
+    Got = {_ColumnDescriptions, Rows} = riakc_ts:query(C, Qry),
     io:format("Got is ~p~n", [Got]),
-    ?assertEqual(Expected, Got),
+    ?assertEqual(lists:sort(Expected), lists:sort(Rows)),
     pass.
 
 %%

--- a/tests/timeseries_util.erl
+++ b/tests/timeseries_util.erl
@@ -1,4 +1,3 @@
-%% -*- Mode: Erlang -*-
 %% -------------------------------------------------------------------
 %%
 %% Copyright (c) 2015 Basho Technologies, Inc.
@@ -19,6 +18,7 @@
 %%
 %% -------------------------------------------------------------------
 %% @doc A util module for riak_ts basic CREATE TABLE Actions
+
 -module(timeseries_util).
 
 -compile(export_all).
@@ -53,15 +53,15 @@ confirm_activate(ClusterType, DDL, Expected) ->
 confirm_put(ClusterType, TestType, DDL, Obj, Expected) ->
 
     [Node | _]  = build_cluster(ClusterType),
-    
+
     case TestType of
-	normal ->
-	    io:format("1 - Creating and activating bucket~n"),
-	    {ok, _} = create_bucket(Node, DDL),
-	    {ok, _} = activate_bucket(Node, DDL);
-	no_ddl ->
-	    io:format("1 - NOT Creating or activating bucket - failure test~n"),
-	    ok
+        normal ->
+            io:format("1 - Creating and activating bucket~n"),
+            {ok, _} = create_bucket(Node, DDL),
+            {ok, _} = activate_bucket(Node, DDL);
+        no_ddl ->
+            io:format("1 - NOT Creating or activating bucket - failure test~n"),
+            ok
     end,
     Bucket = list_to_binary(get_bucket()),
     io:format("2 - writing to bucket ~p with:~n- ~p~n", [Bucket, Obj]),
@@ -72,24 +72,24 @@ confirm_put(ClusterType, TestType, DDL, Obj, Expected) ->
     pass.
 
 confirm_select(ClusterType, TestType, DDL, Data, Qry, Expected) ->
-    
+
     [Node | _] = build_cluster(ClusterType),
-    
+
     case TestType of
-	normal ->
-	    io:format("1 - Create and activate the bucket~n"),
-	    {ok, _} = create_bucket(Node, DDL),
-	    {ok, _} = activate_bucket(Node, DDL);
-	no_ddl ->
-	    io:format("1 - NOT Creating or activating bucket - failure test~n"),
-	    ok
+        normal ->
+            io:format("1 - Create and activate the bucket~n"),
+            {ok, _} = create_bucket(Node, DDL),
+            {ok, _} = activate_bucket(Node, DDL);
+        no_ddl ->
+            io:format("1 - NOT Creating or activating bucket - failure test~n"),
+            ok
     end,
-    
+
     Bucket = list_to_binary(get_bucket()),
     io:format("2 - writing to bucket ~p with:~n- ~p~n", [Bucket, Data]),
     C = rt:pbc(Node),
     ok = riakc_ts:put(C, Bucket, Data),
-    
+
     io:format("3 - Now run the query ~p~n", [Qry]),
     Got = {_ColumnDescriptions, Rows} = riakc_ts:query(C, Qry),
     io:format("Got is ~p~n", [Got]),
@@ -105,9 +105,9 @@ activate_bucket(Node, _DDL) ->
 
 create_bucket(Node, DDL) ->
     Props = io_lib:format("{\\\"props\\\": {\\\"n_val\\\": 3, " ++
-			      "\\\"table_def\\\": \\\"~s\\\"}}", [DDL]),
-    rt:admin(Node, ["bucket-type", "create", get_bucket(), 
-		    lists:flatten(Props)]).
+                              "\\\"table_def\\\": \\\"~s\\\"}}", [DDL]),
+    rt:admin(Node, ["bucket-type", "create", get_bucket(),
+                    lists:flatten(Props)]).
 
 %% @ignore
 maybe_stop_a_node(one_down, [H | _T]) ->
@@ -150,64 +150,64 @@ get_valid_select_data() ->
     Family = <<"family1">>,
     Series = <<"seriesX">>,
     Times = lists:seq(1, 10),
-    [[Family, Series, X, get_varchar(), get_float()] || X <- Times].     
+    [[Family, Series, X, get_varchar(), get_float()] || X <- Times].
 
 %% a valid DDL - the one used in the documents
 get_ddl(docs) ->
     _SQL = "CREATE TABLE GeoCheckin (" ++
-	"myfamily    varchar   not null, " ++
-	"myseries    varchar   not null, " ++
-	"time        timestamp not null, " ++
-	"weather     varchar   not null, " ++
-	"temperature float, " ++
-	"PRIMARY KEY ((quantum(time, 15, 'm'), myfamily, myseries), " ++
-	"time, myfamily, myseries))";
+        "myfamily    varchar   not null, " ++
+        "myseries    varchar   not null, " ++
+        "time        timestamp not null, " ++
+        "weather     varchar   not null, " ++
+        "temperature float, " ++
+        "PRIMARY KEY ((quantum(time, 15, 'm'), myfamily, myseries), " ++
+        "time, myfamily, myseries))";
 %% another valid DDL - one with all the good stuff like
 %% different types and optional blah-blah
 get_ddl(variety) ->
     _SQL = "CREATE TABLE GeoCheckin (" ++
-	"myfamily    varchar     not null, " ++
-	"myseries    varchar     not null, " ++
-	"time        timestamp   not null, " ++
-	"myint       integer     not null, " ++
-	"myfloat     float       not null, " ++
-	"mybool      boolean     not null, " ++
-	"mytimestamp timestamp   not null, " ++
-	"myany       any         not null, " ++
-	"myoptional  integer, " ++
-	"PRIMARY KEY ((quantum(time, 15, 'm'), myfamily, myseries), " ++
-	"time, myfamily, myseries))";
+        "myfamily    varchar     not null, " ++
+        "myseries    varchar     not null, " ++
+        "time        timestamp   not null, " ++
+        "myint       integer     not null, " ++
+        "myfloat     float       not null, " ++
+        "mybool      boolean     not null, " ++
+        "mytimestamp timestamp   not null, " ++
+        "myany       any         not null, " ++
+        "myoptional  integer, " ++
+        "PRIMARY KEY ((quantum(time, 15, 'm'), myfamily, myseries), " ++
+        "time, myfamily, myseries))";
 %% an invalid TS DDL becuz family and series not both in key
 get_ddl(shortkey_fail) ->
     _SQL = "CREATE TABLE GeoCheckin (" ++
-	"myfamily    varchar   not null, " ++
-	"myseries    varchar   not null, " ++
-	"time        timestamp not null, " ++
-	"weather     varchar   not null, " ++
-	"temperature float, " ++
-	"PRIMARY KEY ((quantum(time, 15, 'm'), myfamily), " ++
-	"time, myfamily))";
+        "myfamily    varchar   not null, " ++
+        "myseries    varchar   not null, " ++
+        "time        timestamp not null, " ++
+        "weather     varchar   not null, " ++
+        "temperature float, " ++
+        "PRIMARY KEY ((quantum(time, 15, 'm'), myfamily), " ++
+        "time, myfamily))";
 %% an invalid TS DDL becuz partition and local keys dont cover the same space
 get_ddl(splitkey_fail) ->
     _SQL = "CREATE TABLE GeoCheckin (" ++
-	"myfamily    varchar   not null, " ++
-	"myseries    varchar   not null, " ++
-	"time        timestamp not null, " ++
-	"weather     varchar   not null, " ++
-	"temperature float, " ++
-	"PRIMARY KEY ((quantum(time, 15, 'm'), myfamily, myseries), " ++
-	"time, myfamily, myseries, temperature))";
+        "myfamily    varchar   not null, " ++
+        "myseries    varchar   not null, " ++
+        "time        timestamp not null, " ++
+        "weather     varchar   not null, " ++
+        "temperature float, " ++
+        "PRIMARY KEY ((quantum(time, 15, 'm'), myfamily, myseries), " ++
+        "time, myfamily, myseries, temperature))";
 %% another invalid TS DDL because family/series must be varchar
 %% or is this total bollox???
 get_ddl(keytype_fail_mebbies_or_not_eh_check_it_properly_muppet_boy) ->
     _SQL = "CREATE TABLE GeoCheckin (" ++
-	"myfamily    integer   not null, " ++
-	"myseries    varchar   not null, " ++
-	"time        timestamp not null, " ++
-	"weather     varchar   not null, " ++
-	"temperature float, " ++
-	"PRIMARY KEY ((quantum(time, 15, 'm'), myfamily, myseries), " ++
-	"time, myfamily, myseries))".
+        "myfamily    integer   not null, " ++
+        "myseries    varchar   not null, " ++
+        "time        timestamp not null, " ++
+        "weather     varchar   not null, " ++
+        "temperature float, " ++
+        "PRIMARY KEY ((quantum(time, 15, 'm'), myfamily, myseries), " ++
+        "time, myfamily, myseries))".
 
 get_valid_obj() ->
     [get_varchar(),

--- a/tests/ts_A_select_pass_1.erl
+++ b/tests/ts_A_select_pass_1.erl
@@ -1,11 +1,31 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2015 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+%% @doc A module to test riak_ts basic create bucket/put/select cycle.
+
 -module(ts_A_select_pass_1).
 
 -behavior(riak_test).
 
 -export([
-	 confirm/0
-	]).
-
+         confirm/0
+        ]).
 
 confirm() ->
     DDL  = timeseries_util:get_ddl(docs),

--- a/tests/ts_A_select_pass_1.erl
+++ b/tests/ts_A_select_pass_1.erl
@@ -6,16 +6,10 @@
 	 confirm/0
 	]).
 
--import(timeseries_util, [
-			  get_ddl/1,
-			  get_valid_select_data/0,
-			  get_valid_qry/0,
-			  confirm_select/6
-			  ]).
 
 confirm() ->
-    DDL = get_ddl(docs),
-    Data = get_valid_select_data(),
-    Qry = get_valid_qry(),
-    Expected = ok,
+    DDL  = timeseries_util:get_ddl(docs),
+    Data = timeseries_util:get_valid_select_data(),
+    Qry  = timeseries_util:get_valid_qry(),
+    Expected = lists:map(fun list_to_tuple/1, Data),
     confirm_select(single, normal, DDL, Data, Qry, Expected).


### PR DESCRIPTION
Note: it naively, but correctly, expects 10 records back from the select query, and thus will begin to pass once that off-by-one issue is properly fixed.