### PR TITLE
assorted post TTB merge fixes

### DIFF
--- a/priv/riak_shell/riak_shell_regression1.log
+++ b/priv/riak_shell/riak_shell_regression1.log
@@ -32,8 +32,8 @@
 {{command, "insert into GeoCheckin (myfamily, myseries, time, weather, temperature) values ('family1','series1',10,28);\n"}, {result, "Error (1003): Invalid data found at row index(es) 1"}}.
 {{command, "insert into GeoCheckin (myfamily, myseries, time, weather, temperature) values ('family1','series1',10,'hail',38.1);\n"}, {result, ""}}.
 {{command, "select time, weather, temperature from GeoCheckin where myfamily='family1' and myseries='seriesX' and time > 10 and time < 1000;\n"}, {result, ""}}.
-{{command, "select * from GeoCheckin;\n"}, {result, "Error (1001): no_where_clause: The query must have a where clause."}}.
-{{command, "select * from GeoCheckin where myfamily = 'family1' and myseries = 'series1' and time >= 1420113600000 and time <= 1420119300000;\n"}, {result, "Error (1001): {too_many_subqueries,7}"}}.
+{{command, "select * from GeoCheckin;\n"}, {result, "Error (1001): The query must have a where clause."}}.
+{{command, "select * from GeoCheckin where myfamily = 'family1' and myseries = 'series1' and time >= 1420113600000 and time <= 1420119300000;\n"}, {result, "Error (1001): Too many subqueries (7)"}}.
 {{command, "select * from GeoCheckin where myfamily = 'family1' and myseries = 'series1' and time >= 1 and time <= 2;\n"}, {result, "+--------+--------+----+-------+--------------------------+
 |myfamily|myseries|time|weather|       temperature        |
 +--------+--------+----+-------+--------------------------+
@@ -41,9 +41,9 @@
 |family1 |series1 | 2  | rain  |2.45000000000000000000e+01|
 +--------+--------+----+-------+--------------------------+
 "}}.
-{{command, "select * from GeoCheckin where myfamily = 'family1' and myseries = 'series1' and time >= 10 and time <= 8;\n"}, {result, "Error (1001): lower_bound_must_be_less_than_upper_bound: The lower time bound is greater than the upper time bound."}}.
-{{command, "select * from GeoCheckin where myfamily = 'family1' and myseries = 'series1' and time >= 10;\n"}, {result, "Error (1001): incomplete_where_clause: Where clause has no upper bound."}}.
-{{command, "select * from GeoCheckin where myfamily = 'family1' and myseries = 'series1' and time <= 8;\n"}, {result, "Error (1001): incomplete_where_clause: Where clause has no lower bound."}}.
+{{command, "select * from GeoCheckin where myfamily = 'family1' and myseries = 'series1' and time >= 10 and time <= 8;\n"}, {result, "Error (1001): The lower time bound is greater than the upper time bound."}}.
+{{command, "select * from GeoCheckin where myfamily = 'family1' and myseries = 'series1' and time >= 10;\n"}, {result, "Error (1001): Where clause has no upper bound."}}.
+{{command, "select * from GeoCheckin where myfamily = 'family1' and myseries = 'series1' and time <= 8;\n"}, {result, "Error (1001): Where clause has no lower bound."}}.
 {{command, "select * from GeoCheckin where myfamily = 'family1' and myseries = 'series1' and time >= 2 and time <= 7;\n"}, {result, "+--------+--------+----+-------+--------------------------+
 |myfamily|myseries|time|weather|       temperature        |
 +--------+--------+----+-------+--------------------------+

--- a/tests/ts_cluster_comprehensive.erl
+++ b/tests/ts_cluster_comprehensive.erl
@@ -56,7 +56,7 @@ run_tests(PvalP1, PvalP2) ->
                   ?PKEY_P1, ?PKEY_P2, ?PKEY_P3,
                   ?PKEY_P1, ?PKEY_P2, ?PKEY_P3,
                   ?PKEY_P1, ?PKEY_P2, ?PKEY_P3]),
-    ts_util:create_and_activate_bucket_type(Cluster, lists:flatten(TableDef), ?BUCKET),
+    ?assertEqual({[], []}, riakc_ts:query(rt:pbc(hd(Cluster)), TableDef)),
 
     %% Make sure data is written to each node
     lists:foreach(fun(Node) -> confirm_all_from_node(Node, Data, PvalP1, PvalP2) end, Cluster),

--- a/tests/ts_cluster_comprehensive.erl
+++ b/tests/ts_cluster_comprehensive.erl
@@ -56,7 +56,7 @@ run_tests(PvalP1, PvalP2) ->
                   ?PKEY_P1, ?PKEY_P2, ?PKEY_P3,
                   ?PKEY_P1, ?PKEY_P2, ?PKEY_P3,
                   ?PKEY_P1, ?PKEY_P2, ?PKEY_P3]),
