### PR TITLE
search expect / wait for index refactor and associated cleanup

### DIFF
--- a/include/yokozuna_rt.hrl
+++ b/include/yokozuna_rt.hrl
@@ -21,3 +21,5 @@
 -type schema_name() :: string().
 -type raw_schema() :: binary().
 -type bucket() :: bucket() | {bucket(), bucket()}.
+
+-define(IBROWSE_TIMEOUT, 60000).

--- a/src/riak_test_runner.erl
+++ b/src/riak_test_runner.erl
@@ -61,7 +61,7 @@ confirm(TestModule, Outdir, TestMetaData, HarnessArgs) ->
             {fail, all_prereqs_not_present}
     end,
 
-    lager:notice("~s Test Run Complete", [TestModule]),
+    lager:notice("~s Test Run Complete ~p", [TestModule, Status]),
     {ok, Logs} = stop_lager_backend(),
     Log = unicode:characters_to_binary(Logs),
 

--- a/src/yokozuna_rt.erl
+++ b/src/yokozuna_rt.erl
@@ -53,6 +53,7 @@
 -type search_type() :: solr | yokozuna.
 
 -define(FMT(S, Args), lists:flatten(io_lib:format(S, Args))).
+-define(IBROWSE_TIMEOUT, 60000).
 -define(SOFTCOMMIT, 1000).
 
 -spec host_entries(rt:conn_info()) -> [{host(), portnum()}].
@@ -276,7 +277,8 @@ search_expect(Nodes, solr, Index, Name0, Term0, Shards, Expect)
     lager:info("Run solr search ~s", [URL]),
     Opts = [{response_format, binary}],
     F = fun(_) ->
-                {ok, "200", _, R} = ibrowse:send_req(URL, [], get, [], Opts),
+                {ok, "200", _, R} = ibrowse:send_req(URL, [], get, [], Opts,
+                                                     ?IBROWSE_TIMEOUT),
                 verify_count_http(Expect, R)
         end,
     wait_until(Nodes, F);
@@ -347,7 +349,7 @@ search(Type, {Host, Port}, Index, Name0, Term0) ->
     URL = ?FMT(FmtStr, [Host, Port, Index, Name, Term]),
     lager:info("Run search ~s", [URL]),
     Opts = [{response_format, binary}],
-    ibrowse:send_req(URL, [], get, [], Opts).
+    ibrowse:send_req(URL, [], get, [], Opts, ?IBROWSE_TIMEOUT).
 
 %%%===================================================================
 %%% Private

