### PR TITLE
RTS-1088: Start ibrowse when beginning the HTTP test

### DIFF
--- a/tests/ts_simple_http_api_SUITE.erl
+++ b/tests/ts_simple_http_api_SUITE.erl
@@ -34,6 +34,7 @@ suite() ->
     [{timetrap,{minutes,10}}].
 
 init_per_suite(Config) ->
+    application:start(ibrowse),
     [Node|_] = Cluster = ts_util:build_cluster(single),
     rt:wait_for_service(Node, riak_kv),
     [{cluster, Cluster} | Config].


### PR DESCRIPTION
Initial experiments are promising that this helps to pass the `ts_simple_http_api_SUITE` test