### PR TITLE
Fixed ts_A_put_pass_2 to pass.  Primary key was backwards, type 'any'…

### DIFF
--- a/tests/ts_A_put_pass_2.erl
+++ b/tests/ts_A_put_pass_2.erl
@@ -21,16 +21,16 @@ confirm() ->
 	"myfloat     float       not null, " ++
 	"mybool      boolean     not null, " ++
 	"mytimestamp timestamp   not null, " ++
-	"myany       any         not null, " ++
 	"myoptional  integer, " ++
-	"PRIMARY KEY ((quantum(time, 15, 'm'), myfamily, myseries), " ++
-	"time, myfamily, myseries))",
+	"PRIMARY KEY ((myfamily, myseries, quantum(time, 15, 'm')), " ++
+	"myfamily, myseries, time))",
     Family = <<"family1">>,
     Series = <<"seriesX">>,
     N = 10,
     Data = make_data(N, Family, Series, []),
     %% Expected is wrong but we can't write data at the moment
-    ?assertEqual(ok, timeseries_util:confirm_put(Cluster, TestType, DDL, Data)).
+    ?assertEqual(ok, timeseries_util:confirm_put(Cluster, TestType, DDL, Data)),
+    pass.
 
 make_data(0, _, _, Acc) ->
     Acc;
@@ -43,15 +43,12 @@ make_data(N, F, S, Acc) when is_integer(N) andalso N > 0 ->
 	      N + 0.1, 
 	      get_bool(N), 
 	      N + 100000, 
-	      get_any(N), 
 	      get_optional(N, N)
 	     ],
     make_data(N - 1, F, S, [NewAcc | Acc]).
 
-get_bool(N) when N < 5 -> <<"true">>;
-get_bool(_)            -> <<"false">>.
-
-get_any(N) -> term_to_binary(lists:seq(1, N)).
+get_bool(N) when N < 5 -> true;
+get_bool(_)            -> false.
 
 get_optional(N, X) ->
     case N rem 2 of


### PR DESCRIPTION
… no longer supported, booleans need to be booleans (ie, 'true') and not binaries (<<"true">>), and test must return 'pass' atom after assertions have succeeded