### PR TITLE
Update tests for different default bucket properties

### DIFF
--- a/tests/bucket_types.erl
+++ b/tests/bucket_types.erl
@@ -10,7 +10,11 @@ confirm() ->
     lager:info("Deploy some nodes"),
     Nodes = rt:build_cluster(4, [], [
                                      {riak_core, [{default_bucket_props,
-                                                   [{n_val, 2}]}]}]),
+                                                   [
+                                                       {n_val, 2},
+                                                       {allow_mult, true},
+                                                       {dvv_enabled, true}
+                                                   ]}]}]),
     Node = hd(Nodes),
 
     RMD = riak_test_runner:metadata(),

--- a/tests/ensemble_byzantine.erl
+++ b/tests/ensemble_byzantine.erl
@@ -56,7 +56,7 @@ confirm() ->
     test_lose_minority_synctrees(PBC, Bucket, Key, Val, PL),
     test_lose_majority_synctrees(PBC, Bucket, Key, Val, PL),
     test_lose_minority_synctrees_one_node_partitioned(PBC, Bucket, Key, Val,
-        PL, Nodes),
+                                                      PL, Nodes),
     test_lose_all_data_and_trees_except_one_node(PBC, Bucket, Key, Val, PL),
     {ok, _NewVal} = test_backup_restore_data_not_trees(Bucket, Key, Val, PL),
     test_lose_all_data(PBC, Bucket, Key, PL),
@@ -64,7 +64,12 @@ confirm() ->
     pass.
 
 config() ->