-    ?assertEqual({[], []}, riakc_ts:query(rt:pbc(hd(Cluster)), TableDef)),
+    ?assertEqual({ok, {[], []}}, riakc_ts:query(rt:pbc(hd(Cluster)), TableDef)),
 
     %% Make sure data is written to each node
     lists:foreach(fun(Node) -> confirm_all_from_node(Node, Data, PvalP1, PvalP2) end, Cluster),

--- a/tests/ts_cluster_coverage.erl
+++ b/tests/ts_cluster_coverage.erl
@@ -58,7 +58,7 @@ test_quanta_range(Table, ExpectedData, Nodes, NumQuanta, QuantumMS) ->
           fun({{IP, Port}, Context, TsRange, _Description}, Acc) ->
                   {ok, Pid} = riakc_pb_socket:start_link(
                                 binary_to_list(IP), Port),
-                  {_, ThisQuantum} = riakc_ts:query(Pid, Qry, [], Context),
+                  {ok, {_, ThisQuantum}} = riakc_ts:query(Pid, Qry, [], Context),
                   riakc_pb_socket:stop(Pid),
 
                   %% Open a connection to another node and
@@ -66,7 +66,7 @@ test_quanta_range(Table, ExpectedData, Nodes, NumQuanta, QuantumMS) ->
                   %% this cover context
                   {ok, WrongPid} = riakc_pb_socket:start_link(
                                      binary_to_list(IP), alternate_port(Port)),
-                  ?assertEqual({[], []},
+                  ?assertEqual({ok, {[], []}},
                                riakc_ts:query(WrongPid, Qry, [], Context)),
                   riakc_pb_socket:stop(WrongPid),
 

--- a/tests/ts_cluster_coverage.erl
+++ b/tests/ts_cluster_coverage.erl
@@ -54,31 +54,31 @@ test_quanta_range(Table, ExpectedData, Nodes, NumQuanta, QuantumMS) ->
     {ok, CoverageEntries} = riakc_ts:get_coverage(AdminPid, Table, Qry),
 
     Results =
-        lists:foldl(fun(#tscoverageentry{ip=IP, port=Port, cover_context=C,
-                                         range=TsRange}, Acc) ->
-                            {ok, Pid} = riakc_pb_socket:start_link(binary_to_list(IP),
-                                                                   Port),
-                            {ok, {_, ThisQuantum}} = riakc_ts:query(Pid, Qry, [], C),
-                            riakc_pb_socket:stop(Pid),
+        lists:foldl(
+          fun({{IP, Port}, Context, TsRange, _Description}, Acc) ->
+                  {ok, Pid} = riakc_pb_socket:start_link(
+                                binary_to_list(IP), Port),
+                  {_, ThisQuantum} = riakc_ts:query(Pid, Qry, [], Context),
+                  riakc_pb_socket:stop(Pid),
 
-                            %% Open a connection to another node and
-                            %% make certain we get no results using
-                            %% this cover context
-                            {ok, WrongPid} = riakc_pb_socket:start_link(binary_to_list(IP),
-                                                                        alternate_port(Port)),
-                            ?assertEqual({ok, {[], []}},
-                                         riakc_ts:query(WrongPid, Qry, [], C)),
-                            riakc_pb_socket:stop(WrongPid),
+                  %% Open a connection to another node and
+                  %% make certain we get no results using
+                  %% this cover context
+                  {ok, WrongPid} = riakc_pb_socket:start_link(
+                                     binary_to_list(IP), alternate_port(Port)),
+                  ?assertEqual({[], []},
+                               riakc_ts:query(WrongPid, Qry, [], Context)),
+                  riakc_pb_socket:stop(WrongPid),
 
-                            %% Let's compare the range data with the
-                            %% query results to make sure the latter
-                            %% fall within the former
-                            check_data_against_range(ThisQuantum, TsRange),
-                            %% Now add to the pile and continue
-                            ThisQuantum ++ Acc
-                    end,
-                    [],
-                    CoverageEntries),
+                  %% Let's compare the range data with the
+                  %% query results to make sure the latter
+                  %% fall within the former
+                  check_data_against_range(ThisQuantum, TsRange),
+                  %% Now add to the pile and continue
+                  ThisQuantum ++ Acc
+          end,
+          [],
+          CoverageEntries),
     ?assertEqual(lists:sort(ExpectedData), lists:sort(Results)),
 
     %% Expect {error,{1001,<<"{too_many_subqueries,13}">>}} if NumQuanta > 5
