### PR TITLE
Log the start of each test in repl_aae_fullsync

### DIFF
--- a/tests/repl_aae_fullsync.erl
+++ b/tests/repl_aae_fullsync.erl
@@ -46,6 +46,8 @@ confirm() ->
     pass.
 
 simple_test() ->
+    lager:info("Starting simple_test"),
+
     %% Deploy 6 nodes.
     Nodes = rt:deploy_nodes(6, ?CONF(5), [riak_kv, riak_repl]),
 
@@ -118,6 +120,8 @@ simple_test() ->
     pass.
 
 dual_test() ->
+    lager:info("Starting dual_test"),
+
     %% Deploy 6 nodes.
     Nodes = rt:deploy_nodes(6, ?CONF(infinity), [riak_kv, riak_repl]),
 
@@ -218,6 +222,8 @@ dual_test() ->
     pass.
 
 bidirectional_test() ->
+    lager:info("Starting bidirectional_test"),
+
     %% Deploy 6 nodes.
     Nodes = rt:deploy_nodes(6, ?CONF(5), [riak_kv, riak_repl]),
 
@@ -301,6 +307,8 @@ bidirectional_test() ->
     pass.
 
 difference_test() ->
+    lager:info("Starting difference_test"),
+
     %% Deploy 6 nodes.
     Nodes = rt:deploy_nodes(6, ?CONF(5), [riak_kv, riak_repl]),
 
@@ -393,6 +401,8 @@ difference_test() ->
     pass.
 
 deadlock_test() ->
+    lager:info("Starting deadlock_test"),
+
     %% Deploy 6 nodes.
     Nodes = rt:deploy_nodes(6, ?CONF(5), [riak_kv, riak_repl]),
 


### PR DESCRIPTION
This makes it much easier to tell which code is being executed at a given point in the log, since many of the tests print identical log messages.