### PR TITLE
test TS HTTP API, reusing ts_cluster_comprehensive scenario

### DIFF
--- a/tests/ts_cluster_comprehensive.erl
+++ b/tests/ts_cluster_comprehensive.erl
@@ -35,6 +35,13 @@
 -define(BADKEY, [<<"b">>,<<"a">>, ?TIMEBASE-1]).
 -define(LIFESPAN, 300).  %% > 100, which is the default chunk size for list_keys
 
+%% passed to Client:get and :delete, for riakhttpc to properly
+%% construct URLs for the case of {send_key_as,
+%% path_elements}. Ignored by riakc.
+-define(EXTRA_SINGLE_KEY_OPTIONS,
+        [{key_column_names, [?PKEY_P1, ?PKEY_P2, ?PKEY_P3]}]).
+
+
 confirm() ->
     inets:start(),
     run_tests(?PVAL_P1, ?PVAL_P2).
@@ -69,6 +76,7 @@ get_client_at_node(Node, ClientMod) ->
         rhc_ts ->
             {ok, [{IP, Port}]} = rt:get_http_conn_info(Node),
             rhc_ts:create(IP, Port, [])
+            %% select mode with {send_key_as, json|path_elements}
     end.
 
 confirm_create_table({Mod, C}) ->
@@ -178,29 +186,29 @@ confirm_overwrite({Mod, C}, Data) ->
     ok.
 
 confirm_delete({Mod, C}, [Pooter1, Pooter2, Timepoint | _] = Record) ->
-    ResFail = Mod:delete(C, <<"no-bucket-like-this">>, ?BADKEY, []),
+    ResFail = Mod:delete(C, <<"no-bucket-like-this">>, ?BADKEY, ?EXTRA_SINGLE_KEY_OPTIONS),
     io:format("Nothing deleted from a non-existent bucket: ~p\n", [ResFail]),
     ?assertMatch({error, _}, ResFail),
 
     Key = [Pooter1, Pooter2, Timepoint],
 
     BadKey1 = [Pooter1],
-    BadRes1 = Mod:delete(C, ?BUCKET, BadKey1, []),
+    BadRes1 = Mod:delete(C, ?BUCKET, BadKey1, ?EXTRA_SINGLE_KEY_OPTIONS),
     io:format("Not deleted because short key: ~p\n", [BadRes1]),
     ?assertMatch({error, _}, BadRes1),
 
     BadKey2 = Key ++ [43],
-    BadRes2 = Mod:delete(C, ?BUCKET, BadKey2, []),
+    BadRes2 = Mod:delete(C, ?BUCKET, BadKey2, ?EXTRA_SINGLE_KEY_OPTIONS),
     io:format("Not deleted because long key: ~p\n", [BadRes2]),
     ?assertMatch({error, _}, BadRes2),
 
-    Res = Mod:delete(C, ?BUCKET, Key, []),
+    Res = Mod:delete(C, ?BUCKET, Key, ?EXTRA_SINGLE_KEY_OPTIONS),
     io:format("Deleted record ~p: ~p\n", [Record, Res]),
     ?assertEqual(ok, Res),
     ok.
 
 confirm_nx_delete({Mod, C}) ->
-    Res = Mod:delete(C, ?BUCKET, ?BADKEY, []),
+    Res = Mod:delete(C, ?BUCKET, ?BADKEY, ?EXTRA_SINGLE_KEY_OPTIONS),
     io:format("Not deleted non-existing key: ~p\n", [Res]),
     case Mod of
         riakc_ts ->
@@ -235,18 +243,22 @@ confirm_select({Mod, C}, PvalP1, PvalP2) ->
     ok.
 
 confirm_get({Mod, C}, Record = [Pooter1, Pooter2, Timepoint | _]) ->
