### PR TITLE
Misconfigured test

### DIFF
--- a/tests/ts_cluster_select_pass_2.erl
+++ b/tests/ts_cluster_select_pass_2.erl
@@ -34,7 +34,7 @@ confirm() ->
     Qry  = ts_util:get_valid_qry_spanning_quanta(),
     Expected = {ok, {
         ts_util:get_cols(),
-        ts_util:exclusive_result_from_data(Data, 2, 9)}},
+        ts_util:exclusive_result_from_data(Data, 1, 10)}},
     Got = ts_util:ts_query(
             ts_util:cluster_and_connect(multiple), normal, DDL, Data, Qry),
     ?assertEqual(Expected, Got),


### PR DESCRIPTION
A set of 10 elements spanning multiple quanta is written to database
Then a query *inclusive* of the two end records was generated, but
the expected database was *exclusive* of the limits - causing it to fail