### PR TITLE
Fix issues with yz_extractor test

### DIFF
--- a/tests/yz_extractors.erl
+++ b/tests/yz_extractors.erl
@@ -253,8 +253,6 @@ confirm() ->
     test_extractor_works(Cluster, Packet),
     test_extractor_with_aae_expire(Cluster, ?INDEX2, ?BUCKET2, Packet),
 
-    rt:clean_cluster(Cluster),
-
     pass.
 
 %%%===================================================================

--- a/tests/yz_extractors.erl
+++ b/tests/yz_extractors.erl
@@ -145,7 +145,9 @@
            %% allow AAE to build trees and exchange rapidly
            {anti_entropy_build_limit, {100, 1000}},
            {anti_entropy_concurrency, 8},
-           {anti_entropy_tick, 1000}
+           {anti_entropy_tick, 1000},
+           %% but start with AAE turned off so as not to interfere with earlier parts of the test
+           {anti_entropy, {off, []}}
           ]},
          {yokozuna,
           [
@@ -317,6 +319,8 @@ test_extractor_with_aae_expire(Cluster, Index, Bucket, Packet) ->
 
     yokozuna_rt:search_expect({Host, Port}, Index, <<"host">>,
                               <<"www*">>, 1),
+
+    rpc:multicall(Cluster, riak_kv_entropy_manager, enable, []),
 
     yokozuna_rt:expire_trees(Cluster),
     yokozuna_rt:wait_for_full_exchange_round(Cluster, erlang:now()),


### PR DESCRIPTION
This PR addresses some false positives we were occasionally seeing with the yz_extractor test. The issue had to do with some test code that counts the number of calls to an internal yokozuna function, get_map. It normally gets called once per read, so after doing 20 reads with n=3, the test expects to see that the function was called 60 times. Occasionally though, a YZ AAE exchange would occur during those 20 writes and trigger a repair, which in turn would trigger an extra call to get_map, which caused us to see 61 calls instead.

To fix this, we start the test off with AAE disabled, and then enable it later on once we're passed the race-prone part of the test (we do need to turn it on later, and can't just leave it disabled, since the end of the test requires AAE). This ended up being somewhat tricky, since the yokozuna_rt:rolling_upgrade function that this test uses was previously hardcoded to enable AAE on the upgraded cluster. This particular feature of the function seems to be safe to remove though, and Jason recently wrote a new, refactored version of the rolling_upgrade function as well, so I've incorporated that into the fixes.

On a final, unrelated note, I also removed an extra call to rt:clean_cluster that was previously at the end of the test. Just seemed unnecessary, since the whole environment gets cleaned up anyway when we start a new test, and I figured sometimes we may even want things left as-is after the test finishes if we're investigating an error.