-    ResFail = Mod:get(C, <<"no-bucket-like-this">>, ?BADKEY, []),
+    ResFail = Mod:get(C, <<"no-bucket-like-this">>, ?BADKEY, ?EXTRA_SINGLE_KEY_OPTIONS),
     io:format("Got nothing from a non-existent bucket: ~p\n", [ResFail]),
     ?assertMatch({error, _}, ResFail),
 
     Key = [Pooter1, Pooter2, Timepoint],
-    Res = Mod:get(C, ?BUCKET, Key, []),
-    io:format("Get a single record: ~p\n", [Res]),
+    Res = Mod:get(C, ?BUCKET, Key, ?EXTRA_SINGLE_KEY_OPTIONS),
+    io:format("Get a single record (with column names for riakhttpc): ~p\n", [Res]),
     ?assertMatch({ok, {_, [Record]}}, Res),
+
+    Res2 = Mod:get(C, ?BUCKET, Key, []),  %% no column names
+    io:format("Get a single record (no column names): ~p\n", [Res2]),
+    ?assertMatch({ok, {_, [Record]}}, Res2),
     ok.
 
 confirm_nx_get({Mod, C}) ->
-    Res = Mod:get(C, ?BUCKET, ?BADKEY, []),
+    Res = Mod:get(C, ?BUCKET, ?BADKEY, ?EXTRA_SINGLE_KEY_OPTIONS),
     io:format("Not got a nonexistent single record: ~p\n", [Res]),
     ?assertMatch({error, notfound}, Res),
     ok.
@@ -281,6 +293,11 @@ confirm_delete_all({Mod, C}, AllKeys) ->
     io:format("Deleting ~b keys\n", [length(AllKeys)]),
     lists:foreach(
       fun(K) -> ok = Mod:delete(C, ?BUCKET, tuple_to_list(K), []) end,
+      %% Here we call delete with no options, specifically without
+      %% key_column_names, which causes rhc_ts:delete to construct
+      %% URLs with just bare values. This is to cover both modes in
+      %% delete invocations. (Wrt get, both modes are explicitly
+      %% tested in confirm_get.)
       AllKeys),
     timer:sleep(3500),
     {ok, Res} = ts_list_keys(C, ?BUCKET),

--- a/tests/ts_cluster_comprehensive.erl
+++ b/tests/ts_cluster_comprehensive.erl
@@ -1,6 +1,6 @@
 % -------------------------------------------------------------------
 %%
-%% Copyright (c) 2015 Basho Technologies, Inc.
+%% Copyright (c) 2015, 2016 Basho Technologies, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -22,7 +22,7 @@
 
 -module(ts_cluster_comprehensive).
 -behavior(riak_test).
--export([confirm/0, run_tests/2]).
+-export([confirm/0, run_tests/2, run_tests/3]).
 -include_lib("eunit/include/eunit.hrl").
 
 -define(BUCKET, <<"ts_test_bucket_one">>).
@@ -36,39 +36,62 @@
 -define(LIFESPAN, 300).  %% > 100, which is the default chunk size for list_keys
 
 confirm() ->
+    inets:start(),
     run_tests(?PVAL_P1, ?PVAL_P2).
 
 run_tests(PvalP1, PvalP2) ->
+    run_tests(PvalP1, PvalP2, riakc_ts).
+
+run_tests(PvalP1, PvalP2, ClientMod) ->
     Data = make_data(PvalP1, PvalP2),
     io:format("Data to be written:\n~p\n...\n~p\n", [hd(Data), lists:last(Data)]),
 
-    Cluster = ts_util:build_cluster(multiple),
+    [Node1|_] = Cluster = ts_util:build_cluster(single),
 
