### PR TITLE
Return an error when deleting a key that does not exist RTS-894

### DIFF
--- a/tests/ts_cluster_comprehensive.erl
+++ b/tests/ts_cluster_comprehensive.erl
@@ -167,9 +167,10 @@ confirm_delete(C, [Pooter1, Pooter2, Timepoint | _] = Record) ->
     ok.
 
 confirm_nx_delete(C) ->
-    Res = riakc_ts:delete(C, ?BUCKET, ?BADKEY, []),
-    io:format("Not deleted non-existing key: ~p\n", [Res]),
-    ?assertEqual(ok, Res),
+    ?assertEqual(
+        {error, {1021, <<"notfound">>}},
+        riakc_ts:delete(C, ?BUCKET, ?BADKEY, [])
+    ),
     ok.
 
 confirm_select(C, PvalP1, PvalP2) ->


### PR DESCRIPTION
Currently `ok` is returned when a single key delete is issued against a key that does not exist.

With this change `{error, {1021, <<"notfound">>}}` is returned instead. 1021 is a new error code for the case where the key does not exist.