### PR TITLE
RTS-1005: Fix tests for additional DESCRIBE columns

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -17,8 +17,8 @@
         {getopt,        ".*",   {git, "git://github.com/jcomellas/getopt",              {tag, "v0.4"}}},
         {meck,          ".*",   {git, "git://github.com/basho/meck.git",                {tag, "0.8.2"}}},
         {mapred_verify, ".*",   {git, "git://github.com/basho/mapred_verify",           {branch, "master"}}},
-        {riakc,         ".*",   {git, "git://github.com/basho/riak-erlang-client",      {branch, "master"}}},
-        {riakhttpc,     ".*",   {git, "git://github.com/basho/riak-erlang-http-client", {branch, "riak_ts-develop"}}},
+        {riakc,         ".*",   {git, "git://github.com/basho/riak-erlang-client",      {branch, "develop"}}},
+        {riakhttpc,     ".*",   {git, "git://github.com/basho/riak-erlang-http-client", {branch, "develop"}}},
         {kvc,          "1.3.0", {git, "https://github.com/etrepum/kvc",                 {tag, "v1.3.0"}}},
         {druuid,       ".*",    {git, "git://github.com/kellymclaughlin/druuid.git",    {tag, "0.2"}}},
         {tdiff,         ".*",   {git, "git://github.com/tomas-abrahamsson/tdiff",       {tag, "0.1"}}}

--- a/tests/ts_cluster_create_table_via_sql_SUITE.erl
+++ b/tests/ts_cluster_create_table_via_sql_SUITE.erl
@@ -127,12 +127,12 @@ ddl_common() ->
     ts_util:get_ddl(small).
 
 table_described() ->
-    {ok, {[<<"Column">>,<<"Type">>,<<"Is Null">>,<<"Primary Key">>, <<"Local Key">>],
-     [{<<"myfamily">>,   <<"varchar">>,   false,  1,  1},
-      {<<"myseries">>,   <<"varchar">>,   false,  2,  2},
-      {<<"time">>,       <<"timestamp">>, false,  3,  3},
-      {<<"weather">>,    <<"varchar">>,   false, [], []},
-      {<<"temperature">>,<<"double">>,    true,  [], []}]}}.
+    {ok, {[<<"Column">>,<<"Type">>,<<"Is Null">>,<<"Primary Key">>, <<"Local Key">>, <<"Interval">>, <<"Unit">>],
+     [{<<"myfamily">>,   <<"varchar">>,   false,  1,  1, [], []},
+      {<<"myseries">>,   <<"varchar">>,   false,  2,  2, [], []},
+      {<<"time">>,       <<"timestamp">>, false,  3,  3, 15, <<"m">>},
+      {<<"weather">>,    <<"varchar">>,   false, [], [], [], []},
+      {<<"temperature">>,<<"double">>,    true,  [], [], [], []}]}}.
 
 enquote_varchar(P) when is_binary(P) ->
     re:replace(P, "'", "''", [global, {return, binary}]);

--- a/tests/ts_cluster_riak_shell_basic_sql.erl
+++ b/tests/ts_cluster_riak_shell_basic_sql.erl
@@ -49,15 +49,16 @@ create_table_test(Pid) ->
     State = riak_shell_test_util:shell_init(),
     lager:info("~n~nStart running the command set-------------------------", []),
     CreateTable = lists:flatten(io_lib:format("~s;", [ts_util:get_ddl(small)])),
-    Describe = io_lib:format("+-----------+---------+-------+-----------+---------+~n"
-    "|  Column   |  Type   |Is Null|Primary Key|Local Key|~n"
-    "+-----------+---------+-------+-----------+---------+~n"
-    "| myfamily  | varchar | false |     1     |    1    |~n"
-    "| myseries  | varchar | false |     2     |    2    |~n"
-    "|   time    |timestamp| false |     3     |    3    |~n"
-    "|  weather  | varchar | false |           |         |~n"
-    "|temperature| double  | true  |           |         |~n"
-    "+-----------+---------+-------+-----------+---------+", []),
+    Describe = io_lib:format(
+        "+-----------+---------+-------+-----------+---------+--------+----+~n"
+        "|  Column   |  Type   |Is Null|Primary Key|Local Key|Interval|Unit|~n"
+        "+-----------+---------+-------+-----------+---------+--------+----+~n"
+        "| myfamily  | varchar | false |     1     |    1    |        |    |~n"
+        "| myseries  | varchar | false |     2     |    2    |        |    |~n"
+        "|   time    |timestamp| false |     3     |    3    |   15   | m  |~n"
+        "|  weather  | varchar | false |           |         |        |    |~n"
+        "|temperature| double  | true  |           |         |        |    |~n"
+        "+-----------+---------+-------+-----------+---------+--------+----+", []),
     Cmds = [
             %% 'connection prompt on' means you need to do unicode printing and stuff
             {run,

--- a/tests/ts_simple_describe_table.erl
+++ b/tests/ts_simple_describe_table.erl
@@ -36,11 +36,11 @@ confirm() ->
     ts_util:create_and_activate_bucket_type(ClusterConn, DDL),
     Got = ts_util:single_query(Conn, Qry),
     Expected =
-        {ok, {[<<"Column">>,<<"Type">>,<<"Is Null">>,<<"Primary Key">>, <<"Local Key">>],
-        [{<<"myfamily">>,  <<"varchar">>,   false,  1,  1},
-        {<<"myseries">>,   <<"varchar">>,   false,  2,  2},
-        {<<"time">>,       <<"timestamp">>, false,  3,  3},
-        {<<"weather">>,    <<"varchar">>,   false, [], []},
-        {<<"temperature">>,<<"double">>,    true,  [], []}]}},
+        {ok, {[<<"Column">>,<<"Type">>,<<"Is Null">>,<<"Primary Key">>, <<"Local Key">>, <<"Interval">>, <<"Unit">>],
+        [{<<"myfamily">>,  <<"varchar">>,   false,  1,  1, [], []},
+        {<<"myseries">>,   <<"varchar">>,   false,  2,  2, [], []},
+        {<<"time">>,       <<"timestamp">>, false,  3,  3, 15, <<"m">>},
+        {<<"weather">>,    <<"varchar">>,   false, [], [], [], []},
+        {<<"temperature">>,<<"double">>,    true,  [], [], [], []}]}},
     ?assertEqual(Expected, Got),
     pass.


### PR DESCRIPTION
Adjust the tests to accommodate https://github.com/basho/riak_kv/pull/1438.  The test `ts_simple_http_api_SUITE` also does a `DESCRIBE` but compares the HTTP output to the TTB output so does not require a change.  The other tests just need the extra columns.

Also floating the Erlang client dependencies to `develop` since KV version has now merged with TS version.