### PR TITLE
riakc_ts:get now returns a tuple

### DIFF
--- a/tests/ts_basic.erl
+++ b/tests/ts_basic.erl
@@ -95,12 +95,12 @@ confirm() ->
     GetKey = [GetTimepoint, GetSensor],
     ResGet = riakc_ts:get(C, ?BUCKET, GetKey, []),
     io:format("Get a single record: ~p\n", [ResGet]),
-    ?assertEqual([GetRecord], ResGet),
+    ?assertMatch({_, [GetRecord]}, ResGet),
 
     GetNXKey = [GetTimepoint, <<"dudu">>],
     ResNXGet = riakc_ts:get(C, ?BUCKET, GetNXKey, []),
     io:format("Not got a nonexistent single record: ~p\n", [ResNXGet]),
-    ?assertEqual([], ResNXGet),
+    ?assertMatch({_, []}, ResNXGet),
 
     pass.
 


### PR DESCRIPTION
RTS-480. Uses API as of https://github.com/basho/riak_kv/pull/1243 (and related PRs).