### PR TITLE
Add confirm_missing to rt: and use it in ts_replication

### DIFF
--- a/tests/repl_util.erl
+++ b/tests/repl_util.erl
@@ -49,7 +49,8 @@
          read_from_cluster/6,
          check_fullsync/3,
          validate_completed_fullsync/6,
-         validate_intercepted_fullsync/5
+         validate_intercepted_fullsync/5,
+         confirm_missing/5
         ]).
 -include_lib("eunit/include/eunit.hrl").
 
@@ -203,6 +204,11 @@ wait_for_reads(Node, Start, End, Bucket, R) ->
     Reads = rt:systest_read(Node, Start, End, Bucket, R, <<>>, true),
     lager:info("Reads: ~p", [Reads]),
     length(Reads).
+
+confirm_missing(Node, Start, End, Bucket, R) ->
+    Reads = rt:systest_read(Node, Start, End, Bucket, R, <<>>, true),
+    Expected = [{N,{error,notfound}} || N <- lists:seq(Start, End)],
+    lists:sort(Reads) == lists:sort(Expected).
 
 get_fs_coord_status_item(Node, SinkName, ItemName) ->
     Status = rpc:call(Node, riak_repl_console, status, [quiet]),

--- a/tests/ts_replication.erl
+++ b/tests/ts_replication.erl
@@ -207,7 +207,7 @@ no_w1c_real_time_replication_test([AFirst|_] = ANodes, [BFirst|_] = BNodes, Lead
     timer:sleep(2000),
 
     lager:info("Verifying none of the new records are on B"),
-    ?assertEqual(100, repl_util:wait_for_reads(BFirst, 1001, 1100, Bucket, 2)),
+    ?assertEqual(true, repl_util:confirm_missing(BFirst, 1001, 1100, Bucket, 2)),
 
     disconnect_clusters(ANodes, LeaderA, "B").
 


### PR DESCRIPTION
Added to remove 10-minute delay in `ts_replication` test.