### PR TITLE
Update tsqueryresp to {ok, {_, _}} 

### DIFF
--- a/tests/riak_shell_test_util.erl
+++ b/tests/riak_shell_test_util.erl
@@ -19,7 +19,7 @@
 %% -------------------------------------------------------------------
 -module(riak_shell_test_util).
 
--define(CLUSTERSIZE, 2).
+-define(CLUSTERSIZE, 3).
 -define(EMPTYCONFIG, []).
 
 -export([

--- a/tests/ts_cluster_riak_shell_basic_sql.erl
+++ b/tests/ts_cluster_riak_shell_basic_sql.erl
@@ -112,7 +112,7 @@ query(Conn, SQL) ->
     case riakc_ts:query(Conn, SQL) of
         {error, {ErrNo, Binary}} ->
             io_lib:format("Error (~p): ~s", [ErrNo, Binary]);
-        {Header, Rows} ->
+        {ok, {Header, Rows}} ->
             Hdr = [binary_to_list(X) || X <- Header],
             Rs = [begin
                       Row = tuple_to_list(RowTuple),


### PR DESCRIPTION
This change is required because of https://github.com/basho/riak-erlang-client/pull/276.  Make `tsqueryresp` success and failure have the same shape.

Also increase the `riak_shell` test cluster size to 3.