### PR TITLE
Fix missed type rename in ts_A_put_pass_2

### DIFF
--- a/tests/ts_A_put_pass_2.erl
+++ b/tests/ts_A_put_pass_2.erl
@@ -21,7 +21,7 @@ confirm() ->
 	"myfloat     double      not null, " ++
 	"mybool      boolean     not null, " ++
 	"mytimestamp timestamp   not null, " ++
-	"myoptional  integer, " ++
+	"myoptional  sint64, " ++
 	"PRIMARY KEY ((myfamily, myseries, quantum(time, 15, 'm')), " ++
 	"myfamily, myseries, time))",
     Family = <<"family1">>,


### PR DESCRIPTION
One of the datatype renamed was missed.  `integer` is now `sint64`