### PR TITLE
ts_simple_recompile_ddl: Wait for cluster after restarting the node

### DIFF
--- a/tests/ts_simple_recompile_ddl.erl
+++ b/tests/ts_simple_recompile_ddl.erl
@@ -39,7 +39,7 @@ confirm() ->
     rt:stop(Node),
     simulate_old_dets_entries(),
     rt:start(Node),
-    rt:wait_until_nodes_ready(Cluster),
+    rt:wait_for_service(Node, riak_kv),
     verify_resulting_dets_entries(),
     pass.
 

--- a/tests/ts_simple_recompile_ddl.erl
+++ b/tests/ts_simple_recompile_ddl.erl
@@ -39,6 +39,7 @@ confirm() ->
     rt:stop(Node),
     simulate_old_dets_entries(),
     rt:start(Node),
+    rt:wait_until_nodes_ready(Cluster),
     verify_resulting_dets_entries(),
     pass.
 


### PR DESCRIPTION
See if pausing before reading the results helps to get a consistent test result