### PR TITLE
Change assert_float to use relative error

### DIFF
--- a/tests/ts_simple_aggregation.erl
+++ b/tests/ts_simple_aggregation.erl
@@ -147,7 +147,7 @@ verify_aggregation(ClusterType) ->
     Expected9 = {[<<"STDDEV_POP(temperature)">>, <<"STDDEV_POP(pressure)">>,
                   <<"STDDEV(temperature)">>, <<"STDDEV(pressure)">>,
                   <<"STDDEV_SAMP(temperature)">>, <<"STDDEV_SAMP(pressure)">>],
-                 [{StdDev4, StdDev5, StdDev4, StdDev5, Sample4, Sample5}]},
+                 [{StdDev4, StdDev5, Sample4, Sample5, Sample4, Sample5}]},
     Result9 = ts_util:assert_float(test_name(ClusterType, "Standard Deviation"), Expected9, Got9),
 
     Qry10 = "SELECT SUM(temperature), MIN(pressure), AVG(pressure) FROM " ++ Bucket ++ Where,

--- a/tests/ts_util.erl
+++ b/tests/ts_util.erl
@@ -470,7 +470,7 @@ get_optional(N, X) ->
     end.
 
 
--define(DELTA, 1.0e-10).
+-define(EPSILON, 1.0e-10).
 
 assert_float(String, {Cols, [ValsA]} = Exp, {Cols, [ValsB]} = Got) ->
     case assertf2(tuple_to_list(ValsA), tuple_to_list(ValsB)) of
@@ -487,8 +487,8 @@ assert_float(String, Exp, Got) -> assert(String, Exp, Got).
 assertf2([], []) -> pass;
 assertf2([H1 | T1], [H2 | T2]) ->
     Diff = H1 - H2,
-    Av = (H1 + H2)/2,
-    if Diff/Av > ?DELTA -> fail;
+    Delta = abs(Diff/H2),
+    if Delta > ?EPSILON -> fail;
         el/=se           -> assertf2(T1, T2)
     end.
 


### PR DESCRIPTION
#Tweak how `ts_util:assert_float` determines the difference between too floats.  Previously two values were calculated by taking the difference over the average of the numbers.  Now use relative error which uses the absolute value of the difference over the expected value. https://en.wikipedia.org/wiki/Approximation_error

Also the aggregation function STDDEV had been tested to be equal to STDDEV_POP which is incorrect. It's actually the same as STDDEV_SAMP and the above change helps to detect the difference.