-    %% use riak-admin to create a bucket
-    TableDef = io_lib:format(
-                 "CREATE TABLE ~s "
-                 "(~s varchar not null, "
-                 " ~s varchar not null, "
-                 " ~s timestamp not null, "
-                 " score double not null, "
-                 " PRIMARY KEY ((~s, ~s, quantum(~s, 10, s)), ~s, ~s, ~s))",
-                 [?BUCKET,
-                  ?PKEY_P1, ?PKEY_P2, ?PKEY_P3,
-                  ?PKEY_P1, ?PKEY_P2, ?PKEY_P3,
-                  ?PKEY_P1, ?PKEY_P2, ?PKEY_P3]),
-    ts_util:create_and_activate_bucket_type(Cluster, lists:flatten(TableDef), ?BUCKET),
+    %% 0. create table
+    Client = get_client_at_node(Node1, ClientMod),
+    io:format("using client mod ~s, client ~p\n", [ClientMod, Client]),
+    ok = confirm_create_table({ClientMod, Client}),
 
     %% Make sure data is written to each node
-    lists:foreach(fun(Node) -> confirm_all_from_node(Node, Data, PvalP1, PvalP2) end, Cluster),
+    lists:foreach(
+      fun(Node) ->
+              confirm_all_from_node(
+                {ClientMod, get_client_at_node(Node, ClientMod)},
+                Data, PvalP1, PvalP2)
+      end, Cluster),
     pass.
 
+get_client_at_node(Node, ClientMod) ->
+    case ClientMod of
+        riakc_ts ->
+            rt:pbc(Node);
+        rhc_ts ->
+            {ok, [{IP, Port}]} = rt:get_http_conn_info(Node),
+            rhc_ts:create(IP, Port, [])
+    end.
 
-confirm_all_from_node(Node, Data, PvalP1, PvalP2) ->
-    %% set up a client
-    C = rt:pbc(Node),
+confirm_create_table({Mod, C}) ->
+    TableDef =
+        flat_format(
+          "CREATE TABLE ~s "
+          "(~s varchar not null, "
+          " ~s varchar not null, "
+          " ~s timestamp not null, "
+          " score double not null, "
+          " PRIMARY KEY ((~s, ~s, quantum(~s, 10, s)), ~s, ~s, ~s))",
+          [?BUCKET,
+           ?PKEY_P1, ?PKEY_P2, ?PKEY_P3,
+           ?PKEY_P1, ?PKEY_P2, ?PKEY_P3,
+           ?PKEY_P1, ?PKEY_P2, ?PKEY_P3]),
+    ?assertEqual({[], []}, Mod:query(C, TableDef)),
+    ok.
+
+confirm_all_from_node(C, Data, PvalP1, PvalP2) ->
 
     %% 1. put some data
     ok = confirm_put(C, doctor_data(Data)),
+    ok = confirm_put_nothing(C),
     ok = confirm_overwrite(C, Data),
 
     %% 2. get a single key
@@ -97,7 +120,7 @@ confirm_all_from_node(Node, Data, PvalP1, PvalP2) ->
     ok = confirm_nx_get(C),
 
     %% Switch to native mode and repeat a few tests
-    riakc_pb_socket:use_native_encoding(C, true),
+    ok = switch_encoding_mode(C, true),
 
     %% 5 (redux). select
     ok = confirm_select(C, PvalP1, PvalP2),
@@ -106,11 +129,15 @@ confirm_all_from_node(Node, Data, PvalP1, PvalP2) ->
     ok = confirm_get(C, lists:nth(12, Data)),
     ok = confirm_nx_get(C),
 
-    riakc_pb_socket:use_native_encoding(C, false),
+    ok = switch_encoding_mode(C, false),
 
     ok = confirm_delete_all(C, RemainingKeys),
     {ok, []} = confirm_list_keys(C, 0).
 