@@ -104,10 +104,7 @@ time_within_range(Time, Lower, LowerIncl, Upper, UpperIncl) ->
             UpperIncl
     end.
 
-check_data_against_range(Data, #tsrange{lower_bound=Lower,
-                                        lower_bound_inclusive=LowerIncl,
-                                        upper_bound=Upper,
-                                        upper_bound_inclusive=UpperIncl}) ->
+check_data_against_range(Data, {_FieldName, {{Lower, LowerIncl}, {Upper, UpperIncl}}}) ->
     ?assertEqual([], lists:filter(fun({_, _, Time, _, _}) ->
                                           not time_within_range(Time, Lower, LowerIncl,
                                                                 Upper, UpperIncl)

--- a/tests/ts_simple_aggregation_math.erl
+++ b/tests/ts_simple_aggregation_math.erl
@@ -74,7 +74,7 @@ confirm() ->
 div_by_zero_test(Conn, Bucket, Where) ->
     Query = "SELECT 5 / 0 FROM " ++ Bucket ++ Where,
     ?assertEqual(
-        {error,{1001,<<"divide_by_zero">>}},
+        {error,{1001,<<"Divide by zero">>}},
         ts_util:single_query(Conn, Query)
     ).
 
@@ -82,7 +82,7 @@ div_by_zero_test(Conn, Bucket, Where) ->
 div_aggregate_function_by_zero_test(Conn, Bucket, Where) ->
     Query = "SELECT COUNT(*) / 0 FROM " ++ Bucket ++ Where,
     ?assertEqual(
-        {error,{1001,<<"divide_by_zero">>}},
+        {error,{1001,<<"Divide by zero">>}},
         ts_util:single_query(Conn, Query)
     ).
 

--- a/tests/ts_simple_div_by_zero.erl
+++ b/tests/ts_simple_div_by_zero.erl
@@ -87,4 +87,4 @@ where() ->
     "AND time >= 1 AND time <= 10 ".
 
 error_divide_by_zero() ->
-    {error,{1001,<<"divide_by_zero">>}}.
+    {error,{1001,<<"Divide by zero">>}}.

--- a/tests/ts_simple_put_bad_date.erl
+++ b/tests/ts_simple_put_bad_date.erl
@@ -30,11 +30,11 @@ confirm() ->
     TestType = normal,
     DDL = ts_util:get_ddl(),
     Obj =
-        [[ts_util:get_varchar(),
+        [{ts_util:get_varchar(),
           ts_util:get_varchar(),
           <<"abc">>,
           ts_util:get_varchar(),
-          ts_util:get_float()]],
+          ts_util:get_float()}],
     Expected = {error, {1003, <<"Invalid data found at row index(es) 1">>}},
     Got = ts_util:ts_put(
             ts_util:cluster_and_connect(single), TestType, DDL, Obj),

--- a/tests/ts_simple_select_incompatible_type_float_not_allowed.erl
+++ b/tests/ts_simple_select_incompatible_type_float_not_allowed.erl
@@ -37,9 +37,7 @@ confirm() ->
     Expected =
         {error,
          {1001,
-          <<"invalid_query: \n",
-            "incompatible_type: field myseries with type varchar cannot be compared to type float in where clause.">>}},
+          <<".*incompatible_type: field myseries with type varchar cannot be compared to type float in where clause.">>}},
     Got = ts_util:ts_query(
             ts_util:cluster_and_connect(single), normal, DDL, Data, Qry),
