### PR TITLE
RTS-899: Tweak assert_disjoint_ranges/2 to test the case where the list is empty

### DIFF
--- a/tests/ts_cluster_coverage.erl
+++ b/tests/ts_cluster_coverage.erl
@@ -102,11 +102,16 @@ assert_disjoint_ranges(_, []) ->
 assert_disjoint_ranges(Data1, Data2) ->
     Times1 = [A || [_, _, A|_] <- Data1],
     Times2 = [A || [_, _, A|_] <- Data2],
-    {Ta1, Tz1} = {hd(Times1), lists:last(Times1)},
-    {Ta2, Tz2} = {hd(Times2), lists:last(Times2)},
+    {Ta1, Tz1} = first_and_last_times(Times1),
+    {Ta2, Tz2} = first_and_last_times(Times2),
     Disjoint = (Tz1<Ta2) or (Tz2<Ta1),
     ?assert(Disjoint == true),
     ok.
+
+first_and_last_times([]) ->
+    {[],[]};
+first_and_last_times(Times) ->
+    {hd(Times), lists:last(Times)}.
 
 time_within_range(Time, Lower, LowerIncl, Upper, UpperIncl) ->
     if


### PR DESCRIPTION
This failed on a previous test run because `Times1` had an empty list: http://giddyup.basho.com/#/projects/riak_ts/scorecards/197/197-2892-ts_cluster_coverage-centos-6-64-eleveldb/211715/artifacts/8295333