### PR TITLE
RTS-1087: Rename expected strings from "riak_shell" to "riak-shell"

### DIFF
--- a/priv/riak_shell/riak_shell_regression1.log
+++ b/priv/riak_shell/riak_shell_regression1.log
@@ -1,5 +1,5 @@
 {{command, "reconnect; "}, {result, "Reconnected to 'dev1@127.0.0.1' on port 10017"}}.
-{{command, "show_connection; "}, {result, "riak_shell is connected to: 'dev1@127.0.0.1' on port 10017"}}.
+{{command, "show_connection; "}, {result, "riak-shell is connected to: 'dev1@127.0.0.1' on port 10017"}}.
 {{command, "show_nodes; "}, {result, "The connected nodes are: ['dev1@127.0.0.1','dev2@127.0.0.1','dev3@127.0.0.1']"}}.
 {{command, "show_history; "}, {result, "The history contains:
 - 1: reconnect; 
@@ -64,4 +64,4 @@
 "}}.
 {{command, "reconnect; "}, {result, "Reconnected to 'dev1@127.0.0.1' on port 10017"}}.
 {{command, "connect dev2@127.0.0.1; "}, {result, "Connected to 'dev2@127.0.0.1' on port 10027"}}.
-{{command, "show_connection; "}, {result, "riak_shell is connected to: 'dev2@127.0.0.1' on port 10027"}}.
+{{command, "show_connection; "}, {result, "riak-shell is connected to: 'dev2@127.0.0.1' on port 10027"}}.

--- a/tests/riak_shell_test_connecting.erl
+++ b/tests/riak_shell_test_connecting.erl
@@ -49,7 +49,7 @@ run_test(Pid) ->
              "show_connection;"},
             {run,
              "connect 'dev1@127.0.0.1';"},
-            {{match, "riak_shell is connected to: 'dev1@127.0.0.1' on port 10017"},
+            {{match, "riak-shell is connected to: 'dev1@127.0.0.1' on port 10017"},
              "show_connection;"}
            ],
     Result = riak_shell_test_util:run_commands(Cmds, State,

--- a/tests/riak_shell_test_disconnecting.erl
+++ b/tests/riak_shell_test_disconnecting.erl
@@ -51,7 +51,7 @@ run_test(Pid) ->
              'dev1@127.0.0.1'},
             {drain, 
              "Connected..."},
-            {{match, "riak_shell is connected to: 'dev2@127.0.0.1' on port 10027"}, 
+            {{match, "riak-shell is connected to: 'dev2@127.0.0.1' on port 10027"},
              "show_connection;"},
             {start_node, 
              'dev1@127.0.0.1'},
@@ -61,7 +61,7 @@ run_test(Pid) ->
              "reconnect;"},
             {drain, 
              "Reconnected to 'dev1@127.0.0.1' on port 10017"},
-            {{match, "riak_shell is connected to: 'dev1@127.0.0.1' on port 10017"}, 
+            {{match, "riak-shell is connected to: 'dev1@127.0.0.1' on port 10017"},
              "show_connection;"}
            ], 
     Result = riak_shell_test_util:run_commands(Cmds, State,

--- a/tests/riak_shell_test_reconnecting.erl
+++ b/tests/riak_shell_test_reconnecting.erl
@@ -49,7 +49,7 @@ run_test(Pid) ->
              "show_connection;"},
             {run, 
              "reconnect;"},
-            {{match, "riak_shell is connected to: 'dev1@127.0.0.1' on port 10017"}, 
+            {{match, "riak-shell is connected to: 'dev1@127.0.0.1' on port 10017"},
              "show_connection;"}
            ],
     Result = riak_shell_test_util:run_commands(Cmds, State,


### PR DESCRIPTION
When the strings were renamed in https://github.com/basho/riak_shell/pull/32, we needed to change the expected results to match.