### PR TITLE
Fix the expected sub string in basic_command_line getpid test

### DIFF
--- a/tests/basic_command_line.erl
+++ b/tests/basic_command_line.erl
@@ -166,5 +166,7 @@ getpid_up_test(Node) ->
 getpid_down_test(Node) ->
     lager:info("Test riak getpid fails on ~s", [Node]),
     {ok, PidOut} = rt:riak(Node, ["getpid"]),
-    ?assert(rt:str_mult(PidOut, ?PING_FAILURE_OUTPUT)),
+    %% note that the error message is slightly different to the
+    %% other commands
+    ?assert(rt:str(PidOut, "Node is not running!")),
     ok.


### PR DESCRIPTION
The error message is different for the `getpid` command, and the test was using `rt:str_mult/2` but not passing a list of strings.

Fixed by calling `rt:str/2` without the correct error message sub string.