### PR TITLE
RTS-877: Adjust the error message for ts_simple_select_compare_two_fields_not_allowed

### DIFF
--- a/tests/ts_simple_select_compare_two_fields_not_allowed.erl
+++ b/tests/ts_simple_select_compare_two_fields_not_allowed.erl
@@ -38,7 +38,7 @@ confirm() ->
         "AND myfamily = 'fa2mily1' "
         "AND myseries ='seriesX' "
         "AND weather = myseries",
-    {error, Got} = ts_util:ts_query(
+    {error, {1001, Got}} = ts_util:ts_query(
                      ts_util:cluster_and_connect(single), normal, DDL, Data, Qry),
     ?assertNotEqual(0, string:str(
                          binary_to_list(Got),


### PR DESCRIPTION
This includes the error number added by KV.  Requires https://github.com/basho/riak_ql/pull/101