### PR TITLE
Return 0 instead of doing another rt:sysread in repl_util:wait_for_reads/5

### DIFF
--- a/src/rt.erl
+++ b/src/rt.erl
@@ -664,7 +664,7 @@ wait_until(Fun) when is_function(Fun) ->
 
 %% @doc Convenience wrapper for wait_until for the myriad functions that
 %% take a node as single argument.
--spec wait_until(node(), fun((node()) -> boolean())) -> ok | {fail, Result :: term()}.
+-spec wait_until(node(), fun(() -> boolean())) -> ok | {fail, Result :: term()}.
 wait_until(Node, Fun) when is_atom(Node), is_function(Fun) ->
     wait_until(fun() -> Fun(Node) end);
 

--- a/src/rt.erl
+++ b/src/rt.erl
@@ -664,7 +664,7 @@ wait_until(Fun) when is_function(Fun) ->
 
 %% @doc Convenience wrapper for wait_until for the myriad functions that
 %% take a node as single argument.
--spec wait_until([node()], fun((node()) -> boolean())) -> ok.
+-spec wait_until(node(), fun((node()) -> boolean())) -> ok | {fail, Result :: term()}.
 wait_until(Node, Fun) when is_atom(Node), is_function(Fun) ->
     wait_until(fun() -> Fun(Node) end);
 

--- a/tests/repl_util.erl
+++ b/tests/repl_util.erl
@@ -195,14 +195,17 @@ wait_until_fullsync_stopped(SourceLeader) ->
                   end).
 
 wait_for_reads(Node, Start, End, Bucket, R) ->
-    rt:wait_until(Node,
+    ok = rt:wait_until(Node,
         fun(_) ->
                 Reads = rt:systest_read(Node, Start, End, Bucket, R, <<>>, true),
                 Reads == []
         end),
-    Reads = rt:systest_read(Node, Start, End, Bucket, R, <<>>, true),
-    lager:info("Reads: ~p", [Reads]),
-    length(Reads).
+    %% rt:systest_read/6 returns a list of errors encountered while performing
+    %% the requested reads. Since we are asserting this list is empty above,
+    %% we already know that if we reached here, that the list of reads has
+    %% no errors. Therefore, we simply return 0 and do not execute another
+    %% systest_read call.
+    0.
 
 get_fs_coord_status_item(Node, SinkName, ItemName) ->
     Status = rpc:call(Node, riak_repl_console, status, [quiet]),


### PR DESCRIPTION
Previously, wait_until_read function would execute
another rt:systest_read call and return a count of
errors, when we already asserted above that the list
is empty.

If the wait_until function does not return true, or
times out, or hits the retry limit, the running test
ought to fail anyway without needing an additional
read to fail.

So doing another call is redundant and unnecessary;
we just return 0 as the value if rt:wait_until
completes successfully.