### PR TITLE
Coverage query test for TimeSeries

### DIFF
--- a/tests/ts_A_coverage.erl
+++ b/tests/ts_A_coverage.erl
@@ -19,7 +19,7 @@
 %% -------------------------------------------------------------------
 %% @doc A module to test riak_ts cover plan retrieval/usage.
 
--module(ts_coverage).
+-module(ts_A_coverage).
 -behavior(riak_test).
 -export([confirm/0]).
 -include_lib("eunit/include/eunit.hrl").
@@ -47,7 +47,7 @@ confirm() ->
     test_quanta_range(Table, lists_to_tuples(Data), Nodes, QuantaTally, QuantumMS),
     pass.
 
-    
+
 %% We put data with each record as a list, but in the results it's a tuple
 lists_to_tuples(Rows) ->
     lists:map(fun erlang:list_to_tuple/1, Rows).

--- a/tests/ts_coverage.erl
+++ b/tests/ts_coverage.erl
@@ -104,7 +104,7 @@ assert_disjoint_ranges(Data1, Data2) ->
     Times2 = [A || [_, _, A|_] <- Data2],
     {Ta1, Tz1} = {hd(Times1), lists:last(Times1)},
     {Ta2, Tz2} = {hd(Times2), lists:last(Times2)},
-    Disjoint = ((Ta1 < Ta2) and (Tz1 < Ta2)) or ((Tz1 > Tz2) and (Ta1 > Tz2)),
+    Disjoint = (Tz1<Ta2) or (Tz2<Ta1),
     ?assert(Disjoint == true),
     ok.
 

--- a/tests/ts_coverage.erl
+++ b/tests/ts_coverage.erl
@@ -66,6 +66,7 @@ test_quanta_range(Table, ExpectedData, Nodes, NumQuanta, QuantumMS) ->
                             {ok, Pid} = riakc_pb_socket:start_link(binary_to_list(IP),
                                                                    Port),
                             {_Headers, ThisQuantum} = riakc_ts:query(Pid, Qry, [], C),
+                            riakc_pb_socket:stop(Pid),
 
                             %% Let's compare the range data with the
                             %% query results to make sure the latter

