### PR TITLE
Pause to allow delete_mode delay to function

### DIFF
--- a/tests/ts_basic.erl
+++ b/tests/ts_basic.erl
@@ -73,6 +73,11 @@ confirm_all_from_node(Node, Data, PvalP1, PvalP2) ->
     ok = confirm_delete(C, lists:nth(15, Data)),
     ok = confirm_nx_delete(C),
 
+    %% Pause briefly. Deletions have a default 3 second
+    %% reaping interval, and our list keys test may run
+    %% afoul of that.
+    timer:sleep(3500),
+
     %% 5. select
     ok = confirm_select(C, PvalP1, PvalP2),
 

--- a/tests/ts_basic.erl
+++ b/tests/ts_basic.erl
@@ -194,6 +194,7 @@ confirm_delete_all(C) ->
     lists:foreach(
       fun(K) -> ok = riakc_ts:delete(C, ?BUCKET, tuple_to_list(K), []) end,
       Keys),
+    timer:sleep(3500),
     {keys, Res} = riakc_ts:list_keys(C, ?BUCKET, []),
     io:format("Deleted all: ~p\n", [Res]),
     ?assertMatch([], Res),


### PR DESCRIPTION
Key lists have historically included tombstones. In TS they have not because Andrei's code had to open each object to determine the key; with @jonmeredith's forthcoming changes, we can now reliably generate the key tuple without opening the object.

Because of this, we'll start seeing `ts_basic` failures because the list keys function still sees the deleted object because the tombstone has yet to be reaped. Introduce a small delay to allow reaping.