### PR TITLE
Compile ts_simple_create_table_eqc only if EQC is present

### DIFF
--- a/tests/ts_simple_create_table_eqc.erl
+++ b/tests/ts_simple_create_table_eqc.erl
@@ -22,9 +22,9 @@
 -module(ts_simple_create_table_eqc).
 -compile(export_all).
 
+-ifdef(EQC).
 -behavior(riak_test).
 
-%-ifdef(EQC).
 -include_lib("riakc/include/riakc.hrl").
 -include_lib("eqc/include/eqc.hrl").
 -include_lib("eqc/include/eqc_fsm.hrl").
@@ -51,3 +51,4 @@ create_and_activate(ClusterConn, Table, DDL) ->
     {ok, _} = ts_util:create_and_activate_bucket_type(ClusterConn, DDL, Table, ?DEFAULT_NVAL),
     true.
 
+-endif.

--- a/tests/ts_sql_eqc_util.erl
+++ b/tests/ts_sql_eqc_util.erl
@@ -24,7 +24,7 @@
 
 -compile(export_all).
 
-%-ifdef(EQC).
+-ifdef(EQC).
 -include_lib("eqc/include/eqc.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("riak_ql/include/riak_ql_ddl.hrl").
@@ -196,4 +196,4 @@ make_q(#hash_fn_v1{mod  = riak_ql_quanta,
 lk_to_sql(LK) ->
     string:join([binary_to_list(X#param_v1.name) || X <- LK#key_v1.ast], ", ").
 
-%-endif.
+-endif.


### PR DESCRIPTION
This test won't compile without EQC installed