### PR TITLE
Make eleveldb backend explicit for TS

### DIFF
--- a/tests/timeseries_util.erl
+++ b/tests/timeseries_util.erl
@@ -127,6 +127,7 @@ build_c2(Size) ->
     build_c2(Size, []).
 -spec build_c2(non_neg_integer(), list()) -> [node()].
 build_c2(Size, Config) ->
+    rt:set_backend(eleveldb),
     [_Node1|_] = Nodes = rt:deploy_nodes(Size, Config),
     rt:join_cluster(Nodes),
     Nodes.

--- a/tests/ts_B_random_query_pass_eqc.erl
+++ b/tests/ts_B_random_query_pass_eqc.erl
@@ -122,6 +122,7 @@ get_multi({No, m})  -> 60*1000 * No;
 get_multi({No, s})  -> 1000 * No.
 
 build_cluster(Size) ->
+    rt:set_backend(eleveldb),
     Nodes = rt:deploy_nodes(Size, []),
     rt:join_cluster(Nodes),
     Nodes.

--- a/tests/ts_basic.erl
+++ b/tests/ts_basic.erl
@@ -111,6 +111,7 @@ build_cluster(Size) ->
     build_cluster(Size, []).
 -spec build_cluster(pos_integer(), list()) -> [node()].
 build_cluster(Size, Config) ->
+    rt:set_backend(eleveldb),
     [_Node1|_] = Nodes = rt:deploy_nodes(Size, Config),
     rt:join_cluster(Nodes),
     Nodes.


### PR DESCRIPTION
Before we do a `deploy_nodes` make sure `eleveldb` is the backend. Most tests rely on `timeseries_util`, so this is mostly centralized.