--- a/src/yokozuna_rt.erl
+++ b/src/yokozuna_rt.erl
@@ -90,7 +90,7 @@ write_data(Cluster, Pid, Index, {SchemaName, SchemaData},
     riakc_pb_socket:create_search_schema(Pid, SchemaName, SchemaData),
 
     create_and_set_index(Cluster, Pid, Bucket, Index, SchemaName),
-    timer:sleep(1000),
+    yokozuna_rt:commit(Cluster, Index),
 
     %% Write keys
     lager:info("Writing ~p keys", [length(Keys)]),

--- a/tests/yz_core_properties_create_unload.erl
+++ b/tests/yz_core_properties_create_unload.erl
@@ -58,13 +58,11 @@ confirm() ->
 
     %% Create a search index and associate with a bucket
     lager:info("Create and set Index ~p for Bucket ~p~n", [?INDEX, ?BUCKET]),
-    ok = riakc_pb_socket:create_search_index(Pid, ?INDEX),
+    _ = riakc_pb_socket:create_search_index(Pid, ?INDEX),
     yokozuna_rt:wait_for_index(Cluster, ?INDEX),
     ok = rt:create_and_activate_bucket_type(Node,
                                             ?TYPE,
                                             [{search_index, ?INDEX}]),
-    timer:sleep(1000),
-
     %% Write keys and wait for soft commit
     lager:info("Writing ~p keys", [KeyCount]),
     [ok = rt:pbc_write(Pid, ?BUCKET, Key, Key, "text/plain") || Key <- Keys],

--- a/tests/yz_core_properties_create_unload.erl
+++ b/tests/yz_core_properties_create_unload.erl
@@ -96,7 +96,7 @@ test_core_props_removal(Cluster, RandNodes, KeyCount, Pid) ->
 
 test_remove_index_dirs(Cluster, RandNodes, KeyCount, Pid) ->
     lager:info("Remove index directories on each node and let them recreate/reindex"),
-    yokozuna_rt:remove_index_dirs(RandNodes, ?INDEX),
+    yokozuna_rt:remove_index_dirs(RandNodes, ?INDEX, [riak_kv, yokozuna]),
 
     yokozuna_rt:check_exists(Cluster, ?INDEX),
 
@@ -115,7 +115,7 @@ test_remove_segment_infos_and_rebuild(Cluster, RandNodes, KeyCount, Pid) ->
 
     lager:info("To fix, we remove index directories on each node and let them recreate/reindex"),
 
-    yokozuna_rt:remove_index_dirs(RandNodes, ?INDEX),
+    yokozuna_rt:remove_index_dirs(RandNodes, ?INDEX, [riak_kv, yokozuna]),
 
     yokozuna_rt:check_exists(Cluster, ?INDEX),
 

--- a/tests/yz_core_properties_create_unload.erl
+++ b/tests/yz_core_properties_create_unload.erl
@@ -60,15 +60,19 @@ confirm() ->
     lager:info("Create and set Index ~p for Bucket ~p~n", [?INDEX, ?BUCKET]),
     _ = riakc_pb_socket:create_search_index(Pid, ?INDEX),
     yokozuna_rt:wait_for_index(Cluster, ?INDEX),
+
     ok = rt:create_and_activate_bucket_type(Node,
                                             ?TYPE,
                                             [{search_index, ?INDEX}]),
+
+    rt:wait_until_bucket_type_visible(Cluster, ?TYPE),
+
     %% Write keys and wait for soft commit
     lager:info("Writing ~p keys", [KeyCount]),
     [ok = rt:pbc_write(Pid, ?BUCKET, Key, Key, "text/plain") || Key <- Keys],
     yokozuna_rt:commit(Cluster, ?INDEX),
 
-    verify_count(Pid, KeyCount),
+    yokozuna_rt:verify_num_found_query(Cluster, ?INDEX, KeyCount),
 
     test_core_props_removal(Cluster, RandNodes, KeyCount, Pid),
     test_remove_index_dirs(Cluster, RandNodes, KeyCount, Pid),
@@ -88,7 +92,7 @@ test_core_props_removal(Cluster, RandNodes, KeyCount, Pid) ->
     ok = rt:pbc_write(Pid, ?BUCKET, <<"foo">>, <<"foo">>, "text/plain"),
     yokozuna_rt:commit(Cluster, ?INDEX),
 
-    verify_count(Pid, KeyCount + 1).
+    yokozuna_rt:verify_num_found_query(Cluster, ?INDEX, KeyCount+1).
 
 test_remove_index_dirs(Cluster, RandNodes, KeyCount, Pid) ->
     lager:info("Remove index directories on each node and let them recreate/reindex"),
@@ -103,7 +107,7 @@ test_remove_index_dirs(Cluster, RandNodes, KeyCount, Pid) ->
     ok = rt:pbc_write(Pid, ?BUCKET, <<"food">>, <<"foody">>, "text/plain"),
     yokozuna_rt:commit(Cluster, ?INDEX),
 
-    verify_count(Pid, KeyCount + 2).
+    yokozuna_rt:verify_num_found_query(Cluster, ?INDEX, KeyCount+2).
 
 test_remove_segment_infos_and_rebuild(Cluster, RandNodes, KeyCount, Pid) ->
     lager:info("Remove segment info files in each index data dir"),
@@ -122,18 +126,7 @@ test_remove_segment_infos_and_rebuild(Cluster, RandNodes, KeyCount, Pid) ->
     ok = rt:pbc_write(Pid, ?BUCKET, <<"baz">>, <<"bar">>, "text/plain"),
     yokozuna_rt:commit(Cluster, ?INDEX),
 
-    verify_count(Pid, KeyCount + 3).
-
-%% @doc Verify search count.
-verify_count(Pid, ExpectedKeyCount) ->
-    case riakc_pb_socket:search(Pid, ?INDEX, <<"*:*">>) of
-        {ok ,{search_results, _, _, NumFound}} ->
-            lager:info("Check Count, Expected: ~p | Actual: ~p~n",
-                       [ExpectedKeyCount, NumFound]),
-            ?assertEqual(ExpectedKeyCount, NumFound);
-        E ->
-            lager:info("No results because ~p~n", [E])
-    end.
+    yokozuna_rt:verify_num_found_query(Cluster, ?INDEX, KeyCount+3).
 
 %% @doc Remove core properties file on nodes.
 remove_core_props(Nodes, IndexName) ->

--- a/tests/yz_extractors.erl
+++ b/tests/yz_extractors.erl
@@ -311,8 +311,8 @@ test_extractor_with_aae_expire(Cluster, Index, Bucket, Packet) ->
                      mochiweb_util:quote_plus(Key)),
 
     CT = ?EXTRACTOR_CT,
