### PR TITLE
Add repl code to test deletes

### DIFF
--- a/tests/repl_aae_fullsync.erl
+++ b/tests/repl_aae_fullsync.erl
@@ -395,7 +395,8 @@ difference_test() ->
                                   [{timeout, 4000}]),
     ?assertEqual([<<"baz">>, <<"baz2">>], lists:sort(riakc_obj:get_values(O2))),
 
-    ok = riakc_pb_socket:delete(APBC, <<"foo">>, <<"bar">>, [{timeout, 4000}]),
+    {ok, CurObjA} = riakc_pb_socket:get(APBC, <<"foo">>, <<"bar">>, [{timeout, 4000}]),
+    ok = riakc_pb_socket:delete_obj(APBC, CurObjA, [{timeout, 4000}]),
 
     {Time3, _} = timer:tc(repl_util,
                          start_and_wait_until_fullsync_complete,

--- a/tests/repl_aae_fullsync.erl
+++ b/tests/repl_aae_fullsync.erl
@@ -371,6 +371,7 @@ difference_test() ->
                          [LeaderA, "B"]),
     lager:info("Fullsync completed in ~p seconds", [Time1/1000/1000]),
 
+    lager:info("Checking that object was replicated to cluster B"),
     %% Read key from after fullsync.
     {ok, O1} = riakc_pb_socket:get(BPBC, <<"foo">>, <<"bar">>,
                                   [{timeout, 4000}]),
@@ -388,10 +389,21 @@ difference_test() ->
                          [LeaderA, "B"]),
     lager:info("Fullsync completed in ~p seconds", [Time2/1000/1000]),
 
+    lager:info("Checking that sibling data was replicated to cluster B"),
     %% Read key from after fullsync.
     {ok, O2} = riakc_pb_socket:get(BPBC, <<"foo">>, <<"bar">>,
                                   [{timeout, 4000}]),
     ?assertEqual([<<"baz">>, <<"baz2">>], lists:sort(riakc_obj:get_values(O2))),
+
+    ok = riakc_pb_socket:delete(APBC, <<"foo">>, <<"bar">>, [{timeout, 4000}]),
+
+    {Time3, _} = timer:tc(repl_util,
+                         start_and_wait_until_fullsync_complete,
+                         [LeaderA, "B"]),
+    lager:info("Fullsync completed in ~p seconds", [Time3/1000/1000]),
+
+    lager:info("Checking that deletion was replicated to cluster B"),
+    {error, notfound} = riakc_pb_socket:get(BPBC, <<"foo">>, <<"bar">>, [{timeout, 4000}]),
 
     rt:clean_cluster(Nodes),
 

--- a/tests/repl_util.erl
+++ b/tests/repl_util.erl
@@ -13,6 +13,7 @@
          wait_until_connection/1,
          wait_until_no_connection/1,
          wait_for_reads/5,
+         wait_for_deletes/5,
          wait_until_fullsync_started/1,
          wait_until_fullsync_stopped/1,
          start_and_wait_until_fullsync_complete/1,
@@ -195,9 +196,15 @@ wait_until_fullsync_stopped(SourceLeader) ->
                   end).
 
 wait_for_reads(Node, Start, End, Bucket, R) ->
+    wait_for_x(Node, fun() -> rt:systest_read(Node, Start, End, Bucket, R, <<>>, true) end).
+
+wait_for_deletes(Node, Start, End, Bucket, R) ->
+    wait_for_x(Node, fun() -> rt:systest_verify_delete(Node, Start, End, Bucket, R) end).
+
+wait_for_x(Node, Fun) ->
     ok = rt:wait_until(Node,
         fun(_) ->
-                Reads = rt:systest_read(Node, Start, End, Bucket, R, <<>>, true),
+                Reads = Fun(),
                 Reads == []
         end),
     %% rt:systest_read/6 returns a list of errors encountered while performing

--- a/tests/repl_util.erl
+++ b/tests/repl_util.erl
@@ -13,7 +13,7 @@
          wait_until_connection/1,
          wait_until_no_connection/1,
          wait_for_reads/5,
-         wait_for_deletes/5,
+         wait_for_all_notfound/5,
          wait_until_fullsync_started/1,
          wait_until_fullsync_stopped/1,
          start_and_wait_until_fullsync_complete/1,
@@ -198,14 +198,14 @@ wait_until_fullsync_stopped(SourceLeader) ->
 wait_for_reads(Node, Start, End, Bucket, R) ->
     wait_for_x(Node, fun() -> rt:systest_read(Node, Start, End, Bucket, R, <<>>, true) end).
 
-wait_for_deletes(Node, Start, End, Bucket, R) ->
+wait_for_all_notfound(Node, Start, End, Bucket, R) ->
     wait_for_x(Node, fun() -> rt:systest_verify_delete(Node, Start, End, Bucket, R) end).
 
 wait_for_x(Node, Fun) ->
     ok = rt:wait_until(Node,
         fun(_) ->
-                Reads = Fun(),
-                Reads == []
+                Results = Fun(),
+                Results =:= []
         end),
     %% rt:systest_read/6 returns a list of errors encountered while performing
     %% the requested reads. Since we are asserting this list is empty above,

--- a/tests/replication2.erl
+++ b/tests/replication2.erl
@@ -176,7 +176,7 @@ real_time_replication_test([AFirst|_] = ANodes, [BFirst|_] = BNodes, Connected) 
     lager:info("Deleting 100 keys on Cluster A"),
 
     ?assertEqual([], rt:systest_delete(LeaderA, 1, 100, TestBucket, 2)),
-    ?assertEqual(0, repl_util:wait_for_deletes(BFirst, 1, 100, TestBucket, 2)).
+    ?assertEqual(0, repl_util:wait_for_all_notfound(BFirst, 1, 100, TestBucket, 2)).
 
 %% @doc Disconnected Clusters Full Sync Test
 %%      Test Cycle:


### PR DESCRIPTION
Up until now, none of the riak_test modules for repl have tested deletes. These changes add some code to verify that deletions are propagated across clusters for both realtime and fullsync replication.