### PR TITLE
dependency cleanup

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -13,10 +13,10 @@
 {deps, [
         {lager, ".*", {git, "git://github.com/basho/lager", {tag, "2.2.3"}}},
         {getopt, ".*", {git, "git://github.com/jcomellas/getopt", {tag, "v0.4"}}},
-        {meck, ".*", {git, "git://github.com/basho/meck.git", {tag, "0.8.2"}}},
+        {meck, "0.8.2", {git, "git://github.com/basho/meck.git", {tag, "0.8.2"}}},
         {mapred_verify, ".*", {git, "git://github.com/basho/mapred_verify", {branch, "master"}}},
-        {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {tag, "2.1.2"}}},
-        {riakhttpc, ".*", {git, "git://github.com/basho/riak-erlang-http-client", {branch, "master"}}},
+        {riakc, "2.1.2", {git, "git://github.com/basho/riak-erlang-client", {tag, "2.1.2"}}},
+        {riakhttpc, ".*", {git, "git://github.com/basho/riak-erlang-http-client", {tag, "2.1.2"}}},
         {kvc, "1.3.0", {git, "https://github.com/etrepum/kvc", {tag, "v1.3.0"}}},
         {druuid, ".*", {git, "git://github.com/kellymclaughlin/druuid.git", {tag, "0.2"}}}
        ]}.


### PR DESCRIPTION
This PR pins dependencies on meck, riak erlanf client, and riak erlang http client to tagged dependencies, to reduce the chances that tests on this branch will fail because of floating dependencies.