### PR TITLE
Update the error message for ts_A_select_compare_two_fields_not_allowed

### DIFF
--- a/tests/ts_A_select_compare_two_fields_not_allowed.erl
+++ b/tests/ts_A_select_compare_two_fields_not_allowed.erl
@@ -39,7 +39,6 @@ confirm() ->
         "AND myfamily = 'fa2mily1' "
         "AND myseries ='seriesX' "
         "AND weather = myseries",
-    Expected = "Expect that fields cannot be compared",
-    Got = ts_util:ts_query(ts_util:cluster_and_connect(single), normal, DDL, Data, Qry),
-    ?assertEqual(Expected, Got),
+    {error, Got} = ts_util:ts_query(ts_util:cluster_and_connect(single), normal, DDL, Data, Qry),
+    ?assertNotEqual(0, string:str(binary_to_list(Got), "Comparing or otherwise operating on two fields is not supported")),
     pass.


### PR DESCRIPTION
The previous error message was temporary.