### PR TITLE
Update basic_command_line for new CLI messages

### DIFF
--- a/tests/basic_command_line.erl
+++ b/tests/basic_command_line.erl
@@ -24,6 +24,8 @@
 -compile(export_all).
 -export([confirm/0]).
 
+-define(PING_FAILURE_OUTPUT, "Node did not respond to ping!").
+
 confirm() ->
 
     %% Deploy a node to test against
@@ -118,7 +120,7 @@ ping_down_test(Node) ->
 attach_down_test(Node) ->
     lager:info("Testing riak attach while down"),
     {ok, AttachOut} = rt:riak(Node, ["attach"]),
-    ?assert(rt:str(AttachOut, "Node did not respond to ping!")),
+    ?assert(rt:str(AttachOut, ?PING_FAILURE_OUTPUT)),
     ok.
 
 attach_direct_up_test(Node) ->
@@ -133,7 +135,7 @@ attach_direct_up_test(Node) ->
 attach_direct_down_test(Node) ->
     lager:info("Testing riak attach-direct while down"),
     {ok, AttachOut} = rt:riak(Node, ["attach-direct"]),
-    ?assert(rt:str(AttachOut, "Node did not respond to ping!")),
+    ?assert(rt:str(AttachOut, ?PING_FAILURE_OUTPUT)),
     ok.
 
 status_up_test(Node) ->
@@ -151,7 +153,7 @@ status_down_test(Node) ->
     lager:info("Test riak-admin status while down"),
     {ok, {ExitCode, StatusOut}} = rt:admin(Node, ["status"], [return_exit_code]),
     ?assertEqual(1, ExitCode),
-    ?assert(rt:str(StatusOut, "Node did not respond to ping!")),
+    ?assert(rt:str(StatusOut, ?PING_FAILURE_OUTPUT)),
     ok.
 
 getpid_up_test(Node) ->

--- a/tests/basic_command_line.erl
+++ b/tests/basic_command_line.erl
@@ -118,7 +118,7 @@ ping_down_test(Node) ->
 attach_down_test(Node) ->
     lager:info("Testing riak attach while down"),
     {ok, AttachOut} = rt:riak(Node, ["attach"]),
-    ?assert(rt:str(AttachOut, "Node is not running!")),
+    ?assert(rt:str(AttachOut, "Node did not respond to ping!")),
     ok.
 
 attach_direct_up_test(Node) ->
@@ -133,7 +133,7 @@ attach_direct_up_test(Node) ->
 attach_direct_down_test(Node) ->
     lager:info("Testing riak attach-direct while down"),
     {ok, AttachOut} = rt:riak(Node, ["attach-direct"]),
-    ?assert(rt:str(AttachOut, "Node is not running!")),
+    ?assert(rt:str(AttachOut, "Node did not respond to ping!")),
     ok.
 
 status_up_test(Node) ->
@@ -151,7 +151,7 @@ status_down_test(Node) ->
     lager:info("Test riak-admin status while down"),
     {ok, {ExitCode, StatusOut}} = rt:admin(Node, ["status"], [return_exit_code]),
     ?assertEqual(1, ExitCode),
-    ?assert(rt:str(StatusOut, "Node is not running!")),
+    ?assert(rt:str(StatusOut, "Node did not respond to ping!")),
     ok.
 
 getpid_up_test(Node) ->


### PR DESCRIPTION
In the latest 2.0 code, it now prints "node did not respond to ping"
instead of "node is not running" when using a ping test to try and
check the node status.