### PR TITLE
RTS-949: Add @seemaj's riak_shell script as a test

### DIFF
--- a/priv/riak_shell/riak_shell_regression1.log
+++ b/priv/riak_shell/riak_shell_regression1.log
@@ -1,0 +1,67 @@
+{{command, "reconnect; "}, {result, "Reconnected to 'dev1@127.0.0.1' on port 10017"}}.
+{{command, "show_connection; "}, {result, "riak_shell is connected to: 'dev1@127.0.0.1' on port 10017"}}.
+{{command, "show_nodes; "}, {result, "The connected nodes are: ['dev1@127.0.0.1','dev2@127.0.0.1','dev3@127.0.0.1']"}}.
+{{command, "show_history; "}, {result, "The history contains:
+- 1: reconnect; 
+- 2: show_connection; 
+- 3: show_nodes; 
+"}}.
+{{command, "show_nodes; "}, {result, "The connected nodes are: ['dev1@127.0.0.1','dev2@127.0.0.1','dev3@127.0.0.1']"}}.
+{{command, "CREATE TABLE GeoCheckin (myfamily varchar not null, myseries varchar not null, time  timestamp not null, weather  varchar not null, temperature double, PRIMARY KEY ((myfamily, myseries, quantum(time, 15, 'm')), myfamily, myseries, time));\n"}, {result, ""}}.
+{{command, "describe GeoCheckin;\n"}, {result, "+-----------+---------+-------+-----------+---------+
+|  Column   |  Type   |Is Null|Primary Key|Local Key|
++-----------+---------+-------+-----------+---------+
+| myfamily  | varchar | false |     1     |    1    |
+| myseries  | varchar | false |     2     |    2    |
+|   time    |timestamp| false |     3     |    3    |
+|  weather  | varchar | false |           |         |
+|temperature| double  | true  |           |         |
++-----------+---------+-------+-----------+---------+
+"}}.
+{{command, "insert into GeoCheckin (myfamily, myseries, time, weather, temperature) values ('family1','series1',1,'snow',25.2);\n"}, {result, ""}}.
+{{command, "insert into GeoCheckin (myfamily, myseries, time, weather, temperature) values ('family1','series1',2,'rain',24.5);\n"}, {result, ""}}.
+{{command, "insert into GeoCheckin (myfamily, myseries, time, weather, temperature) values ('family1','series1',3,'rain',23.0);\n"}, {result, ""}}.
+{{command, "insert into GeoCheckin (myfamily, myseries, time, weather, temperature) values ('family1','series1',4,'sunny',28.6);\n"}, {result, ""}}.
+{{command, "insert into GeoCheckin (myfamily, myseries, time, weather, temperature) values ('family1','series1',5,'sunny',24.7);\n"}, {result, ""}}.
+{{command, "insert into GeoCheckin (myfamily, myseries, time, weather, temperature) values ('family1','series1',6,'cloudy',32.789);\n"}, {result, ""}}.
+{{command, "insert into GeoCheckin (myfamily, myseries, time, weather, temperature) values ('family1','series1',7,'cloudy',27.9);\n"}, {result, ""}}.
+{{command, "insert into GeoCheckin (myfamily, myseries, time, weather, temperature) values ('family1','series1',8,'blizard',45.55);\n"}, {result, ""}}.
+{{command, "insert into GeoCheckin (myfamily, myseries, time, weather, temperature) values ('family1','series1',8,'fog',34.9);\n"}, {result, ""}}.
+{{command, "insert into GeoCheckin (myfamily, myseries, time, weather, temperature) values ('family1','series1',9,'fog',28);\n"}, {result, "Error (1003): Invalid data found at row index(es) 1"}}.
+{{command, "insert into GeoCheckin (myfamily, myseries, time, weather, temperature) values ('family1','series1',9,'fog',28.7);\n"}, {result, ""}}.
+{{command, "insert into GeoCheckin (myfamily, myseries, time, weather, temperature) values ('family1','series1',10,28);\n"}, {result, "Error (1003): Invalid data found at row index(es) 1"}}.
+{{command, "insert into GeoCheckin (myfamily, myseries, time, weather, temperature) values ('family1','series1',10,'hail',38.1);\n"}, {result, ""}}.
+{{command, "select time, weather, temperature from GeoCheckin where myfamily='family1' and myseries='seriesX' and time > 10 and time < 1000;\n"}, {result, ""}}.
+{{command, "select * from GeoCheckin;\n"}, {result, "Error (1001): no_where_clause: The query must have a where clause."}}.
+{{command, "select * from GeoCheckin where myfamily = 'family1' and myseries = 'series1' and time >= 1420113600000 and time <= 1420119300000;\n"}, {result, "Error (1001): {too_many_subqueries,7}"}}.
+{{command, "select * from GeoCheckin where myfamily = 'family1' and myseries = 'series1' and time >= 1 and time <= 2;\n"}, {result, "+--------+--------+----+-------+--------------------------+
+|myfamily|myseries|time|weather|       temperature        |
++--------+--------+----+-------+--------------------------+
+|family1 |series1 | 1  | snow  |2.51999999999999992895e+01|
+|family1 |series1 | 2  | rain  |2.45000000000000000000e+01|
++--------+--------+----+-------+--------------------------+
+"}}.
+{{command, "select * from GeoCheckin where myfamily = 'family1' and myseries = 'series1' and time >= 10 and time <= 8;\n"}, {result, "Error (1001): lower_bound_must_be_less_than_upper_bound: The lower time bound is greater than the upper time bound."}}.
+{{command, "select * from GeoCheckin where myfamily = 'family1' and myseries = 'series1' and time >= 10;\n"}, {result, "Error (1001): incomplete_where_clause: Where clause has no upper bound."}}.
+{{command, "select * from GeoCheckin where myfamily = 'family1' and myseries = 'series1' and time <= 8;\n"}, {result, "Error (1001): incomplete_where_clause: Where clause has no lower bound."}}.
+{{command, "select * from GeoCheckin where myfamily = 'family1' and myseries = 'series1' and time >= 2 and time <= 7;\n"}, {result, "+--------+--------+----+-------+--------------------------+
+|myfamily|myseries|time|weather|       temperature        |
++--------+--------+----+-------+--------------------------+
+|family1 |series1 | 2  | rain  |2.45000000000000000000e+01|
+|family1 |series1 | 3  | rain  |2.30000000000000000000e+01|
+|family1 |series1 | 4  | sunny |2.86000000000000014211e+01|
+|family1 |series1 | 5  | sunny |2.46999999999999992895e+01|
+|family1 |series1 | 6  |cloudy |3.27890000000000014779e+01|
+|family1 |series1 | 7  |cloudy |2.78999999999999985789e+01|
++--------+--------+----+-------+--------------------------+
+"}}.
+{{command, "show_cookie; "}, {result, "Cookie is riak [actual riak]"}}.
+{{command, "show_config; "}, {result, "The config is [{cookie,riak},
+               {logging,off},
+               {nodes,['dev1@127.0.0.1','dev2@127.0.0.1','dev3@127.0.0.1',
+                       'dev4@127.0.0.1','dev5@127.0.0.1','dev6@127.0.0.1',
+                       'dev7@127.0.0.1','dev8@127.0.0.1']}]
+"}}.
+{{command, "reconnect; "}, {result, "Reconnected to 'dev1@127.0.0.1' on port 10017"}}.
+{{command, "connect dev2@127.0.0.1; "}, {result, "Connected to 'dev2@127.0.0.1' on port 10027"}}.
+{{command, "show_connection; "}, {result, "riak_shell is connected to: 'dev2@127.0.0.1' on port 10027"}}.

--- a/tests/riak_shell_test_connecting.erl
+++ b/tests/riak_shell_test_connecting.erl
@@ -52,7 +52,7 @@ run_test(Pid) ->
             {{match, "riak_shell is connected to: 'dev1@127.0.0.1' on port 10017"},
              "show_connection;"}
            ],
-    Result = riak_shell_test_util:run_commands(Cmds, "Start", State,
+    Result = riak_shell_test_util:run_commands(Cmds, State,
                                                ?DONT_INCREMENT_PROMPT),
     lager:info("Result is ~p~n", [Result]),
     lager:info("~n~n------------------------------------------------------", []),

--- a/tests/riak_shell_test_connecting_error.erl
+++ b/tests/riak_shell_test_connecting_error.erl
@@ -50,7 +50,7 @@ run_test(Pid) ->
             {{match, "Connection to 'made up guff' failed"},
              "connect 'made up guff';"}
            ],
-    Result = riak_shell_test_util:run_commands(Cmds, "Start", State,
+    Result = riak_shell_test_util:run_commands(Cmds, State,
                                                ?DONT_INCREMENT_PROMPT),
     lager:info("Result is ~p~n", [Result]),
     lager:info("~n~n------------------------------------------------------", []),

--- a/tests/riak_shell_test_reconnecting.erl
+++ b/tests/riak_shell_test_reconnecting.erl
@@ -52,7 +52,7 @@ run_test(Pid) ->
             {{match, "riak_shell is connected to: 'dev1@127.0.0.1' on port 10017"}, 
              "show_connection;"}
            ],
-    Result = riak_shell_test_util:run_commands(Cmds, "Start", State,
+    Result = riak_shell_test_util:run_commands(Cmds, State,
                                                ?DONT_INCREMENT_PROMPT),
     lager:info("Result is ~p~n", [Result]),
     lager:info("~n~n------------------------------------------------------", []),

--- a/tests/riak_shell_test_util.erl
+++ b/tests/riak_shell_test_util.erl
@@ -24,7 +24,7 @@
 
 -export([
          shell_init/0,
-         run_commands/4,
+         run_commands/3,
          build_cluster/0,
          loop/0
         ]).
@@ -61,49 +61,50 @@ build_cluster() ->
     rt:set_backend(eleveldb),
     _Nodes  = rt:build_cluster(?CLUSTERSIZE, ?EMPTYCONFIG).
 
-run_commands([], _Msg, _State, _ShouldIncrement) ->
+run_commands([], _State, _ShouldIncrement) ->
     pass;
-run_commands([{drain, discard} | T], Msg, State, ShouldIncrement) ->
-    {NewMsg, NewState, NewShdIncr} = riak_shell:loop_TEST(Msg, State, ShouldIncrement),
+run_commands([{drain, discard} | T], State, ShouldIncrement) ->
+    {NewMsg, NewState, NewShdIncr} = riak_shell:loop_TEST(riak_shell:make_cmd(), State, ShouldIncrement),
     lager:info("Message drained and discared unchecked ~p", [lists:flatten(NewMsg)]),
-    run_commands(T, Msg, NewState, NewShdIncr);    
-run_commands([{drain, Response} | T], Msg, State, ShouldIncrement) ->
-    {NewMsg, NewState, NewShdIncr} = riak_shell:loop_TEST(Msg, State, ShouldIncrement),
-    case lists:flatten(NewMsg) of
-        Response -> lager:info("Message drained successfully ~p", [Response]),
-                    run_commands(T, Msg, NewState, NewShdIncr);    
-        Got      -> print_error("Message Expected", "", Response, Got),
+    run_commands(T, NewState, NewShdIncr);
+run_commands([{drain, Expected} | T], State, ShouldIncrement) ->
+    {Response, NewState, NewShdIncr} = riak_shell:loop_TEST(riak_shell:make_cmd(), State, ShouldIncrement),
+    case lists:flatten(Response) of
+        Expected -> lager:info("Message drained successfully ~p", [Expected]),
+                    run_commands(T, NewState, NewShdIncr);
+        Got      -> print_error("Message Expected", "", Expected, Got),
                     fail
     end;
-run_commands([{start_node, Node} | T], Msg, State, ShouldIncrement) ->
+run_commands([{start_node, Node} | T], State, ShouldIncrement) ->
     rt:start(Node),
     rt:wait_until_pingable(Node),
-    run_commands(T, Msg, State, ShouldIncrement);    
-run_commands([{stop_node, Node} | T], Msg, State, ShouldIncrement) ->
+    run_commands(T, State, ShouldIncrement);
+run_commands([{stop_node, Node} | T], State, ShouldIncrement) ->
     rt:stop(Node),
     rt:wait_until_unpingable(Node),
-    run_commands(T, Msg, State, ShouldIncrement);    
-run_commands([sleep | T], Msg, State, ShouldIncrement) ->
+    run_commands(T, State, ShouldIncrement);
+run_commands([sleep | T], State, ShouldIncrement) ->
     timer:sleep(1000),
-    run_commands(T, Msg, State, ShouldIncrement);
-run_commands([{{match, Expected}, Cmd} | T], Msg, State, ShouldIncrement) ->
-    {NewMsg, NewState, NewShdIncr} = run_cmd(Cmd, Msg, State, ShouldIncrement),
-    %% when you start getting off-by-1 wierdness you will WANT to uncomment this
+    run_commands(T, State, ShouldIncrement);
+run_commands([{{match, Expected}, Cmd} | T], State, ShouldIncrement) ->
+    {_Error, Response, NewState, NewShdIncr} = run_cmd(Cmd, State, ShouldIncrement),
+    %% when you start getting off-by-1 weirdness you will WANT to uncomment this
     %% Trim off the newlines to aid in string comparison
     ExpectedTrimmed = re:replace(Expected, "\n", "", [global,{return,list}]),
-    ResultTrimmed = re:replace(lists:flatten(NewMsg), "\n", "", [global,{return,list}]),
+    ResultTrimmed = re:replace(lists:flatten(Response), "\n", "", [global,{return,list}]),
     case ResultTrimmed of
         ExpectedTrimmed -> lager:info("Successful match of ~p from ~p", [Expected, Cmd]),
-                           run_commands(T, NewMsg, NewState, NewShdIncr);
+                           run_commands(T, NewState, NewShdIncr);
         Got             -> print_error("Ran ~p:", Cmd, Expected, Got),
                            fail
     end;
-run_commands([{run, Cmd} | T], Msg, State, ShouldIncrement) ->
+run_commands([{run, Cmd} | T], State, ShouldIncrement) ->
     lager:info("Run command: ~p", [Cmd]),
-    {NewMsg, NewState, NewShdIncr} = run_cmd(Cmd, Msg, State, ShouldIncrement),
-    run_commands(T, NewMsg, NewState, NewShdIncr).
+    {_Error, Result, NewState, NewShdIncr} = run_cmd(Cmd, State, ShouldIncrement),
+    lists:map(fun(X) -> lager:info("~s~n", [X]) end, re:split(Result, "\n", [trim])),
+    run_commands(T, NewState, NewShdIncr).
 
-run_cmd(Cmd, Msg, State, ShouldIncrement) ->
+run_cmd(Cmd, State, ShouldIncrement) ->
     %% the riak-shell works by spawning a process that has captured
     %% standard input and then dropping into a receive that the spawned
     %% process sends a message to
@@ -111,7 +112,7 @@ run_cmd(Cmd, Msg, State, ShouldIncrement) ->
     %% we are going to send a message at some time in the future
     %% and then go into a loop waiting for it
     timer:apply_after(500, riak_shell, send_to_shell, [self(), {command, Cmd}]),
-    riak_shell:loop_TEST(Msg, State, ShouldIncrement).
+    riak_shell:loop_TEST(riak_shell:make_cmd(Cmd), State, ShouldIncrement).
 
 print_error(Format, Cmd, Expected, Got) ->
     lager:info(?PREFIX ++ "Match Failure"),

--- a/tests/ts_cluster_riak_shell_basic_sql.erl
+++ b/tests/ts_cluster_riak_shell_basic_sql.erl
@@ -17,7 +17,7 @@
 %% under the License.
 %%
 %% -------------------------------------------------------------------
--module(ts_riak_shell_basic_sql).
+-module(ts_cluster_riak_shell_basic_sql).
 
 -behavior(riak_test).
 
@@ -73,7 +73,7 @@ create_table_test(Pid) ->
             {{match, Describe},
              "DESCRIBE GeoCheckin;"}
            ],
-    Result = riak_shell_test_util:run_commands(Cmds, "Start", State,
+    Result = riak_shell_test_util:run_commands(Cmds, State,
                                                ?DONT_INCREMENT_PROMPT),
     lager:info("Result is ~p~n", [Result]),
     lager:info("~n~n------------------------------------------------------", []),
@@ -101,7 +101,7 @@ query_table_test(Pid, Conn) ->
         {{match, Expected},
             Select}
     ],
-    Result = riak_shell_test_util:run_commands(Cmds, "Start", State,
+    Result = riak_shell_test_util:run_commands(Cmds, State,
         ?DONT_INCREMENT_PROMPT),
     lager:info("Result is ~p~n", [Result]),
     lager:info("~n~n------------------------------------------------------", []),


### PR DESCRIPTION
Add a `riak_shell` regression log as a basic functionality test.  Also fix interaction with `riak_shell` which was changed in https://github.com/basho/riak_shell/pull/23. We are consuming the command `cmd_error` code, but are not using it in tests yet.

Requires https://github.com/basho/riak_shell/pull/27