### PR TITLE
Handle node_package message change

### DIFF
--- a/src/rt.erl
+++ b/src/rt.erl
@@ -1,6 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%% Copyright (c) 2013-2014 Basho Technologies, Inc.
+%% Copyright (c) 2013-2016 Basho Technologies, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -130,6 +130,7 @@
          stop_tracing/0,
          stop_and_wait/1,
          str/2,
+         str_mult/2,
          systest_read/2,
          systest_read/3,
          systest_read/5,
@@ -218,6 +219,11 @@ str(String, Substr) ->
         0 -> false;
         _ -> true
     end.
+
+%% @doc if String contains any of Substrs, return true.
+-spec str_mult(string(), [string()]) -> boolean().
+str_mult(String, Substrs) ->
+    lists:any(fun(S) -> str(String, S) end, Substrs).
 
 -spec set_conf(atom(), [{string(), string()}]) -> ok.
 set_conf(all, NameValuePairs) ->

--- a/tests/basic_command_line.erl
+++ b/tests/basic_command_line.erl
@@ -168,5 +168,5 @@ getpid_up_test(Node) ->
 getpid_down_test(Node) ->
     lager:info("Test riak getpid fails on ~s", [Node]),
     {ok, PidOut} = rt:riak(Node, ["getpid"]),
-    ?assert(rt:str(PidOut, "Node is not running!")),
+    ?assert(rt:str_mult(PidOut, ?PING_FAILURE_OUTPUT)),
     ok.

--- a/tests/basic_command_line.erl
+++ b/tests/basic_command_line.erl
@@ -24,6 +24,10 @@
 -compile(export_all).
 -export([confirm/0]).
 
+% node_package 3.x changes this - new first, old second
+-define(PING_FAILURE_OUTPUT,
+    ["Node did not respond to ping!", "Node is not running!"]).
+
 confirm() ->
 
     %% Deploy a node to test against
@@ -118,7 +122,7 @@ ping_down_test(Node) ->
 attach_down_test(Node) ->
     lager:info("Testing riak attach while down"),
     {ok, AttachOut} = rt:riak(Node, ["attach"]),
-    ?assert(rt:str(AttachOut, "Node is not running!")),
+    ?assert(rt:str_mult(AttachOut, ?PING_FAILURE_OUTPUT)),
     ok.
 
 attach_direct_up_test(Node) ->
@@ -133,7 +137,7 @@ attach_direct_up_test(Node) ->
 attach_direct_down_test(Node) ->
     lager:info("Testing riak attach-direct while down"),
     {ok, AttachOut} = rt:riak(Node, ["attach-direct"]),
-    ?assert(rt:str(AttachOut, "Node is not running!")),
+    ?assert(rt:str_mult(AttachOut, ?PING_FAILURE_OUTPUT)),
     ok.
 
 status_up_test(Node) ->
@@ -151,7 +155,7 @@ status_down_test(Node) ->
     lager:info("Test riak-admin status while down"),
     {ok, {ExitCode, StatusOut}} = rt:admin(Node, ["status"], [return_exit_code]),
     ?assertEqual(1, ExitCode),
-    ?assert(rt:str(StatusOut, "Node is not running!")),
+    ?assert(rt:str_mult(StatusOut, ?PING_FAILURE_OUTPUT)),
     ok.
 
 getpid_up_test(Node) ->

--- a/tests/basic_command_line.erl
+++ b/tests/basic_command_line.erl
@@ -1,6 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%% Copyright (c) 2012 Basho Technologies, Inc.
+%% Copyright (c) 2012-2016 Basho Technologies, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file


### PR DESCRIPTION
Adds rt:str_mult/2, to check for any of multiple substrings.
Alters the basic_command_line test to accept the ping response from node_package 2.x or 3.x.