### PR TITLE
RTS-396: Fix TS table creation tests

### DIFF
--- a/tests/timeseries_util.erl
+++ b/tests/timeseries_util.erl
@@ -55,13 +55,13 @@ confirm_put(ClusterType, TestType, DDL, Obj) ->
     [Node | _]  = build_cluster(ClusterType),
     
     case TestType of
-	normal ->
-	    io:format("1 - Creating and activating bucket~n"),
-	    {ok, _} = create_bucket(Node, DDL, 3),
-	    {ok, _} = activate_bucket(Node, DDL);
-	no_ddl ->
-	    io:format("1 - NOT Creating or activating bucket - failure test~n"),
-	    ok
+        normal ->
+            io:format("1 - Creating and activating bucket~n"),
+            {ok, _} = create_bucket(Node, DDL, 3),
+            {ok, _} = activate_bucket(Node, DDL);
+        no_ddl ->
+            io:format("1 - NOT Creating or activating bucket - failure test~n"),
+            ok
     end,
     Bucket = list_to_binary(get_bucket()),
     io:format("2 - writing to bucket ~p with:~n- ~p~n", [Bucket, Obj]),
@@ -73,17 +73,17 @@ confirm_select(ClusterType, TestType, DDL, Data, Qry, Expected) ->
     [Node | _] = build_cluster(ClusterType),
     
     case TestType of
-	normal ->
-	    io:format("1 - Create and activate the bucket~n"),
-	    {ok, _} = create_bucket(Node, DDL, 3),
-	    {ok, _} = activate_bucket(Node, DDL);
-	n_val_one ->
-	    io:format("1 - Creating and activating bucket~n"),
-	    {ok, _} = create_bucket(Node, DDL, 1),
-	    {ok, _} = activate_bucket(Node, DDL);
-	no_ddl ->
-	    io:format("1 - NOT Creating or activating bucket - failure test~n"),
-	    ok
+        normal ->
+            io:format("1 - Create and activate the bucket~n"),
+            {ok, _} = create_bucket(Node, DDL, 3),
+            {ok, _} = activate_bucket(Node, DDL);
+        n_val_one ->
+            io:format("1 - Creating and activating bucket~n"),
+            {ok, _} = create_bucket(Node, DDL, 1),
+            {ok, _} = activate_bucket(Node, DDL);
+        no_ddl ->
+            io:format("1 - NOT Creating or activating bucket - failure test~n"),
+            ok
     end,
     
     Bucket = list_to_binary(get_bucket()),
@@ -106,10 +106,10 @@ activate_bucket(Node, _DDL) ->
 
 create_bucket(Node, DDL, NVal) when is_integer(NVal) ->
     Props = io_lib:format("{\\\"props\\\": {\\\"n_val\\\": " ++ 
-			      integer_to_list(NVal) ++
-			      ", \\\"table_def\\\": \\\"~s\\\"}}", [DDL]),
+                          integer_to_list(NVal) ++
+                          ", \\\"table_def\\\": \\\"~s\\\"}}", [DDL]),
     rt:admin(Node, ["bucket-type", "create", get_bucket(), 
-		    lists:flatten(Props)]).
+                    lists:flatten(Props)]).
 
 %% @ignore
 maybe_stop_a_node(one_down, [H | _T]) ->
@@ -181,10 +181,10 @@ get_cols(docs) ->
      <<"temperature">>].
 
 exclusive_result_from_data(Data, Start, Finish) when is_integer(Start)   andalso
-						     is_integer(Finish)  andalso
-						     Start  > 0          andalso
-						     Finish > 0          andalso
-						     Finish > Start ->
+                                                     is_integer(Finish)  andalso
+                                                     Start  > 0          andalso
+                                                     Finish > 0          andalso
+                                                     Finish > Start ->
     [list_to_tuple(X) || X <- lists:sublist(Data, Start, Finish - Start + 1)].
 
 remove_last(Data) ->
@@ -193,59 +193,59 @@ remove_last(Data) ->
 %% a valid DDL - the one used in the documents
 get_ddl(docs) ->
     _SQL = "CREATE TABLE GeoCheckin (" ++
-	"myfamily    varchar   not null, " ++
-	"myseries    varchar   not null, " ++
-	"time        timestamp not null, " ++
-	"weather     varchar   not null, " ++
-	"temperature float, " ++
-	"PRIMARY KEY ((quantum(time, 15, 'm'), myfamily, myseries), " ++
-	"time, myfamily, myseries))";
+    "myfamily    varchar   not null, " ++
+    "myseries    varchar   not null, " ++
+    "time        timestamp not null, " ++
+    "weather     varchar   not null, " ++
+    "temperature float, " ++
+    "PRIMARY KEY ((myfamily, myseries, quantum(time, 15, 'm')), " ++
+    "myfamily, myseries, time))";
 %% another valid DDL - one with all the good stuff like
 %% different types and optional blah-blah
 get_ddl(variety) ->
     _SQL = "CREATE TABLE GeoCheckin (" ++