+switch_encoding_mode({riakc_ts, C}, Mode) ->
+    riakc_pb_socket:use_native_encoding(C, Mode);
+switch_encoding_mode(_, _) ->
+    ok.
 
 make_data(PvalP1, PvalP2) ->
     lists:reverse(
@@ -126,95 +153,108 @@ make_data(PvalP1, PvalP2) ->
 doctor_data(Data) ->
     [[A, B, C, D + 0.42] || [A, B, C, D] <- Data].
 
-confirm_put(C, Data) ->
-    ResFail = riakc_ts:put(C, <<"no-bucket-like-this">>, Data),
+confirm_put({Mod, C}, Data) ->
+    ResFail = Mod:put(C, <<"no-bucket-like-this">>, Data),
     io:format("Nothing put in a non-existent bucket: ~p\n", [ResFail]),
     ?assertMatch({error, _}, ResFail),
 
     %% Res = lists:map(fun(Datum) -> riakc_ts:put(C, ?BUCKET, [Datum]), timer:sleep(300) end, Data0),
-    %% (for future tests of batch put writing order)
-    Res = riakc_ts:put(C, ?BUCKET, Data),
+    %% (was meant for tests of batch put writing order, obsoleted)
+    Res = Mod:put(C, ?BUCKET, Data),
     io:format("Put ~b records: ~p\n", [length(Data), Res]),
     ?assertEqual(ok, Res),
     ok.
 
-confirm_overwrite(C, Data) ->
-    Res = riakc_ts:put(C, ?BUCKET, Data),
+confirm_put_nothing({Mod, C}) ->
+    Res = Mod:put(C, ?BUCKET, []),
+    io:format("Nothing put in existing bucket: ~p\n", [Res]),
+    ?assertMatch(ok, Res),
+    ok.
+
+confirm_overwrite({Mod, C}, Data) ->
+    Res = Mod:put(C, ?BUCKET, Data),
     io:format("Overwrote ~b records: ~p\n", [length(Data), Res]),
     ?assertEqual(ok, Res),
     ok.
 
-confirm_delete(C, [Pooter1, Pooter2, Timepoint | _] = Record) ->
-    ResFail = riakc_ts:delete(C, <<"no-bucket-like-this">>, ?BADKEY, []),
+confirm_delete({Mod, C}, [Pooter1, Pooter2, Timepoint | _] = Record) ->
+    ResFail = Mod:delete(C, <<"no-bucket-like-this">>, ?BADKEY, []),
     io:format("Nothing deleted from a non-existent bucket: ~p\n", [ResFail]),
     ?assertMatch({error, _}, ResFail),
 
     Key = [Pooter1, Pooter2, Timepoint],
 
     BadKey1 = [Pooter1],
-    BadRes1 = riakc_ts:delete(C, ?BUCKET, BadKey1, []),
+    BadRes1 = Mod:delete(C, ?BUCKET, BadKey1, []),
     io:format("Not deleted because short key: ~p\n", [BadRes1]),
     ?assertMatch({error, _}, BadRes1),
 
     BadKey2 = Key ++ [43],
-    BadRes2 = riakc_ts:delete(C, ?BUCKET, BadKey2, []),
+    BadRes2 = Mod:delete(C, ?BUCKET, BadKey2, []),
     io:format("Not deleted because long key: ~p\n", [BadRes2]),
     ?assertMatch({error, _}, BadRes2),
 
-    Res = riakc_ts:delete(C, ?BUCKET, Key, []),
+    Res = Mod:delete(C, ?BUCKET, Key, []),
     io:format("Deleted record ~p: ~p\n", [Record, Res]),
     ?assertEqual(ok, Res),
     ok.
 
-confirm_nx_delete(C) ->
-    ?assertEqual(
-        {error, {1021, <<"notfound">>}},
-        riakc_ts:delete(C, ?BUCKET, ?BADKEY, [])
-    ),
+confirm_nx_delete({Mod, C}) ->
+    Res = Mod:delete(C, ?BUCKET, ?BADKEY, []),
+    io:format("Not deleted non-existing key: ~p\n", [Res]),
+    case Mod of
+        riakc_ts ->
+            ?assertEqual(
+               {error, {1021, <<"notfound">>}},
+               Res);
+        rhc_ts ->
+            ?assertEqual(
+               {error, notfound},
+               Res)
+    end,
     ok.
 
-confirm_select(C, PvalP1, PvalP2) ->
+confirm_select({Mod, C}, PvalP1, PvalP2) ->
     Query =
-        lists:flatten(
-          io_lib:format(
-            "select score, pooter2 from ~s where"
-            "     ~s = '~s'"
-            " and ~s = '~s'"
-            " and ~s > ~b and ~s < ~b",
-           [?BUCKET,
-            ?PKEY_P1, PvalP1,
-            ?PKEY_P2, PvalP2,
-            ?PKEY_P3, ?TIMEBASE + 10, ?PKEY_P3, ?TIMEBASE + 20])),
+        flat_format(
+          "select score, pooter2 from ~s where"
+          "     ~s = '~s'"
+          " and ~s = '~s'"
+          " and ~s > ~b and ~s < ~b",
+          [?BUCKET,
+           ?PKEY_P1, PvalP1,
+           ?PKEY_P2, PvalP2,
+           ?PKEY_P3, ?TIMEBASE + 10, ?PKEY_P3, ?TIMEBASE + 20]),
     io:format("Running query: ~p\n", [Query]),
-    {_Columns, Rows} = riakc_ts:query(C, Query),
+    {_Columns, Rows} = Mod:query(C, Query),
     io:format("Got ~b rows back\n~p\n", [length(Rows), Rows]),
     ?assertEqual(10 - 1 - 1, length(Rows)),
-    {_Columns, Rows} = riakc_ts:query(C, Query),
+    {_Columns, Rows} = Mod:query(C, Query),
     io:format("Got ~b rows back again\n", [length(Rows)]),
     ?assertEqual(10 - 1 - 1, length(Rows)),
     ok.
 
-confirm_get(C, Record = [Pooter1, Pooter2, Timepoint | _]) ->
-    ResFail = riakc_ts:get(C, <<"no-bucket-like-this">>, ?BADKEY, []),
+confirm_get({Mod, C}, Record = [Pooter1, Pooter2, Timepoint | _]) ->
+    ResFail = Mod:get(C, <<"no-bucket-like-this">>, ?BADKEY, []),
     io:format("Got nothing from a non-existent bucket: ~p\n", [ResFail]),
     ?assertMatch({error, _}, ResFail),
 
     Key = [Pooter1, Pooter2, Timepoint],
-    Res = riakc_ts:get(C, ?BUCKET, Key, []),
+    Res = Mod:get(C, ?BUCKET, Key, []),
     io:format("Get a single record: ~p\n", [Res]),
     ?assertMatch({ok, {_, [Record]}}, Res),
     ok.
 
-confirm_nx_get(C) ->
-    Res = riakc_ts:get(C, ?BUCKET, ?BADKEY, []),
+confirm_nx_get({Mod, C}) ->
+    Res = Mod:get(C, ?BUCKET, ?BADKEY, []),
     io:format("Not got a nonexistent single record: ~p\n", [Res]),
-    ?assertMatch({ok, {[], []}}, Res),
+    ?assertMatch({error, notfound}, Res),
     ok.
 
-confirm_nx_list_keys(C) ->
-    {Status, Reason} = list_keys(C, <<"no-bucket-like-this">>),
+confirm_nx_list_keys({_Mod, C}) ->
+    {_Status, Reason} = Res = ts_list_keys(C, <<"no-bucket-like-this">>),
     io:format("Nothing listed from a non-existent bucket: ~p\n", [Reason]),
-    ?assertMatch(error, Status),
+    ?assertMatch({error, notfound}, Res),
     ok.
 
 confirm_list_keys(C, N) ->
@@ -222,29 +262,45 @@ confirm_list_keys(C, N) ->
 confirm_list_keys(_C, _N, 0) ->
     io:format("stream_list_keys is lying\n", []),
     fail;
-confirm_list_keys(C, N, TriesToGo) ->
-    {Status, Keys} = list_keys(C, ?BUCKET),
-    case length(Keys) of
-        N ->
-            {ok, Keys};
-        _NotN ->
-            io:format("Listed ~b (expected ~b) keys streaming (~p). Retrying.\n", [length(Keys), N, Status]),
-            confirm_list_keys(C, N, TriesToGo - 1)
+confirm_list_keys({_Mod, C} = CMod, N, TriesToGo) ->
+    case ts_list_keys(C, ?BUCKET) of
+        {ok, Keys} ->
+            case length(Keys) of
+                N ->
+                    {ok, Keys};
+                _NotN ->
+                    io:format("Listed ~b (expected ~b) keys streaming. Retrying.\n", [length(Keys), N]),
+                    confirm_list_keys(CMod, N, TriesToGo - 1)
+            end;
+        {error, Reason} ->
+            io:format("streaming keys error: ~p\n", [Reason]),
+            fail
     end.
 
-confirm_delete_all(C, AllKeys) ->
+confirm_delete_all({Mod, C}, AllKeys) ->
     io:format("Deleting ~b keys\n", [length(AllKeys)]),
     lists:foreach(
-      fun(K) -> ok = riakc_ts:delete(C, ?BUCKET, tuple_to_list(K), []) end,
+      fun(K) -> ok = Mod:delete(C, ?BUCKET, tuple_to_list(K), []) end,
       AllKeys),
     timer:sleep(3500),
-    {ok, Res} = list_keys(C, ?BUCKET),
+    {ok, Res} = ts_list_keys(C, ?BUCKET),
     io:format("Deleted all: ~p\n", [Res]),
     ?assertMatch([], Res),
     ok.
 
-list_keys(C, Bucket) ->
-    {ok, ReqId1} = riakc_ts:stream_list_keys(C, Bucket, []),
+
+%% ----------------------------
+
+ts_list_keys(C, Table) when is_pid(C) ->
+    %% there's only streaming version available for TS list_keys, so
+    %% we slurp the stream here
+    list_keys(C, Table);
+ts_list_keys(C, Table) ->
+    %% .. whereas rhc_ts does the slurping for us
+    rhc_ts:list_keys(C, Table).
+
+list_keys(C, Table) ->
+    {ok, ReqId1} = riakc_ts:stream_list_keys(C, Table, []),
     receive_keys(ReqId1, []).
 
 receive_keys(ReqId, Acc) ->
@@ -252,6 +308,8 @@ receive_keys(ReqId, Acc) ->
         {ReqId, {keys, Keys}} ->
             io:format("received batch of ~b\n", [length(Keys)]),
             receive_keys(ReqId, lists:append(Keys, Acc));
+        {ReqId, {error, {1019, _BucketNotExistsMessage}}} ->
+            {error, notfound};
         {ReqId, {error, Reason}} ->
             io:format("list_keys(~p) at ~b got an error: ~p\n", [ReqId, length(Acc), Reason]),
             {error, Reason};
@@ -265,3 +323,6 @@ receive_keys(ReqId, Acc) ->
             io:format("Consider streaming done\n", []),
             {ok, Acc}
     end.
+
+flat_format(Format, Args) ->
+    lists:flatten(io_lib:format(Format, Args)).

--- a/tests/ts_cluster_http.erl
+++ b/tests/ts_cluster_http.erl
@@ -1,0 +1,31 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2016 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+%% @doc A module to test riak_ts basic create bucket/put/select cycle
+%%      using http client (rhc_ts).
+
+-module(ts_cluster_http).
+-behavior(riak_test).
+-export([confirm/0]).
+
+-define(PVAL_P1, <<"ZXC11">>).
+-define(PVAL_P2, <<"PDP-11">>).
+
+confirm() ->
+    ts_cluster_comprehensive:run_tests(?PVAL_P1, ?PVAL_P2, rhc_ts).

--- a/tests/ts_cluster_http.erl
+++ b/tests/ts_cluster_http.erl
@@ -31,3 +31,140 @@
 
 confirm() ->
     ts_cluster_comprehensive:run_tests(?PVAL_P1, ?PVAL_P2, rhc_ts).
+
+%% below is an alternative test scenario, using curl:
+%% #!/bin/bash
+%%
+%% set -e
+%%
+%% extra_opts=$*
+%% host=http://localhost:10018
+%%
+%% ddl="create table bob (a varchar not null, b varchar not null, c timestamp not null, d sint64, primary key ((a, b, quantum(c, 1, m)), a, b, c))"
+%%
+%% function req {
+%%     local expected="$5" payload="$4" method_option="-X $2"
+%%     echo -n "$1 ($2) ..."
+%%     got=`curl $method_option $host/ts/v1/$3 -s $extra_opts \
+%%          --data "$payload"`
+%%     if ! [[ $got =~ $expected ]]; then
+%%         echo
+%%         echo "Request failed: $2 $3 $4:"
+%%         echo "Expected output: $expected"
+%%         echo "            Got: $got"
+%%         return 1
+%%     else
+%%         echo " ok"
+%%     fi
+%% }
+%%
+%% req "create table" \
+%%     POST query "{\"query\": \"$ddl\"}" \
+%%     "ok|already_active" || :
+%%
+%% req "describe table" \
+%%     GET  query '{"query": "describe bob"}' \
+%%     columns
+%%     #'{\"columns\":[\"Column\",\"Type\",\"Is Null\",\"Primary Key\",\"Local Key\"],\"rows\":[[\"a\",\"varchar\",false,1,1],[\"b\",\"varchar\",false,2,2],[\"c\",\"timestamp\",false,3,3],[\"d\",\"sint64\",true,\"undefined\",\"undefined\"]]}'
+%%
+%% #echo "sleeping to allow riak to complete table activation"
+%% #sleep 4
+%%
+%% req "put some data" \
+%%     PUT  tables/bob/keys '{"data": [["q1", "w1", 11, 110], ["q1", "w1", 22, 220], ["q2", "w2", 22, 220]]}' \
+%%     "ok"
+%%
+%% req "single-key get (field-qualified)" \
+%%     GET  tables/bob/keys/a/q1/b/w1/c/11 '' \
+%%     columns
+%%     #'{"columns":["a","b","c","d"],"rows":[["q1","w1",11,110]]}'
+%%
+%% req "single-key get (field-qualified, shuffled)" \
+%%     GET  tables/bob/keys/b/w1/a/q1/c/11 '' \
+%%     columns
+%%     #'{"columns":["a","b","c","d"],"rows":[["q1","w1",11,110]]}'
+%%
+%% req "single-key get (bare values)" \
+%%     GET  tables/bob/keys/q1/w1/11 '' \
+%%     columns
+%%     #'{"columns":["a","b","c","d"],"rows":[["q1","w1",11,110]]}'
+%%
+%% req "single-key non-existing get" \
+%%     GET  tables/bob/keys/no/such/333 '' \
+%%     "Key not found"
+%%
+%% req "list_keys" \
+%%     GET  tables/bob/list_keys '' \
+%%     keys
+%%     #'{"keys":[["q2","w2",22]]}{"keys":[["q1","w1",22],["q1","w1",11]]}{"keys":[]}'
+%%
+%% req "select query" \
+%%     GET  query "{\"query\": \"select * from bob where a = 'q1' and b = 'w1' and c > 1 and c < 999\"}" \
+%%     columns
+%%     #'{"columns":["a","b","c","d"],"rows":[["q1","w1",11,110],["q1","w1",22,220]]}'
+%%
+%% req "single-key delete" \
+%%     DELETE tables/bob/keys/q1/w1/22 '' \
+%%     "ok"
+%%
+%% req "select query (one record missing)" \
+%%     GET  query "{\"query\": \"select * from bob where a = 'q1' and b = 'w1' and c > 1 and c < 999\"}" \
+%%     columns
+%%     #'{"columns":["a","b","c","d"],"rows":[["q1","w1",11,110]]}'
+%%
+%% req "select query (empty)" \
+%%     GET  query "{\"query\": \"select * from bob where a = 'q9' and b = 'w1' and c > 1 and c < 999\"}" \
+%%     columns
+%%     #'{"columns":["a","b","c","d"],"rows":[]}'
+%%
+%% req "coverage" \
+%%     GET coverage "{\"query\": \"select * from bob where a = 'q1' and b = 'w1' and c > 1 and c < 999\"}" \
+%%     entry || :  # uncomment it reenabled in riak_kv
+%%     #'{"coverage":{"entry":'
+%%
+%% # some errors:
+%%
+%% req "bad get (wrong table)" \
+%%     GET tables/bib/keys/q1/w1/11 '' \
+%%     "does not"
+%%     #'Table "bib" does not exist'
+%%
+%% req "bad put (wrong parameters)" \
+%%     PUT tables/bob/keys/p1/w1/11 '' \
+%%     "Malformed PUT request"
+%%
+%% req "bad put (wrong table and parameters)" \
+%%     PUT tables/bib/keys '{"key": ["p1", "w1", 11]}' \
+%%     "Malformed PUT request"
+%%
+%% req "bad put (parameters ok but not quite)" \
+%%     PUT tables/bob/keys '{"data": [["p1", "w1", 11]]}' \
+%%     "Invalid record #1"
+%%
+%% req "bad get (short key)" \
+%%     GET tables/bob/keys/p1/w1 '' \
+%%     Unpaired
+%%
+%% req "bad get (long key)" \
+%%     GET tables/bob/keys/p1/w1/w1/w1/w1 '' \
+%%     Unpaired
+%%
+%% req "bad query 1" \
+%%     GET query "babad" \
+%%     'Malformed GET request'
+%% req "bad query 2" \
+%%     PUT query "babad" \
+%%     'Method Not Allowed'
+%% req "bad query 3" \
+%%     POST query "babad" \
+%%     'Malformed POST request'
+%%
+%% req "inappropriate query for method (PUT and CREATE TABLE)" \
+%%     PUT query "{\"query\": \"$ddl\"}" \
+%%     'Method Not Allowed'
+%% req "inappropriate query for method (GET and CREATE TABLE)" \
+%%     GET query "{\"query\": \"$ddl\"}" \
+%%     'Inappropriate method GET for SQL query type'
+%% req "inappropriate query for method (PUT and SELECT)" \
+%%     PUT  query "{\"query\": \"select * from bob where a = 'q9' and b = 'w1' and c > 1 and c < 999\"}" \
+%%     'Method Not Allowed'

--- a/tests/ts_cluster_http.erl
+++ b/tests/ts_cluster_http.erl
@@ -24,8 +24,10 @@
 -behavior(riak_test).
 -export([confirm/0]).
 
--define(PVAL_P1, <<"ZXC11">>).
--define(PVAL_P2, <<"PDP-11">>).
+%% inject characters to check transit of keys over http barrier
+%% (involves urlendofing/decoding of field values)
+-define(PVAL_P1, <<"ZXC1/1">>).
+-define(PVAL_P2, <<"PDP -11">>).
 
 confirm() ->
     ts_cluster_comprehensive:run_tests(?PVAL_P1, ?PVAL_P2, rhc_ts).


### PR DESCRIPTION
RTS-258

Requires https://github.com/basho/riak_kv/pull/1350, https://github.com/basho/riak-erlang-client/pull/261 and https://github.com/basho/riak-erlang-http-client/pull/55.

The ts_cluster_comprehensive is extended to transparently use either rpb or rhc modules (riakc and riakhttpc, resp.); pbc will be used by default. To use the HTTP client, run `./riak_test -t ts_cluster_http`.