### PR TITLE
DO NOT MERGE: Add yokozuna_rt:ensure_complete_aae_round and fix tests [JIRA: RIAK-2569]

### DIFF
--- a/src/yokozuna_rt.erl
+++ b/src/yokozuna_rt.erl
@@ -40,12 +40,15 @@
          assert_search/6,
          verify_num_found_query/3,
          wait_for_aae/1,
+         wait_for_full_exchange_round/1,
          wait_for_full_exchange_round/2,
+         wait_for_full_exchange_round/3,
          wait_for_index/2,
          wait_for_schema/2,
          wait_for_schema/3,
          write_data/5,
-         write_data/6]).
+         write_data/6]
+         ).
 
 -type host() :: string().
 -type portnum() :: integer().
@@ -122,9 +125,15 @@ wait_for_aae(Cluster) ->
 %%      partitions since Timestamp
 -spec wait_for_aae([node()], erlang:timestamp()) -> ok.
 wait_for_aae(Cluster, Timestamp) ->
+    wait_for_aae(Cluster, Timestamp, false).
+
+%% @doc Use AAE status to verify that exchange has occurred for all
+%%      partitions since Timestamp
+-spec wait_for_aae([node()], erlang:timestamp(), boolean()) -> ok.
+wait_for_aae(Cluster, Timestamp, ForceExchanges) ->
     lager:info("Wait for AAE to migrate/repair indexes"),
     wait_for_all_trees(Cluster),
-    wait_for_full_exchange_round(Cluster, Timestamp),
+    wait_for_full_exchange_round(Cluster, Timestamp, ForceExchanges),
     ok.
 
 %% @doc Wait for all AAE trees to be built.
@@ -138,33 +147,40 @@ wait_for_all_trees(Cluster) ->
         end,
     rt:wait_until(Cluster, F),
     ok.
+-spec wait_for_full_exchange_round([node()]) -> ok.
+wait_for_full_exchange_round(Cluster) ->
+    wait_for_full_exchange_round(Cluster, erlang:now()).
 
 %% @doc Wait for a full exchange round since `Timestamp'.  This means
-%%      that all `{Idx,N}' for all partitions must have exchanged after
-%%      `Timestamp'.
--spec wait_for_full_exchange_round([node()], os:now()) -> ok.
+%% that all `{Idx,N}' for all partitions must have exchanged after
+%% `Timestamp'.
+-spec wait_for_full_exchange_round([node()], erlang:timestamp()) -> ok.
 wait_for_full_exchange_round(Cluster, Timestamp) ->
+    wait_for_full_exchange_round(Cluster, Timestamp, false).
+%% @doc Wait for a full exchange round since `Timestamp'.  This means
+%% that all `{Idx,N}' for all partitions must have exchanged after
+%% `Timestamp'. If `ForceExchangeRound` is true, will also call manual_exchange
+%% for any waiting exchanges.
+-spec wait_for_full_exchange_round([node()], erlang:timestamp(), boolean()) -> ok.
+wait_for_full_exchange_round(Cluster, Timestamp, ForceExchanges) ->
     lager:info("wait for full AAE exchange round on cluster ~p", [Cluster]),
     AllExchanged =
         fun(Node) ->
             Exchanges = get_exchanges_for_node(Node),
             WaitingFor = get_exchanges_older_than(Timestamp, Exchanges),
             lager:info("Still waiting for AAE of ~p ~p", [Node, WaitingFor]),
+            case ForceExchanges of
+                true -> force_exchanges(Node, WaitingFor);
+                _ -> ok
+            end,
             [] == WaitingFor
         end,
     rt:wait_until(Cluster, AllExchanged),
     ok.
 
-%% @doc In order to ensure all KV->YZ exchanges have occurred since a given timestamp,
-%% use yz_kv:compute_exchange_info to get list of exchanges to date. If any completed before
-%% timestamp, force them to run again using yz_entropy_mgr:manual_exchange.
--spec force_exchanges_if_older_than([node()], erlang:timestamp()) -> ok.
-force_exchanges_if_older_than(Cluster, Timestamp) ->
-    lists:foreach(fun(Node) ->
-        Exchanges = get_exchanges_for_node(Node),
-        OldExchanges = get_exchanges_older_than(Timestamp, Exchanges),
-        _ = [rpc:call(Node, yz_entropy_mgr, manual_exchange, [Index]) || Index <- OldExchanges]
-        end, Cluster),
+-spec force_exchanges(node(), non_neg_integer()) -> ok.
+force_exchanges(Node, Indexes) ->
+    _ = [rpc:call(Node, yz_entropy_mgr, manual_exchange, [Index]) || Index <- Indexes],
     ok.
 
 get_exchanges_older_than(Timestamp, Exchanges) ->