-    ?assertEqual(Expected, Got),
-    pass.
+    ts_util:assert_error_regex("Incompatible types", Expected, Got).

--- a/tests/ts_simple_select_incompatible_type_integer_not_allowed.erl
+++ b/tests/ts_simple_select_incompatible_type_integer_not_allowed.erl
@@ -39,9 +39,7 @@ confirm() ->
     Expected =
         {error,
          {1001,
-          <<"invalid_query: \n",
-            "incompatible_type: field myseries with type varchar cannot be compared to type integer in where clause.">>}},
+          <<".*incompatible_type: field myseries with type varchar cannot be compared to type integer in where clause.">>}},
     Got = ts_util:ts_query(
             ts_util:cluster_and_connect(single), normal, DDL, Data, Qry),
-    ?assertEqual(Expected, Got),
-    pass.
+    ts_util:assert_error_regex("Incompatible type", Expected, Got).

--- a/tests/ts_simple_select_missing_field_in_pk_not_allowed.erl
+++ b/tests/ts_simple_select_missing_field_in_pk_not_allowed.erl
@@ -39,8 +39,7 @@ confirm() ->
     Expected =
         {error,
          {1001,
-          <<"missing_key_clause: The 'myfamily' parameter is part the primary key but not specified in the where clause.">>}},
+          <<"The 'myfamily' parameter is part the primary key but not specified in the where clause.">>}},
     Got = ts_util:ts_query(
             ts_util:cluster_and_connect(single), normal, DDL, Data, Query),
-    ?assertEqual(Expected, Got),
-    pass.
+    ts_util:assert_error_regex("Missing key", Expected, Got).

--- a/tests/ts_simple_select_where_has_no_lower_bounds_not_allowed.erl
+++ b/tests/ts_simple_select_where_has_no_lower_bounds_not_allowed.erl
@@ -37,9 +37,8 @@ confirm() ->
     Expected =
         {error,
          {1001,
-          <<"incomplete_where_clause: Where clause has no lower bound.">>}},
+          <<"Where clause has no lower bound.">>}},
     Got = ts_util:ts_query(
             ts_util:cluster_and_connect(single), TestType, DDL, Data, Qry),
-    ?assertEqual(Expected, Got),
-    pass.
+    ts_util:assert_error_regex("No lower bound", Expected, Got).
 

--- a/tests/ts_simple_select_where_has_no_upper_bounds_not_allowed.erl
+++ b/tests/ts_simple_select_where_has_no_upper_bounds_not_allowed.erl
@@ -35,9 +35,8 @@ confirm() ->
           "and myfamily = 'family1' "
           "and myseries ='seriesX' ",
     Expected =
-        {error, {1001, <<"incomplete_where_clause: Where clause has no upper bound.">>}},
+        {error, {1001, <<"Where clause has no upper bound.">>}},
     Got = ts_util:ts_query(
             ts_util:cluster_and_connect(single), TestType, DDL, Data, Qry),
-    ?assertEqual(Expected, Got),
-    pass.
+    ts_util:assert_error_regex("No upper bound", Expected, Got).
 


### PR DESCRIPTION
This PR contains assorted fixes to correspond with the changes in https://github.com/basho/riak_kv/pull/1396 and https://github.com/basho/riak_kv/pull/1397. In particular:

* error messages are now more human-readable and don't include odd `{MnemonicAtom, ErrorDescription}` forcibly converted to a string using "~p";
* `riakc_ts:get_coverage` now returns native Elang term, not a `#tscoverageresp` that needs to be disassembled using internal PB records (they should not be exposed to the callers of `riakc_ts:get_coverage`).