### PR TITLE
WIP: Fix secondary index exact match when bucket type used

### DIFF
--- a/tests/proxy_overload_recovery.erl
+++ b/tests/proxy_overload_recovery.erl
@@ -236,6 +236,15 @@ prepare_next(S, RT, [ThresholdSeed]) ->
     {_RequestInterval, _Interval, Threshold} = get_params(ThresholdSeed),
     S#tstate{rt = RT, threshold = Threshold}.
 
+wait_for_vnode_change(VPid0, Index) ->
+    {ok, VPid1} = riak_core_vnode_manager:get_vnode_pid(Index, riak_kv_vnode),
+        case VPid1 of
+            VPid0 ->
+                timer:sleep(1),
+                wait_for_vnode_change(VPid0, Index);
+            _ ->
+                VPid1
+        end.
 
 %%
 %% Suspend the vnode so it cannot process messages and builds
@@ -476,14 +485,3 @@ confirm() ->
     pass.
 
 -endif.
-
-
-wait_for_vnode_change(VPid0, Index) ->
-    {ok, VPid1} = riak_core_vnode_manager:get_vnode_pid(Index, riak_kv_vnode),
-        case VPid1 of
-            VPid0 ->
-                timer:sleep(1),
-                wait_for_vnode_change(VPid0, Index);
-            _ ->
-                VPid1
-        end.

--- a/tests/verify_2i_returnterms.erl
+++ b/tests/verify_2i_returnterms.erl
@@ -25,6 +25,8 @@
                                stream_pb/3, http_query/3]).
 -define(BUCKET, <<"2ibucket">>).
 -define(FOO, <<"foo">>).
+-define(BAZ, <<"baz">>).
+-define(BAT, <<"bat">>).
 -define(Q_OPTS, [{return_terms, true}]).
 
 confirm() ->
@@ -38,14 +40,19 @@ confirm() ->
 
     [put_an_object(PBPid, N) || N <- lists:seq(0, 100)],
     [put_an_object(PBPid, int_to_key(N), N, ?FOO) || N <- lists:seq(101, 200)],
+    put_an_object(PBPid, int_to_key(201), 201, ?BAZ),
+    put_an_object(PBPid, int_to_key(202), 202, ?BAT),
 
     %% Bucket, key, and index_eq queries should ignore `return_terms'
-    ExpectedKeys = lists:sort([int_to_key(N) || N <- lists:seq(0, 200)]),
+    ExpectedKeys = lists:sort([int_to_key(N) || N <- lists:seq(0, 202)]),
     assertEqual(RiakHttp, PBPid, ExpectedKeys, {<<"$key">>, int_to_key(0), int_to_key(999)}, ?Q_OPTS, keys),
     assertEqual(RiakHttp, PBPid, ExpectedKeys, { <<"$bucket">>, ?BUCKET}, ?Q_OPTS, keys),
 
     ExpectedFooKeys = lists:sort([int_to_key(N) || N <- lists:seq(101, 200)]),
     assertEqual(RiakHttp, PBPid, ExpectedFooKeys, {<<"field1_bin">>, ?FOO}, ?Q_OPTS, keys),
+
+    assertEqual(RiakHttp, PBPid, [int_to_key(201)], {<<"field1_bin">>, ?BAZ}, ?Q_OPTS, keys),
+    assertEqual(RiakHttp, PBPid, [int_to_key(201)], {<<"field2_int">>, 201}, ?Q_OPTS, keys),
 
     ExpectedRangeResults = lists:sort([{list_to_binary(integer_to_list(N)), int_to_key(N)} || N <- lists:seq(1, 100)]),
     assertEqual(RiakHttp, PBPid, ExpectedRangeResults, {<<"field2_int">>, "1", "100"}, ?Q_OPTS, results),


### PR DESCRIPTION
RIAK-2360 (#1329) in JURA

basho/riak_kv#1329
