### PR TITLE
Log PIDs by default for console output

### DIFF
--- a/src/riak_test_escript.erl
+++ b/src/riak_test_escript.erl
@@ -110,8 +110,9 @@ main(Args) ->
             notice
     end,
 
+    Formatter = {lager_default_formatter, [time," [",severity,"] ", pid, " ", message, "\n"]},
     application:set_env(lager, error_logger_hwm, 250), %% helpful for debugging
-    application:set_env(lager, handlers, [{lager_console_backend, ConsoleLagerLevel},
+    application:set_env(lager, handlers, [{lager_console_backend, [ConsoleLagerLevel, Formatter]},
                                           {lager_file_backend, [{file, "log/test.log"},
                                                                 {level, ConsoleLagerLevel}]}]),
     lager:start(),


### PR DESCRIPTION
We've run into a number of issues over time where errant processes hang
around and stomp on other tests, and without PIDs in the logging it can
be difficult or impossible to conclusively identify and debug these
kinds of problems.