### PR TITLE
Synchronize riak_shell Testing Messages

### DIFF
--- a/tests/riak_shell_test_connecting.erl
+++ b/tests/riak_shell_test_connecting.erl
@@ -32,14 +32,11 @@
 confirm() ->
     Nodes = riak_shell_test_util:build_cluster(),
     lager:info("Built a cluster of ~p~n", [Nodes]),
-    Self = self(),
-    _Pid = spawn_link(fun() -> run_test(Self) end),
-    riak_shell_test_util:loop().
-
-run_test(Pid) ->
     State = riak_shell_test_util:shell_init(),
     lager:info("~n~nStart running the command set-------------------------", []),
     Cmds = [
+            {run,
+             "show_version;"},
             %% 'connection prompt on' means you need to do unicode printing and stuff
             {run,
              "connection_prompt off;"},
@@ -52,8 +49,7 @@ run_test(Pid) ->
             {{match, "riak_shell is connected to: 'dev1@127.0.0.1' on port 10017"},
              "show_connection;"}
            ],
-    Result = riak_shell_test_util:run_commands(Cmds, "Start", State,
-                                               ?DONT_INCREMENT_PROMPT),
+    Result = riak_shell_test_util:run_commands(Cmds, State, ?DONT_INCREMENT_PROMPT),
     lager:info("Result is ~p~n", [Result]),
     lager:info("~n~n------------------------------------------------------", []),
-    Pid ! Result.
+    Result.

--- a/tests/riak_shell_test_connecting_error.erl
+++ b/tests/riak_shell_test_connecting_error.erl
@@ -32,14 +32,11 @@
 confirm() ->
     Nodes = riak_shell_test_util:build_cluster(),
     lager:info("Built a cluster of ~p~n", [Nodes]),
-    Self = self(),
-    _Pid = spawn_link(fun() -> run_test(Self) end),
-    riak_shell_test_util:loop().
-
-run_test(Pid) ->
     State = riak_shell_test_util:shell_init(),
     lager:info("~n~nStart running the command set-------------------------", []),
     Cmds = [
+            {run,
+             "show_version;"},
             %% 'connection prompt on' means you need to do unicode printing and stuff
             {run,
              "connection_prompt off;"},
@@ -50,8 +47,7 @@ run_test(Pid) ->
             {{match, "Connection to 'made up guff' failed"},
              "connect 'made up guff';"}
            ],
-    Result = riak_shell_test_util:run_commands(Cmds, "Start", State,
-                                               ?DONT_INCREMENT_PROMPT),
+    Result = riak_shell_test_util:run_commands(Cmds, State, ?DONT_INCREMENT_PROMPT),
     lager:info("Result is ~p~n", [Result]),
     lager:info("~n~n------------------------------------------------------", []),
-    Pid ! Result.
+    Result.

--- a/tests/riak_shell_test_disconnecting.erl
+++ b/tests/riak_shell_test_disconnecting.erl
@@ -32,16 +32,13 @@
 confirm() -> 
     Nodes = riak_shell_test_util:build_cluster(),
     lager:info("Built a cluster of ~p~n", [Nodes]),