-    [{riak_core, [{default_bucket_props, [{n_val, 5}]},
+    [{riak_core, [{default_bucket_props,
+                   [
+                    {n_val, 5},
+                    {allow_mult, true},
+                    {dvv_enabled, true}
+                   ]},
                   {vnode_management_timer, 1000},
                   {ring_creation_size, 16},
                   {enable_consensus, true},
@@ -79,7 +84,7 @@ test_lose_majority_synctrees(PBC, Bucket, Key, Val, PL) ->
     assert_lose_synctrees_and_recover(PBC, Bucket, Key, Val, PL, Majority).
 
 test_lose_minority_synctrees_one_node_partitioned(PBC, Bucket, Key, Val, PL,
-  Nodes) ->
+                                                  Nodes) ->
     Minority = minority_vnodes(PL),
     {{Idx0, Node0}, primary} = hd(PL),
     Ensemble = {kv, Idx0, 5},
@@ -251,7 +256,7 @@ kill_peers(Ensemble, Nodes) ->
     Peers = [P || P={_Id, N} <- View, lists:member(N, Nodes)],
     lager:info("Killing Peers: ~p", [Peers]),
     Pids = [rpc:call(Node, riak_ensemble_manager, get_peer_pid,
-             [Ensemble, Peer]) || Peer <- Peers],
+                     [Ensemble, Peer]) || Peer <- Peers],
     [exit(Pid, kill) || Pid <- Pids, Pid =/= undefined].
 
 wipe_partitions(PL) ->

--- a/tests/ensemble_ring_changes.erl
+++ b/tests/ensemble_ring_changes.erl
@@ -27,7 +27,12 @@
 -define(RING_SIZE, 16).
 
 config() ->
-    [{riak_core, [{default_bucket_props, [{n_val, 5}]},
+    [{riak_core, [{default_bucket_props,
+                  [
+                    {n_val, 5},
+                    {allow_mult, true},
+                    {dvv_enabled, true}
+                  ]},
                   {vnode_management_timer, 1000},
                   {ring_creation_size, ?RING_SIZE},
                   {enable_consensus, true},

--- a/tests/ensemble_util.erl
+++ b/tests/ensemble_util.erl
@@ -58,10 +58,15 @@ fast_config(Nval, EnableAAE) when is_boolean(EnableAAE) ->
 
 fast_config(NVal, RingSize, EnableAAE) ->
     [config_aae(EnableAAE),
-     {riak_core, [{default_bucket_props, [{n_val, NVal}]},
-                  {vnode_management_timer, 1000},
-                  {ring_creation_size, RingSize},
-                  {enable_consensus, true}]}].
+     {riak_core, [{default_bucket_props,
+          [
+             {n_val, NVal,
+             {allow_mult, true},
+             {dvv_enabled, true}}
+          ]},
+          {vnode_management_timer, 1000},
+          {ring_creation_size, RingSize},
+          {enable_consensus, true}]}].
 
 config_aae(true) ->
     {riak_kv, [{anti_entropy_build_limit, {100, 1000}},

--- a/tests/ensemble_util.erl
+++ b/tests/ensemble_util.erl
@@ -60,9 +60,9 @@ fast_config(NVal, RingSize, EnableAAE) ->
     [config_aae(EnableAAE),
      {riak_core, [{default_bucket_props,
           [
-             {n_val, NVal,
+             {n_val, NVal},
              {allow_mult, true},
-             {dvv_enabled, true}}
+             {dvv_enabled, true}
           ]},
           {vnode_management_timer, 1000},
           {ring_creation_size, RingSize},

--- a/tests/http_bucket_types.erl
+++ b/tests/http_bucket_types.erl
@@ -13,7 +13,11 @@ confirm() ->
     lager:info("Deploy some nodes"),
     Nodes = rt:build_cluster(4, [], [
                                      {riak_core, [{default_bucket_props,
-                                                   [{n_val, 2}]}]}]),
+                                                   [
+                                                       {n_val, 2},
+                                                       {allow_mult, true},
+                                                       {dvv_enabled, true}
+                                                   ]}]}]),
     Node = hd(Nodes),
 
     RMD = riak_test_runner:metadata(),

--- a/tests/http_security.erl
+++ b/tests/http_security.erl
@@ -30,7 +30,7 @@ confirm() ->
     PrivDir = rt:priv_dir(),
     Conf = [
             {riak_core, [
-                    {default_bucket_props, [{allow_mult, true}]},
+                    {default_bucket_props, [{allow_mult, true}, {dvv_enabled, true}]},
                     {ssl, [
                             {certfile, filename:join([CertDir,
                                                       "site3.basho.com/cert.pem"])},

--- a/tests/overload.erl
+++ b/tests/overload.erl
@@ -59,7 +59,12 @@ default_config(#config{
     fsm_limit = FsmLimit
 }) ->
     [{riak_core, [{ring_creation_size, 8},
-        {default_bucket_props, [{n_val, 5}]},
+        {default_bucket_props,
+            [
+                {n_val, 5},
+                {allow_mult, true},
+                {dvv_enabled, true}
+            ]},
         {vnode_management_timer, 1000},
         {enable_health_checks, false},
         {enable_consensus, true},

--- a/tests/pb_security.erl
+++ b/tests/pb_security.erl
@@ -53,7 +53,7 @@ confirm() ->
     PrivDir = rt:priv_dir(),
     Conf = [
             {riak_core, [
-                {default_bucket_props, [{allow_mult, true}]},
+                {default_bucket_props, [{allow_mult, true}, {dvv_enabled, true}]},
                 {ssl, [
                     {certfile, filename:join([CertDir,"site3.basho.com/cert.pem"])},
                     {keyfile, filename:join([CertDir, "site3.basho.com/key.pem"])},

--- a/tests/repl_aae_fullsync.erl
+++ b/tests/repl_aae_fullsync.erl
@@ -16,7 +16,12 @@
         {riak_core,
             [
              {ring_creation_size, 8},
-             {default_bucket_props, [{n_val, 1}]}
+             {default_bucket_props,
+                 [
+                     {n_val, 1},
+                     {allow_mult, true},
+                     {dvv_enabled, true}
+                 ]}
             ]
         },
         {riak_kv,

--- a/tests/repl_aae_fullsync_custom_n.erl
+++ b/tests/repl_aae_fullsync_custom_n.erl
@@ -22,7 +22,12 @@ confirm() ->
             {riak_core,
                 [
                  {ring_creation_size, 8},
-                 {default_bucket_props, [{n_val, 1}]}
+                 {default_bucket_props,
+                     [
+                         {n_val, 1},
+                         {allow_mult, true},
+                         {dvv_enabled, true}
+                     ]}
                 ]
             },
             {riak_kv,

--- a/tests/repl_cancel_fullsync.erl
+++ b/tests/repl_cancel_fullsync.erl
@@ -11,7 +11,12 @@
         {riak_core,
             [
              {ring_creation_size, 8},
-             {default_bucket_props, [{n_val, 1}]}
+             {default_bucket_props,
+                 [
+                     {n_val, 1},
+                     {allow_mult, true},
+                     {dvv_enabled, true}
+                 ]}
             ]
         },
         {riak_kv,

--- a/tests/repl_location_failures.erl
+++ b/tests/repl_location_failures.erl
@@ -13,7 +13,12 @@
         {riak_core,
             [
              {ring_creation_size, 8},
-             {default_bucket_props, [{n_val, 1}]}
+             {default_bucket_props,
+                 [
+                     {n_val, 1},
+                     {allow_mult, true},
+                     {dvv_enabled, true}
+                 ]}
             ]
         },
         {riak_kv,

--- a/tests/replication_object_reformat.erl
+++ b/tests/replication_object_reformat.erl
@@ -11,7 +11,12 @@
         {riak_core,
             [
              {ring_creation_size, 8},
-             {default_bucket_props, [{n_val, ?N}]}
+             {default_bucket_props,
+                 [
+                     {n_val, ?N},
+                     {allow_mult, true},
+                     {dvv_enabled, true}
+                 ]}
             ]
         },
         {riak_kv,

--- a/tests/verify_counter_repl.erl
+++ b/tests/verify_counter_repl.erl
@@ -62,7 +62,7 @@ confirm() ->
 make_clusters() ->
     Conf = [{riak_repl, [{fullsync_on_connect, false},
                          {fullsync_interval, disabled}]},
-           {riak_core, [{default_bucket_props, [{allow_mult, true}]}]}],
+           {riak_core, [{default_bucket_props, [{allow_mult, true}, {dvv_enabled, true}]}]}],
     Nodes = rt:deploy_nodes(6, Conf, [riak_kv, riak_repl]),
     {ClusterA, ClusterB} = lists:split(3, Nodes),
     A = make_cluster(ClusterA, "A"),

--- a/tests/verify_handoff_write_once.erl
+++ b/tests/verify_handoff_write_once.erl
@@ -60,7 +60,12 @@ confirm() ->
 
 create_config(Backend) ->
     [{riak_core, [
-        {default_bucket_props, [{n_val, 1}]},
+        {default_bucket_props,
+            [
+                {n_val, 1},
+                {allow_mult, true},
+                {dvv_enabled, true}
+            ]},
         {ring_creation_size, 8},
         {handoff_acksync_threshold, 20},
         {handoff_concurrency, 4},

--- a/tests/verify_write_once.erl
+++ b/tests/verify_write_once.erl
@@ -304,7 +304,12 @@ config(RingSize, NVal) ->
 config(RingSize, NVal, Backend) ->
     [
         {riak_core, [
-            {default_bucket_props, [{n_val, NVal}]},
+            {default_bucket_props,
+                [
+                    {n_val, NVal},
+                    {allow_mult, true},
+                    {dvv_enabled, true}
+                ]},
             {vnode_management_timer, 1000},
             {ring_creation_size, RingSize}]
         },

--- a/tests/yz_default_bucket_type_upgrade.erl
+++ b/tests/yz_default_bucket_type_upgrade.erl
@@ -38,7 +38,12 @@
         [{riak_core,
           [
            {ring_creation_size, 16},
-           {default_bucket_props, [{n_val, ?N}]},
+           {default_bucket_props,
+               [
+                   {n_val, ?N},
+                   {allow_mult, true},
+                   {dvv_enabled, true}
+               ]},
            {anti_entropy_build_limit, {100, 1000}},
            {anti_entropy_concurrency, 8}
           ]},


### PR DESCRIPTION
In Riak 2.1.2 there's been a small, subtle change made in the way that default bucket properties work. To ensure all our tests keep working the same way, we need to explicitly specify settings for allow_mult and dvv_enabled whenever we have a custom value set for riak_core.default_bucket_props. Most of these changes may not be strictly necessary, but we do at least need the change to repl_aae_fullsync, and in general it's better to be explicit about what we expect.

For more background, see https://github.com/basho/riak_core/pull/765

This PR also includes a couple of indentation fixes, and a small, unrelated change that adds some extra logging to wait_until_no_pending_changes.

Doug and I ran through each of the modified tests as well, just to verify that nothing was broken by these changes.
