### PR TITLE
RTS-917: Add riak_shell_version to list of supported stats

### DIFF
--- a/tests/verify_riak_stats.erl
+++ b/tests/verify_riak_stats.erl
@@ -649,6 +649,7 @@ common_stats() ->
         <<"protobuffs_version">>,
         <<"public_key_version">>,
         <<"riak_ql_version">>,
+        <<"riak_shell_version">>,
         <<"read_repairs">>,
         <<"read_repairs_counter">>,
         <<"read_repairs_counter_total">>,


### PR DESCRIPTION
With the addition of riak_shell comes a new statistic