@@ -238,27 +254,14 @@ expire_trees(Cluster) ->
     timer:sleep(100),
     ok.
 
-%% @doc cancel any ongoing exchanges
--spec cancel_all_exchanges([node()]) -> ok.
-cancel_all_exchanges(Cluster) ->
-    lager:info("Expire all trees"),
-    _ = [_ = rpc:call(Node, yz_entropy_mgr, cancel_exchanges, [])
-        || Node <- Cluster],
-
-    %% The expire is async so just give it a moment
-    timer:sleep(100),
-    ok.
-
 %% @doc Expire trees and wait for aae. If any indexes were exchanged
 %% before this function is called, they will be forced to rerun
 %% via a call to yz_entropy_mgr:manual_exchange
 -spec ensure_complete_aae_round([node()]) -> ok.
 ensure_complete_aae_round(Cluster) ->
     Timestamp = os:timestamp(),
-    cancel_all_exchanges(Cluster),
-    force_exchanges_if_older_than(Cluster, Timestamp),
     expire_trees(Cluster),
-    wait_for_aae(Cluster, Timestamp).
+    wait_for_aae(Cluster, Timestamp, true).
 
 %% @doc Expire YZ trees
 -spec clear_trees([node()]) -> ok.

--- a/tests/yz_core_properties_create_unload.erl
+++ b/tests/yz_core_properties_create_unload.erl
@@ -98,8 +98,7 @@ test_remove_index_dirs(Cluster, RandNodes, KeyCount, Pid) ->
 
     yokozuna_rt:check_exists(Cluster, ?INDEX),
 
-    yokozuna_rt:expire_trees(Cluster),
-    yokozuna_rt:wait_for_aae(Cluster),
+    yokozuna_rt:ensure_complete_aae_round(Cluster),
 
     lager:info("Write second piece of data"),
     ok = rt:pbc_write(Pid, ?BUCKET, <<"food">>, <<"foody">>, "text/plain"),
@@ -117,8 +116,7 @@ test_remove_segment_infos_and_rebuild(Cluster, RandNodes, KeyCount, Pid) ->
 
     yokozuna_rt:check_exists(Cluster, ?INDEX),
 
-    yokozuna_rt:expire_trees(Cluster),
-    yokozuna_rt:wait_for_aae(Cluster),
+    yokozuna_rt:ensure_complete_aae_round(Cluster),
 
     lager:info("Write third piece of data"),
     ok = rt:pbc_write(Pid, ?BUCKET, <<"baz">>, <<"bar">>, "text/plain"),

--- a/tests/yz_schema_change_reset.erl
+++ b/tests/yz_schema_change_reset.erl
@@ -202,8 +202,7 @@ confirm() ->
 
     lager:info("Expire and re-check count before updating schema"),
 
-    yokozuna_rt:expire_trees(Cluster),
-    yokozuna_rt:wait_for_aae(Cluster),
+    yokozuna_rt:ensure_complete_aae_round(Cluster),
 
     yokozuna_rt:verify_num_found_query(Cluster, ?INDEX, KeyCount + 3),
 
@@ -239,8 +238,7 @@ confirm() ->
     lager:info("Expire and re-check count to make sure we're correctly indexed
                by the new schema"),
 
-    yokozuna_rt:expire_trees(Cluster),
-    yokozuna_rt:wait_for_aae(Cluster),
+    yokozuna_rt:ensure_complete_aae_round(Cluster),
 
     yokozuna_rt:verify_num_found_query(Cluster, ?INDEX, KeyCount + 5),
 


### PR DESCRIPTION
 and helper functions toallow us to make sure that one AAE round has occurred 
for each partition on a node after a certain point in time. Fixes:
- yz_core_properties_create_unload
- yz_schema_change_reset

We may be masking a real bug in the YZ exchange system - do not merge this yet.