### PR TITLE
Force eleveldb backend for ts_basic test

### DIFF
--- a/tests/ts_basic.erl
+++ b/tests/ts_basic.erl
@@ -35,6 +35,7 @@ confirm() ->
 
     ClusterSize = 1,
     lager:info("Building cluster"),
+    rt:set_backend(eleveldb),
     _Nodes = [Node1|_] =
         build_cluster(
           ClusterSize),


### PR DESCRIPTION
This was crashing out of the box for me with a cryptic error about a "bad_qid". Turned out to be caused by using the wrong backend. This fix should prevent others from running into the same issue in the future.