--- a/tests/ts_coverage.erl
+++ b/tests/ts_coverage.erl
@@ -1,0 +1,83 @@
+% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2015 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+%% @doc A module to test riak_ts cover plan retrieval/usage.
+
+-module(ts_coverage).
+-behavior(riak_test).
+-export([confirm/0]).
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("riak_pb/include/riak_ts_pb.hrl").
+
+confirm() ->
+    %% 100 quanta to populate
+    QuantaTally = 100,
+    %% Each quantum is 15 minutes in milliseconds
+    QuantumMS = 15 * 60 * 1000,
+    UpperBoundExcl = QuantaTally * QuantumMS,
+    TimesGeneration = fun() -> lists:seq(1, UpperBoundExcl-1, 3124) end,
+    DDL = ts_util:get_ddl(),
+    Data = ts_util:get_valid_select_data(TimesGeneration),
+    Nodes = ts_util:build_cluster(multiple),
+    Table = ts_util:get_default_bucket(),
+    ts_util:create_table(normal, Nodes, DDL, Table),
+    ok = riakc_ts:put(rt:pbc(hd(Nodes)), Table, Data),
+    %% First test on a small range well within the size of a normal query
+    SmallData = lists:filter(fun([_, _, Time, _, _]) ->
+                                     Time < (4 * QuantumMS)
+                             end, Data),
+    test_quanta_range(Table, lists_to_tuples(SmallData), Nodes, 4, QuantumMS),
+    %% Now test the full range
+    test_quanta_range(Table, lists_to_tuples(Data), Nodes, QuantaTally, QuantumMS),
+    pass.
+
+    
+%% We put data with each record as a list, but in the results it's a tuple
+lists_to_tuples(Rows) ->
+    lists:map(fun erlang:list_to_tuple/1, Rows).
+
+test_quanta_range(Table, ExpectedData, Nodes, NumQuanta, QuantumMS) ->
+    AdminPid = rt:pbc(lists:nth(3, Nodes)),
+    OtherPid = rt:pbc(lists:nth(2, Nodes)),
+    Qry = ts_util:get_valid_qry(-1, NumQuanta * QuantumMS),
+    ?debugFmt("Query: ~ts~n", [Qry]),
+    {ok, CoverageEntries} = riakc_ts:get_coverage(AdminPid, Table, Qry),
+
+    ?debugFmt("Found ~B coverage entries~n", [length(CoverageEntries)]),
+    Results = 
+        lists:foldl(fun(#tscoverageentry{ip=IP, port=Port, cover_context=C}, Acc) ->
+                            {ok, Pid} = riakc_pb_socket:start_link(binary_to_list(IP),
+                                                                   Port),
+                            {_Headers, ThisQuantum} = riakc_ts:query(Pid, Qry, [], C),
+                            ThisQuantum ++ Acc
+                    end,
+                    [],
+                    CoverageEntries),
+    ?debugFmt("Found ~B results~n", [length(Results)]),
+    ?assertEqual(lists:sort(ExpectedData), lists:sort(Results)),
+
+    %% Expect {error,{1001,<<"{too_many_subqueries,13}">>}} if NumQuanta > 5
+    case NumQuanta > 5 of
+        true ->
+            ?assertMatch({error, {1001, _}}, riakc_ts:query(OtherPid, Qry));
+        false ->
+            {_, StraightQueryResults} = riakc_ts:query(OtherPid, Qry),
+            ?assertEqual(lists:sort(ExpectedData), lists:sort(StraightQueryResults))
+    end.
+

--- a/tests/ts_util.erl
+++ b/tests/ts_util.erl
@@ -32,6 +32,7 @@
     create_bucket_type/2,
     create_bucket_type/3,
     create_bucket_type/4,
+    create_table/4,
     exclusive_result_from_data/3,
     get_bool/1,
     get_cols/0, get_cols/1,
@@ -49,9 +50,9 @@
     get_valid_aggregation_data/1,
     get_valid_big_data/1,
     get_valid_obj/0,
-    get_valid_qry/0,
+    get_valid_qry/0, get_valid_qry/2,
     get_valid_qry_spanning_quanta/0,
-    get_valid_select_data/0,
+    get_valid_select_data/0, get_valid_select_data/1,
     get_valid_select_data_spanning_quanta/0,
     get_varchar/0,
     maybe_stop_a_node/2,
@@ -222,6 +223,9 @@ get_default_bucket() ->
 get_valid_qry() ->
     "select * from GeoCheckin Where time > 1 and time < 10 and myfamily = 'family1' and myseries ='seriesX'".
 
+get_valid_qry(Lower, Upper) ->
+    lists:flatten(io_lib:format("select * from GeoCheckin Where time > ~B and time < ~B and myfamily = 'family1' and myseries ='seriesX'", [Lower, Upper])).
+
 get_invalid_qry(borked_syntax) ->
     "selectah * from GeoCheckin Where time > 1 and time < 10";
 get_invalid_qry(key_not_covered) ->
@@ -234,9 +238,12 @@ get_invalid_qry(type_error) ->
     "select * from GeoCheckin Where time > 1 and time < 10 and myfamily = 'family1' and myseries ='seriesX' and weather > true".
 
 get_valid_select_data() ->
+    get_valid_select_data(fun() -> lists:seq(1, 10) end).
+
+get_valid_select_data(SeqFun) ->
     Family = <<"family1">>,
     Series = <<"seriesX">>,
-    Times = lists:seq(1, 10),
+    Times = SeqFun(),
     [[Family, Series, X, get_varchar(), get_float()] || X <- Times].
 
 


### PR DESCRIPTION
* Test the new functionality that allows for subqueries to be executed individually
* Slightly extend functionality in `ts_util` to assist