### PR TITLE
Change verify_build_cluster reads to use r=3

### DIFF
--- a/tests/verify_build_cluster.erl
+++ b/tests/verify_build_cluster.erl
@@ -103,5 +103,5 @@ wait_and_validate(RingNodes, UpNodes) ->
     [rt:wait_until_owners_according_to(Node, RingNodes) || Node <- UpNodes],
     [rt:wait_for_service(Node, riak_kv) || Node <- UpNodes],
     lager:info("Verify that you got much data... (this is how we do it)"),
-    ?assertEqual([], rt:systest_read(hd(UpNodes), 0, 1000, <<"verify_build_cluster">>, 2)),
+    ?assertEqual([], rt:systest_read(hd(UpNodes), 0, 1000, <<"verify_build_cluster">>, 3)),
     done.


### PR DESCRIPTION
We're hypothesizing that this will fix some intermittent errors we're
seeing in this test, where we get several notfound results after taking
down node 2. If two replicas end up on node 2 after we kill node 1, then
taking down node 2 would leave only one replica left, so an r=2 read
could return notfound. This matches up with our findings that subsequent
reads return the correct data (suggesting that the first read attempt is
triggering read repair).
