### PR TITLE
ts_cluster_comprehensive: don't test overwriting TS data (because w1c)

### DIFF
--- a/tests/ts_cluster_comprehensive.erl
+++ b/tests/ts_cluster_comprehensive.erl
@@ -68,8 +68,7 @@ confirm_all_from_node(Node, Data, PvalP1, PvalP2) ->
     C = rt:pbc(Node),
 
     %% 1. put some data
-    ok = confirm_put(C, doctor_data(Data)),
-    ok = confirm_overwrite(C, Data),
+    ok = confirm_put(C, Data),
 
     %% 2. get a single key
     ok = confirm_get(C, lists:nth(12, Data)),
@@ -120,9 +119,6 @@ make_data(PvalP1, PvalP2) ->
         end,
         [], lists:seq(?LIFESPAN, 1, -1))).
 
-doctor_data(Data) ->
-    [[A, B, C, D + 0.42] || [A, B, C, D] <- Data].
-
 confirm_put(C, Data) ->
     ResFail = riakc_ts:put(C, <<"no-bucket-like-this">>, Data),
     io:format("Nothing put in a non-existent bucket: ~p\n", [ResFail]),
@@ -132,12 +128,6 @@ confirm_put(C, Data) ->
     %% (for future tests of batch put writing order)
     Res = riakc_ts:put(C, ?BUCKET, Data),
     io:format("Put ~b records: ~p\n", [length(Data), Res]),
-    ?assertEqual(ok, Res),
-    ok.
-
-confirm_overwrite(C, Data) ->
-    Res = riakc_ts:put(C, ?BUCKET, Data),
-    io:format("Overwrote ~b records: ~p\n", [length(Data), Res]),
     ?assertEqual(ok, Res),
     ok.
 


### PR DESCRIPTION
Because TS data are write-once, and because overwriting the data will result in, eventually, a random pick from the siblings for a subsequent get, the existing test of the overwriting put in ts_cluster_comprehensive, makes little sense. I am now correcting my assumption of long ago that it should always work. It leaves one wondering why it never failed.