-    Self = self(),
-    _Pid = spawn_link(fun() -> run_test(Self) end),
-    riak_shell_test_util:loop().
-
-run_test(Pid) ->
     State = riak_shell_test_util:shell_init(),
     lager:info("~n~nStart running the command set-------------------------", []),
     Cmds = [
+            {run,
+            "show_version;"},
             %% 'connection prompt on' means you need to do unicode printing and stuff
-            {run, 
+            {run,
              "connection_prompt off;"},
             {run, 
              "show_cookie;"},
@@ -64,9 +61,8 @@ run_test(Pid) ->
             {{match, "riak_shell is connected to: 'dev1@127.0.0.1' on port 10017"}, 
              "show_connection;"}
            ], 
-    Result = riak_shell_test_util:run_commands(Cmds, "Start", State,
-                                               ?DONT_INCREMENT_PROMPT),
+    Result = riak_shell_test_util:run_commands(Cmds, State, ?DONT_INCREMENT_PROMPT),
     lager:info("Result is ~p~n", [Result]),
     lager:info("~n~n------------------------------------------------------", []),
-    Pid ! Result.
+    Result.
 

--- a/tests/riak_shell_test_reconnecting.erl
+++ b/tests/riak_shell_test_reconnecting.erl
@@ -32,14 +32,11 @@
 confirm() -> 
     Nodes = riak_shell_test_util:build_cluster(),
     lager:info("Built a cluster of ~p~n", [Nodes]),
-    Self = self(),
-    _Pid = spawn_link(fun() -> run_test(Self) end),
-    riak_shell_test_util:loop().
-
-run_test(Pid) ->
     State = riak_shell_test_util:shell_init(),
     lager:info("~n~nStart running the command set-------------------------", []),
     Cmds = [
+            {run,
+             "show_version;"},
             %% 'connection prompt on' means you need to do unicode printing and stuff
             {run, 
              "connection_prompt off;"},
@@ -52,9 +49,8 @@ run_test(Pid) ->
             {{match, "riak_shell is connected to: 'dev1@127.0.0.1' on port 10017"}, 
              "show_connection;"}
            ],
-    Result = riak_shell_test_util:run_commands(Cmds, "Start", State,
-                                               ?DONT_INCREMENT_PROMPT),
+    Result = riak_shell_test_util:run_commands(Cmds, State, ?DONT_INCREMENT_PROMPT),
     lager:info("Result is ~p~n", [Result]),
     lager:info("~n~n------------------------------------------------------", []),
-    Pid ! Result.
+    Result.
 

--- a/tests/riak_shell_test_util.erl
+++ b/tests/riak_shell_test_util.erl
@@ -24,7 +24,7 @@
 
 -export([
          shell_init/0,
-         run_commands/4,
+         run_commands/3,
          build_cluster/0,
          loop/0
         ]).
@@ -61,57 +61,58 @@ build_cluster() ->
     rt:set_backend(eleveldb),
     _Nodes  = rt:build_cluster(?CLUSTERSIZE, ?EMPTYCONFIG).
 
-run_commands([], _Msg, _State, _ShouldIncrement) ->
+run_commands([], _State, _ShouldIncrement) ->
     pass;
-run_commands([{drain, discard} | T], Msg, State, ShouldIncrement) ->
-    {NewMsg, NewState, NewShdIncr} = riak_shell:loop_TEST(Msg, State, ShouldIncrement),
-    lager:info("Message drained and discared unchecked ~p", [lists:flatten(NewMsg)]),
-    run_commands(T, Msg, NewState, NewShdIncr);    
-run_commands([{drain, Response} | T], Msg, State, ShouldIncrement) ->
-    {NewMsg, NewState, NewShdIncr} = riak_shell:loop_TEST(Msg, State, ShouldIncrement),
-    case lists:flatten(NewMsg) of
+run_commands([{drain, discard} | T], State, ShouldIncrement) ->
+    {DiscardedMsg, NewState, NewShdIncr} = riak_shell:loop_TEST(State, ShouldIncrement),
+    lager:info("Message drained and discared unchecked ~p", [lists:flatten(DiscardedMsg)]),
+    run_commands(T, NewState, NewShdIncr);
+run_commands([{drain, Response} | T], State, ShouldIncrement) ->
+    {DrainedMsg, NewState, NewShdIncr} = riak_shell:loop_TEST(State, ShouldIncrement),
+    case lists:flatten(DrainedMsg) of
         Response -> lager:info("Message drained successfully ~p", [Response]),
-                    run_commands(T, Msg, NewState, NewShdIncr);    
+                    run_commands(T, NewState, NewShdIncr);
         Got      -> print_error("Message Expected", "", Response, Got),
                     fail
     end;
-run_commands([{start_node, Node} | T], Msg, State, ShouldIncrement) ->
+run_commands([{start_node, Node} | T], State, ShouldIncrement) ->
     rt:start(Node),
     rt:wait_until_pingable(Node),
-    run_commands(T, Msg, State, ShouldIncrement);    
-run_commands([{stop_node, Node} | T], Msg, State, ShouldIncrement) ->
+    run_commands(T, State, ShouldIncrement);
+run_commands([{stop_node, Node} | T], State, ShouldIncrement) ->
     rt:stop(Node),
     rt:wait_until_unpingable(Node),
-    run_commands(T, Msg, State, ShouldIncrement);    
-run_commands([sleep | T], Msg, State, ShouldIncrement) ->
+    run_commands(T, State, ShouldIncrement);
+run_commands([sleep | T], State, ShouldIncrement) ->
     timer:sleep(1000),
-    run_commands(T, Msg, State, ShouldIncrement);
-run_commands([{{match, Expected}, Cmd} | T], Msg, State, ShouldIncrement) ->
-    {NewMsg, NewState, NewShdIncr} = run_cmd(Cmd, Msg, State, ShouldIncrement),
+    run_commands(T, State, ShouldIncrement);
+run_commands([{{match, Expected}, Cmd} | T], State, ShouldIncrement) ->
+    {Msg, NewState, NewShdIncr} = run_cmd(Cmd, State, ShouldIncrement),
     %% when you start getting off-by-1 wierdness you will WANT to uncomment this
     %% Trim off the newlines to aid in string comparison
     ExpectedTrimmed = re:replace(Expected, "\n", "", [global,{return,list}]),
-    ResultTrimmed = re:replace(lists:flatten(NewMsg), "\n", "", [global,{return,list}]),
+    ResultTrimmed = re:replace(lists:flatten(Msg), "\n", "", [global,{return,list}]),
     case ResultTrimmed of
         ExpectedTrimmed -> lager:info("Successful match of ~p from ~p", [Expected, Cmd]),
-                           run_commands(T, NewMsg, NewState, NewShdIncr);
+                           run_commands(T, NewState, NewShdIncr);
         Got             -> print_error("Ran ~p:", Cmd, Expected, Got),
                            fail
     end;
-run_commands([{run, Cmd} | T], Msg, State, ShouldIncrement) ->
-    lager:info("Run command: ~p", [Cmd]),
-    {NewMsg, NewState, NewShdIncr} = run_cmd(Cmd, Msg, State, ShouldIncrement),
-    run_commands(T, NewMsg, NewState, NewShdIncr).
+run_commands([{run, Cmd} | T], State, ShouldIncrement) ->
+    {Msg, NewState, NewShdIncr} = run_cmd(Cmd, State, ShouldIncrement),
+    lager:info("Returned ~p", [lists:flatten(Msg)]),
+    run_commands(T, NewState, NewShdIncr).
 
-run_cmd(Cmd, Msg, State, ShouldIncrement) ->
+run_cmd(Cmd, State, ShouldIncrement) ->
     %% the riak-shell works by spawning a process that has captured
     %% standard input and then dropping into a receive that the spawned
     %% process sends a message to
     %% we have to emulate that here as we are the shell
     %% we are going to send a message at some time in the future
     %% and then go into a loop waiting for it
-    timer:apply_after(500, riak_shell, send_to_shell, [self(), {command, Cmd}]),
-    riak_shell:loop_TEST(Msg, State, ShouldIncrement).
+    timer:sleep(500),
+    lager:info("Testing command: ~p", [Cmd]),
+    riak_shell:send_to_shell(self(), {command, Cmd}), riak_shell:loop_TEST(State, ShouldIncrement).
 
 print_error(Format, Cmd, Expected, Got) ->
     lager:info(?PREFIX ++ "Match Failure"),


### PR DESCRIPTION
- Requires https://github.com/basho/riak_shell/pull/20
- Add `show_version` to tests since it won't automatically come back to `riak_test`
- No longer pass a starting message to `run_commands`
- No longer return the previous message back to `riak_shell`
- No longer spawn a separate process for test cases within `riak_test`
