### PR TITLE
Fixed select pass tests

### DIFF
--- a/tests/timeseries_util.erl
+++ b/tests/timeseries_util.erl
@@ -156,10 +156,15 @@ get_cols(docs) ->
      <<"weather">>,
      <<"temperature">>].
 
-%% Convert put data to result rows exclusive of the first and last records.
-exclusive_result_from_data(Data) ->
-    [_|Tail] = remove_last([list_to_tuple(R) || R <- Data]),
-    Tail.
+exclusive_result_from_data(Data, Start, Finish) when is_integer(Start)   andalso
+						     is_integer(Finish)  andalso
+						     Start  > 0          andalso
+						     Finish > 0          andalso
+						     Finish > Start      andalso
+						     Finish =< length(Data) ->
+    {_, PartialResults} = lists:split(Start - 1, Data),
+    {Results, _} = lists:split(Finish, PartialResults),
+    [list_to_tuple(X) || X <- Results].
 
 remove_last(Data) ->
     lists:reverse(tl(lists:reverse(Data))).

--- a/tests/timeseries_util.erl
+++ b/tests/timeseries_util.erl
@@ -149,6 +149,21 @@ get_valid_select_data() ->
     Times = lists:seq(1, 10),
     [[Family, Series, X, get_varchar(), get_float()] || X <- Times].     
 
+get_cols(docs) ->
+    [<<"myfamily">>,
+     <<"myseries">>,
+     <<"time">>,
+     <<"weather">>,
+     <<"temperature">>].
+
+%% Convert put data to result rows exclusive of the first and last records.
+exclusive_result_from_data(Data) ->
+    [_|Tail] = remove_last([list_to_tuple(R) || R <- Data]),
+    Tail.
+
+remove_last(Data) ->
+    lists:reverse(tl(lists:reverse(Data))).
+
 %% a valid DDL - the one used in the documents
 get_ddl(docs) ->
     _SQL = "CREATE TABLE GeoCheckin (" ++

--- a/tests/ts_A_select_pass_1.erl
+++ b/tests/ts_A_select_pass_1.erl
@@ -21,6 +21,6 @@ confirm() ->
     Qry = get_valid_qry(),
     Expected = {
         timeseries_util:get_cols(docs),
-        timeseries_util:exclusive_result_from_data(Data)},
+        timeseries_util:exclusive_result_from_data(Data, 1, 9)},
     confirm_select(Cluster, TestType, DDL, Data, Qry, Expected).
 

--- a/tests/ts_A_select_pass_1.erl
+++ b/tests/ts_A_select_pass_1.erl
@@ -17,5 +17,18 @@ confirm() ->
     DDL = get_ddl(docs),
     Data = get_valid_select_data(),
     Qry = get_valid_qry(),
-    Expected = ok,
-    confirm_select(single, normal, DDL, Data, Qry, Expected).
+    confirm_select(single, normal, DDL, Data, Qry, {get_cols(docs), to_result(Data)}).
+
+get_cols(docs) ->
+        [<<"myfamily">>,
+         <<"myseries">>,
+         <<"time">>,
+         <<"weather">>,
+         <<"temperature">>].
+
+to_result(Data) ->
+	[_|Tail] = remove_last([list_to_tuple(R) || R <- Data]),
+	Tail	.
+
+remove_last(Data) ->
+	lists:reverse(tl(lists:reverse(Data))).

--- a/tests/ts_A_select_pass_1.erl
+++ b/tests/ts_A_select_pass_1.erl
@@ -14,21 +14,13 @@
 			  ]).
 
 confirm() ->
+    Cluster = single,
+    TestType = normal,
     DDL = get_ddl(docs),
     Data = get_valid_select_data(),
     Qry = get_valid_qry(),
-    confirm_select(single, normal, DDL, Data, Qry, {get_cols(docs), to_result(Data)}).
+    Expected = {
+        timeseries_util:get_cols(docs),
+        timeseries_util:exclusive_result_from_data(Data)},
+    confirm_select(Cluster, TestType, DDL, Data, Qry, Expected).
 
-get_cols(docs) ->
-        [<<"myfamily">>,
-         <<"myseries">>,
-         <<"time">>,
-         <<"weather">>,
-         <<"temperature">>].
-
-to_result(Data) ->
-	[_|Tail] = remove_last([list_to_tuple(R) || R <- Data]),
-	Tail	.
-
-remove_last(Data) ->
-	lists:reverse(tl(lists:reverse(Data))).

--- a/tests/ts_B_select_pass_1.erl
+++ b/tests/ts_B_select_pass_1.erl
@@ -14,8 +14,12 @@
 			  ]).
 
 confirm() ->
+    Cluster = multiple,
+    TestType = normal,
     DDL = get_ddl(docs),
     Data = get_valid_select_data(),
     Qry = get_valid_qry(),
-    Expected = ok,
-    confirm_select(multiple, normal, DDL, Data, Qry, Expected).
+    Expected = {
+        timeseries_util:get_cols(docs),
+        timeseries_util:exclusive_result_from_data(Data)},
+    confirm_select(Cluster, TestType, DDL, Data, Qry, Expected).

--- a/tests/ts_B_select_pass_1.erl
+++ b/tests/ts_B_select_pass_1.erl
@@ -21,5 +21,5 @@ confirm() ->
     Qry = get_valid_qry(),
     Expected = {
         timeseries_util:get_cols(docs),
-        timeseries_util:exclusive_result_from_data(Data)},
+        timeseries_util:exclusive_result_from_data(Data, 1, 9)},
     confirm_select(Cluster, TestType, DDL, Data, Qry, Expected).


### PR DESCRIPTION
Match results of the selection, from ok to {Cols, Rows} where the expected Rows are exclusive the first and last key i.e. `i > 1` instead of `i >= 1'.