### PR TITLE
Add ability to search in log files for a given node

### DIFF
--- a/src/rt.erl
+++ b/src/rt.erl
@@ -1819,6 +1819,13 @@ setup_harness(Test, Args) ->
 get_node_logs() ->
     ?HARNESS:get_node_logs().
 
+%% @doc Performs a search against the log files on `Node' and returns all
+%% matching lines.
+-spec search_logs(node(), Pattern::iodata()) ->
+    [{Path::string(), LineNum::pos_integer(), MatchingLine::string()}].
+search_logs(Node, Pattern) ->
+    ?HARNESS:search_logs(Node, Pattern).
+
 check_ibrowse() ->
     try sys:get_status(ibrowse) of
         {status, _Pid, {module, gen_server} ,_} -> ok
@@ -1965,6 +1972,17 @@ expect_in_log(Node, Pattern) ->
         ok ->
             true;
         _ ->
+            false
+    end.
+
+%% @doc Returns `true' if Pattern is _not_ found in the logs for `Node',
+%% `false' if it _is_ found.
+-spec expect_not_in_logs(Node::node(), Pattern::iodata()) -> boolean().
+expect_not_in_logs(Node, Pattern) ->
+    case search_logs(Node, Pattern) of
+        [] ->
+            true;
+        _Matches ->
             false
     end.
 

--- a/src/rtdev.erl
+++ b/src/rtdev.erl
@@ -765,6 +765,46 @@ get_node_logs() ->
           {lists:nthtail(RootLen, Filename), Port}
       end || Filename <- filelib:wildcard(Root ++ "/*/dev/dev*/log/*") ].
 
+%% @doc Performs a search against the log files on `Node' and returns all
+%% matching lines.
+-spec search_logs(node(), Pattern::iodata()) ->
+    [{Path::string(), LineNum::pos_integer(), Match::string()}].
+search_logs(Node, Pattern) ->
+    Root = filename:absname(proplists:get_value(root, ?PATH)),
+    Wildcard = Root ++ "/*/dev/" ++ node_name(Node) ++ "/log/*",
+    LogFiles = filelib:wildcard(Wildcard),
+    AllMatches = rt:pmap(fun(File) ->
+                                 search_file(File, Pattern)
+                         end,
+                         LogFiles),
+    lists:flatten(AllMatches).
+
+search_file(File, Pattern) ->
+    {ok, Device} = file:open(File, [read]),
+    Matches = search_file(Device, File, Pattern, 1, []),
+    lists:reverse(Matches).
+
+search_file(Device, File, Pattern, LineNum, Accum) ->
+    case io:get_line(Device, "") of
+        eof ->
+            file:close(Device),
+            Accum;
+        Line ->
+            NewAccum = case re:run(Line, Pattern) of
+                           {match, _Captured} ->
+                               Match = {File, LineNum, Line},
+                               [Match|Accum];
+                           nomatch ->
+                               Accum
+                       end,
+            search_file(Device, File, Pattern, LineNum + 1, NewAccum)
+    end.
+
+
+-spec node_name(node()) -> string().
+node_name(Node) ->
+    lists:takewhile(fun(C) -> C /= $@ end, atom_to_list(Node)).
+
 -ifdef(TEST).
 
 release_versions_test() ->


### PR DESCRIPTION
Add a new `search_logs/2` function in `rt` and `rtdev` modules, allowing for searching the log files of a  given node for a regular expression.
