### PR TITLE
Ensure git adds everything and ignores any global ignore settings

### DIFF
--- a/bin/rtdev-install.sh
+++ b/bin/rtdev-install.sh
@@ -37,5 +37,5 @@ echo " - Writing $RT_DEST_DIR/$RELEASE/VERSION"
 echo -n $VERSION > $RT_DEST_DIR/$RELEASE/VERSION
 cd $RT_DEST_DIR
 echo " - Reinitializing git state"
-git add .
+git add --all --force .
 git commit -a -m "riak_test init" --amend > /dev/null

--- a/bin/rtdev-setup-releases.sh
+++ b/bin/rtdev-setup-releases.sh
@@ -42,6 +42,6 @@ git init
 git config user.name "Riak Test"
 git config user.email "dev@basho.com"
 
-git add .
+git add --all --force .
 git commit -a -m "riak_test init" > /dev/null
 echo " - Successfully completed initial git commit of $RT_DEST_DIR"


### PR DESCRIPTION
@javajolt - this is why my initial test didn't complete. The Riak log files showed that the shared object file `crypto.so` could not be loaded, but I was certain it was in the devrel I had built. Turns out I have `*.so` as a global git ignore on my system, so these files weren't added to the git repo used to set up and reset dev envs for `riak_test`. Adding the `--all` and `--force` arguments ensures that everything is added.