### PR TITLE
include a stream_list_keys in ts_basic

### DIFF
--- a/bin/rtdev-setup-releases.sh
+++ b/bin/rtdev-setup-releases.sh
@@ -42,6 +42,10 @@ git init
 git config user.name "Riak Test"
 git config user.email "dev@basho.com"
 
+## this prevents priv/*.so files from being deleted by git clean -fd
+## (the latter is executed in rtdev-current.sh):
+echo "priv/" >.gitignore
+
 git add .
 git commit -a -m "riak_test init" > /dev/null
 echo " - Successfully completed initial git commit of $RT_DEST_DIR"

--- a/tests/ts_basic.erl
+++ b/tests/ts_basic.erl
@@ -179,7 +179,7 @@ confirm_list_keys(C) ->
     io:format("Nothing listed from a non-existent bucket: ~p\n", [ResFail]),
     ?assertMatch({error, _}, ResFail),
 
-    {keys, Keys} = _Res = riakc_ts:list_keys(C, ?BUCKET, []),
+    {keys, Keys} = _Res = riakc_ts:stream_list_keys(C, ?BUCKET, []),
     io:format("Listed ~b keys\n", [length(Keys)]),
     ?assertEqual(?LIFESPAN, length(Keys)),
     ok.


### PR DESCRIPTION
RTS-697. Requires https://github.com/basho/riak_kv/pull/1291.

With changes in https://github.com/basho/riak_kv/pull/1291, ts_basic will have `riakc_ts:list_keys/3` scrapped and replaced by a wrapper around `riakc_ts:stream_list_keys/3`.

The wrapper works by repeatedly calling and collecting keys from the streaming version of list_keys until the required, known, number of keys is received. This becomes necessary because the streaming version, working asynchronously, takes some time to return the keys intended to be in the bucket.