-	"myfamily    varchar     not null, " ++
-	"myseries    varchar     not null, " ++
-	"time        timestamp   not null, " ++
-	"myint       integer     not null, " ++
-	"myfloat     float       not null, " ++
-	"mybool      boolean     not null, " ++
-	"mytimestamp timestamp   not null, " ++
-	"myany       any         not null, " ++
-	"myoptional  integer, " ++
-	"PRIMARY KEY ((quantum(time, 15, 'm'), myfamily, myseries), " ++
-	"time, myfamily, myseries))";
+    "myfamily    varchar     not null, " ++
+    "myseries    varchar     not null, " ++
+    "time        timestamp   not null, " ++
+    "myint       integer     not null, " ++
+    "myfloat     float       not null, " ++
+    "mybool      boolean     not null, " ++
+    "mytimestamp timestamp   not null, " ++
+    "myany       any         not null, " ++
+    "myoptional  integer, " ++
+    "PRIMARY KEY ((myfamily, myseries, quantum(time, 15, 'm')), " ++
+    "myfamily, myseries, time))";
 %% an invalid TS DDL becuz family and series not both in key
 get_ddl(shortkey_fail) ->
     _SQL = "CREATE TABLE GeoCheckin (" ++
-	"myfamily    varchar   not null, " ++
-	"myseries    varchar   not null, " ++
-	"time        timestamp not null, " ++
-	"weather     varchar   not null, " ++
-	"temperature float, " ++
-	"PRIMARY KEY ((quantum(time, 15, 'm'), myfamily), " ++
-	"time, myfamily))";
+    "myfamily    varchar   not null, " ++
+    "myseries    varchar   not null, " ++
+    "time        timestamp not null, " ++
+    "weather     varchar   not null, " ++
+    "temperature float, " ++
+    "PRIMARY KEY ((myfamily, quantum(time, 15, 'm')), " ++
+    "myfamily, time))";
 %% an invalid TS DDL becuz partition and local keys dont cover the same space
 get_ddl(splitkey_fail) ->
     _SQL = "CREATE TABLE GeoCheckin (" ++
-	"myfamily    varchar   not null, " ++
-	"myseries    varchar   not null, " ++
-	"time        timestamp not null, " ++
-	"weather     varchar   not null, " ++
-	"temperature float, " ++
-	"PRIMARY KEY ((quantum(time, 15, 'm'), myfamily, myseries), " ++
-	"time, myfamily, myseries, temperature))";
+    "myfamily    varchar   not null, " ++
+    "myseries    varchar   not null, " ++
+    "time        timestamp not null, " ++
+    "weather     varchar   not null, " ++
+    "temperature float, " ++
+    "PRIMARY KEY ((myfamily, myseries, quantum(time, 15, 'm')), " ++
+    "myfamily, myseries, time, weather))";
 %% another invalid TS DDL because family/series must be varchar
 %% or is this total bollox???
 get_ddl(keytype_fail_mebbies_or_not_eh_check_it_properly_muppet_boy) ->
     _SQL = "CREATE TABLE GeoCheckin (" ++
-	"myfamily    integer   not null, " ++
-	"myseries    varchar   not null, " ++
-	"time        timestamp not null, " ++
-	"weather     varchar   not null, " ++
-	"temperature float, " ++
-	"PRIMARY KEY ((quantum(time, 15, 'm'), myfamily, myseries), " ++
-	"time, myfamily, myseries))".
+    "myfamily    integer   not null, " ++
+    "myseries    varchar   not null, " ++
+    "time        timestamp not null, " ++
+    "weather     varchar   not null, " ++
+    "temperature float, " ++
+    "PRIMARY KEY ((myfamily, myseries, quantum(time, 15, 'm')), " ++
+    "myfamily, myseries, time))".
 
 get_valid_obj() ->
     [get_varchar(),

--- a/tests/ts_A_create_table_already_created.erl
+++ b/tests/ts_A_create_table_already_created.erl
@@ -1,4 +1,4 @@
--module(ts_A_create_table_fail_4).
+-module(ts_A_create_table_already_created).
 
 -behavior(riak_test).
 

--- a/tests/ts_A_create_table_short_key.erl
+++ b/tests/ts_A_create_table_short_key.erl
@@ -1,4 +1,4 @@
--module(ts_A_create_table_fail_2).
+-module(ts_A_create_table_short_key).
 
 -behavior(riak_test).
 
@@ -14,5 +14,5 @@
 confirm() ->
     ClusterType = single,
     DDL = get_ddl(shortkey_fail),
-    Expected = {ok,"some error message, yeah?"},
+    Expected = {ok,"Error creating bucket type GeoCheckin:\nPrimary key is too short\n"},
     confirm_create(ClusterType, DDL, Expected).

--- a/tests/ts_A_create_table_split_key.erl
+++ b/tests/ts_A_create_table_split_key.erl
@@ -1,4 +1,4 @@
--module(ts_A_create_table_fail_1).
+-module(ts_A_create_table_split_key).
 
 -behavior(riak_test).
 
@@ -13,6 +13,6 @@
 
 confirm() ->
     ClusterType = single,
-    DDL = get_ddl(shortkey_fail),
-    Expected = {ok,"this should fail - but doesnt currently"},
+    DDL = get_ddl(splitkey_fail),
+    Expected = {ok,"Error creating bucket type GeoCheckin:\nLocal key does not match primary key\n"},
     confirm_create(ClusterType, DDL, Expected).


### PR DESCRIPTION
Failing table creation tests, were fixed renamed:
- ts_A_create_table_fail_1 → ts_A_create_table_short_key
- ts_A_create_table_fail_2 → ts_A_create_table_split_key
- ts_A_create_table_fail_4 → ts_A_create_table_already_created

This PR relies upon https://github.com/basho/riak_kv/pull/1244