### PR TITLE
Add cleanup intercepts fuction

### DIFF
--- a/intercepts/intercept.erl
+++ b/intercepts/intercept.erl
@@ -54,7 +54,7 @@
 %%             functions.
 %%
 %%             E.g. `[{{update_perform,2}, sleep_update_perform}]'
--spec add(module(), module(), mapping()) -> ok.
+-spec add(module(), module(), mapping(), string()) -> ok.
 add(Target, Intercept, Mapping, OutDir) ->
     Original = ?ORIGINAL(Target),
     TargetAC = get_abstract_code(Target),
@@ -66,6 +66,7 @@ add(Target, Intercept, Mapping, OutDir) ->
     ok = compile_and_load(Original, OrigAC, OutDir),
     ok = compile_and_load(Target, ProxyAC, OutDir).
 
+-spec add(module(), module(), mapping()) -> ok.
 add(Target, Intercept, Mapping) ->
     add(Target, Intercept, Mapping, undefined).
 

--- a/intercepts/intercept.erl
+++ b/intercepts/intercept.erl
@@ -22,7 +22,7 @@
 %% Export explicit API but also send compile directive to export all
 %% because some of these private functions are useful in their own
 %% right.
--export([add/3, add/4]).
+-export([add/3, add/4, clean/1]).
 -compile(export_all).
 
 -type abstract_code() :: term().
@@ -68,6 +68,18 @@ add(Target, Intercept, Mapping, OutDir) ->
 
 add(Target, Intercept, Mapping) ->
     add(Target, Intercept, Mapping, undefined).
+
+%% @doc Cleanup proxy and backuped original module
+-spec clean(module()) -> ok|{error, term()}.
+clean(Target) ->
+    _ = code:purge(Target),
+    _ = code:purge(?ORIGINAL(Target)),
+    case code:load_file(Target) of
+        {module, Target} ->
+            ok;
+        {error, Reason} ->
+            {error, Reason}
+    end.
 
 %% @private
 %%

--- a/src/rt_intercept.erl
+++ b/src/rt_intercept.erl
@@ -78,6 +78,12 @@ add(Node, {Target, Intercept, Mapping}, OutDir) ->
     NMapping = [transform_anon_fun(M) || M <- Mapping],
     ok = rpc:call(Node, intercept, add, [Target, Intercept, NMapping, OutDir]).
 
+clean(Node, Targets) when is_list(Targets) ->
+    [ok = clean(Node, T) || T <- Targets],
+    ok;
+clean(Node, Target) ->
+    ok = rpc:call(Node, intercept, clean, [Target]).
+
 %% The following function transforms anonymous function mappings passed
 %% from an Erlang shell. Anonymous intercept functions from compiled code
 %% require the developer to supply free variables themselves, and also


### PR DESCRIPTION
This PR introduces rt_intercept:clean/2 which purges specified target module created as a proxy
and its backed up original module, then reloads original module.