### PR TITLE
Adjust STDDEV tests to match the current definition

### DIFF
--- a/tests/ts_simple_aggregation.erl
+++ b/tests/ts_simple_aggregation.erl
@@ -147,7 +147,7 @@ verify_aggregation(ClusterType) ->
     Expected9 = {ok, {[<<"STDDEV_POP(temperature)">>, <<"STDDEV_POP(pressure)">>,
                   <<"STDDEV(temperature)">>, <<"STDDEV(pressure)">>,
                   <<"STDDEV_SAMP(temperature)">>, <<"STDDEV_SAMP(pressure)">>],
-                 [{StdDev4, StdDev5, StdDev4, StdDev5, Sample4, Sample5}]}},
+                 [{StdDev4, StdDev5, Sample4, Sample5, Sample4, Sample5}]}},
     Result9 = ts_util:assert_float(test_name(ClusterType, "Standard Deviation"), Expected9, Got9),
 
     Qry10 = "SELECT SUM(temperature), MIN(pressure), AVG(pressure) FROM " ++ Bucket ++ Where,

--- a/tests/ts_util.erl
+++ b/tests/ts_util.erl
@@ -504,7 +504,7 @@ get_optional(N, X) ->
     end.
 
 
--define(DELTA, 1.0e-10).
+-define(DELTA, 1.0e-15).
 
 assert_float(String, {_, {Cols, [ValsA]}} = Exp, {_, {Cols, [ValsB]}} = Got) ->
     case assertf2(tuple_to_list(ValsA), tuple_to_list(ValsB)) of


### PR DESCRIPTION
According to the code and the documentation, STDDEV =:= STDDEV_SAMP, not STDDEV_POP, so make sure the test is actually doing the right thing