-    {ok, "204", _, _} = ibrowse:send_req(
-                          URL, [{"Content-Type", CT}], put, Packet),
+    {ok, "204", _, _} = yokozuna_rt:http(
+        put, URL, [{"Content-Type", CT}], Packet),
 
     yokozuna_rt:commit(Cluster, Index),
 
@@ -332,13 +332,13 @@ test_extractor_with_aae_expire(Cluster, Index, Bucket, Packet) ->
     yokozuna_rt:override_schema(APid, Cluster, Index, ?SCHEMANAME,
                                 ?TEST_SCHEMA_UPGRADE),
 
-    {ok, "200", RHeaders, _} = ibrowse:send_req(URL, [{"Content-Type", CT}], get,
+    {ok, "200", RHeaders, _} = yokozuna_rt:http(get, URL, [{"Content-Type", CT}],
                                                 [], []),
     VC = proplists:get_value("X-Riak-Vclock", RHeaders),
 
-    {ok, "204", _, _} = ibrowse:send_req(
-                          URL, [{"Content-Type", CT}, {"X-Riak-Vclock", VC}],
-                          put, Packet),
+    {ok, "204", _, _} = yokozuna_rt:http(
+                          put, URL, [{"Content-Type", CT}, {"X-Riak-Vclock", VC}],
+                          Packet),
     yokozuna_rt:commit(Cluster, Index),
 
     yokozuna_rt:search_expect(ANode, Index, <<"method">>,

--- a/tests/yz_extractors.erl
+++ b/tests/yz_extractors.erl
@@ -174,7 +174,6 @@ confirm() ->
 
     yokozuna_rt:write_data(Cluster, OldPid, ?INDEX1,
                            {?SCHEMANAME, ?TEST_SCHEMA}, ?BUCKET1, GenKeys),
-    yokozuna_rt:commit(Cluster, ?INDEX1),
 
     ok = rt:stop_tracing(),
 
@@ -317,7 +316,8 @@ test_extractor_with_aae_expire(Cluster, Index, Bucket, Packet) ->
 
     yokozuna_rt:commit(Cluster, Index),
 
-    yokozuna_rt:search_expect({Host, Port}, Index, <<"host">>,
+    ANode = rt:select_random(Cluster),
+    yokozuna_rt:search_expect(ANode, Index, <<"host">>,
                               <<"www*">>, 1),
 
     rpc:multicall(Cluster, riak_kv_entropy_manager, enable, []),
@@ -325,7 +325,7 @@ test_extractor_with_aae_expire(Cluster, Index, Bucket, Packet) ->
     yokozuna_rt:expire_trees(Cluster),
     yokozuna_rt:wait_for_full_exchange_round(Cluster, erlang:now()),
 
-    yokozuna_rt:search_expect({Host, Port}, Index, <<"host">>,
+    yokozuna_rt:search_expect(ANode, Index, <<"host">>,
                               <<"www*">>, 1),
 
     APid = rt:pbc(rt:select_random(Cluster)),
@@ -341,12 +341,12 @@ test_extractor_with_aae_expire(Cluster, Index, Bucket, Packet) ->
                           put, Packet),
     yokozuna_rt:commit(Cluster, Index),
 
-    yokozuna_rt:search_expect({Host, Port}, Index, <<"method">>,
+    yokozuna_rt:search_expect(ANode, Index, <<"method">>,
                               <<"GET">>, 1),
 
     yokozuna_rt:expire_trees(Cluster),
     yokozuna_rt:wait_for_full_exchange_round(Cluster, erlang:now()),
 
-    yokozuna_rt:search_expect({Host, Port}, Index, <<"method">>,
+    yokozuna_rt:search_expect(ANode, Index, <<"method">>,
                               <<"GET">>, 1),
     riakc_pb_socket:stop(APid).

--- a/tests/yz_handoff.erl
+++ b/tests/yz_handoff.erl
@@ -78,7 +78,6 @@ confirm() ->
 
     Pid = rt:pbc(Node2),
     yokozuna_rt:write_data(Nodes, Pid, ?INDEX, ?BUCKET, Keys),
-    yokozuna_rt:commit(Nodes, ?INDEX),
 
     %% Separate out shards for multiple runs
     [Shard1|Shards2Rest] = Shards,

--- a/tests/yz_handoff.erl
+++ b/tests/yz_handoff.erl
@@ -135,7 +135,7 @@ search_url(Host, Port, Index) ->
 verify_count(Url, ExpectedCount) ->
     AreUp =
         fun() ->
-                {ok, "200", _, DBody} = ibrowse:send_req(Url, [], get, []),
+                {ok, "200", _, DBody} = yokozuna_rt:http(get, Url, [], [], "", 60000),
                 FoundCount = get_count(DBody),
                 lager:info("FoundCount: ~b, ExpectedCount: ~b",
                            [FoundCount, ExpectedCount]),
@@ -149,7 +149,7 @@ get_count(Resp) ->
     kvc:path([<<"response">>, <<"numFound">>], Struct).
 
 get_keys_count(BucketURL) ->
-    {ok, "200", _, RBody} = ibrowse:send_req(BucketURL, [], get, []),
+    {ok, "200", _, RBody} = yokozuna_rt:http(get, BucketURL, [], []),
     Struct = mochijson2:decode(RBody),
     length(kvc:path([<<"keys">>], Struct)).
 
@@ -158,8 +158,8 @@ check_counts(Pid, InitKeyCount, BucketURL) ->
                                        Pid, ?INDEX, <<"*:*">>),
                         Resp#search_results.num_found
                   end || _ <- lists:seq(1,?TESTCYCLE)],
-    HTTPCounts = [begin {ok, "200", _, RBody} = ibrowse:send_req(
-                                                  BucketURL, [], get, []),
+    HTTPCounts = [begin {ok, "200", _, RBody} = yokozuna_rt:http(
+                                                  get, BucketURL, [], []),
                         Struct = mochijson2:decode(RBody),
                         length(kvc:path([<<"keys">>], Struct))
                   end || _ <- lists:seq(1,?TESTCYCLE)],

--- a/tests/yz_schema_change_reset.erl
+++ b/tests/yz_schema_change_reset.erl
@@ -145,7 +145,6 @@ confirm() ->
     yokozuna_rt:write_data(Cluster, Pid, ?INDEX,
                            {?SCHEMANAME, ?TEST_SCHEMA},
                            ?BUCKET1, GenKeys),
-    yokozuna_rt:commit(Cluster, ?INDEX),
     lager:info("Create and activate map-based bucket type ~s and tie it to search_index ~s",
                [?TYPE, ?INDEX]),
     rt:create_and_activate_bucket_type(Node1, ?TYPE, [{datatype, map},
@@ -246,8 +245,8 @@ confirm() ->
 
     yokozuna_rt:verify_num_found_query(Cluster, ?INDEX, KeyCount + 5),
 
-    HP = rt:select_random(yokozuna_rt:host_entries(rt:connection_info(Cluster))),
-    yokozuna_rt:search_expect(HP, ?INDEX, <<"age">>, <<"*">>, 3),
+    ANode = rt:select_random(Cluster),
+    yokozuna_rt:search_expect(ANode, ?INDEX, <<"age">>, <<"*">>, 3),
 
     lager:info("Re-Put because AAE won't find a diff even though the types
                have changed, as it only compares based on bkey currently.


### PR DESCRIPTION
^^ @JeetKunDoug @fadushin changes the search_expect 5/6/7 interface to handle nodes and call a wait_for instead of passing in a specific {H, P}. 

I did it in a bit of a rush, but let me know what's needed.  Please test through. Related to https://github.com/basho/yokozuna/pull/643. 