### PR TITLE
Fixed ts_api test to pass once the badarith bugfix is checked in

### DIFF
--- a/tests/ts_api.erl
+++ b/tests/ts_api.erl
@@ -99,3 +99,4 @@ confirm_NeqOps(C) ->
     ts_api_util:confirm_Pass(C, {myfloat, float,   '!=', 2.0}),
     ts_api_util:confirm_Pass(C, {mybin,   varchar, '!=', test2}),
     ts_api_util:confirm_Pass(C, {mybool,  boolean, '!=', true}).
+

--- a/tests/ts_api_util.erl
+++ b/tests/ts_api_util.erl
@@ -90,8 +90,8 @@ get_ddl(api) ->
 	"mybin       varchar     not null, " ++
 	"myfloat     float       not null, " ++
 	"mybool      boolean     not null, " ++
-	"PRIMARY KEY ((quantum(time, 15, 'm'), myfamily, myseries), " ++
-	"time, myfamily, myseries))".
+	"PRIMARY KEY ((myfamily, myseries, quantum(time, 15, 'm')), " ++
+	"myfamily, myseries, time))".
 
 get_map(api) ->
     [{<<"myfamily">>, 1},


### PR DESCRIPTION
ts_api needed to have its primary key construction reversed to match the reversal of the PK construction in the DDL compiler