### PR TITLE
r-e-c now expects good unicode, so use "~ts" in Queries to accommodate

### DIFF
--- a/tests/ts_cluster_comprehensive.erl
+++ b/tests/ts_cluster_comprehensive.erl
@@ -167,14 +167,14 @@ confirm_select(C, PvalP1, PvalP2, Options) ->
         lists:flatten(
           io_lib:format(
             "select score, pooter2 from ~s where"
-            "     ~s = '~s'"
-            " and ~s = '~s'"
+            "     ~s = '~ts'"
+            " and ~s = '~ts'"
             " and ~s > ~b and ~s < ~b",
            [?BUCKET,
             ?PKEY_P1, PvalP1,
             ?PKEY_P2, PvalP2,
             ?PKEY_P3, ?TIMEBASE + 10, ?PKEY_P3, ?TIMEBASE + 20])),
-    io:format("Running query: ~p\n", [Query]),
+    io:format("Running query: ~ts\n", [Query]),
     {ok, {_Columns, Rows}} = riakc_ts:query(C, Query, Options),
     io:format("Got ~b rows back\n~p\n", [length(Rows), Rows]),
     ?assertEqual(10 - 1 - 1, length(Rows)),

--- a/tests/ts_util.erl
+++ b/tests/ts_util.erl
@@ -140,7 +140,7 @@ ts_insert(Conn, Table, Columns, Data) ->
     TermFn = fun insert_term_format/2,
     ColClause = string:strip(lists:foldl(ColFn, [], Columns), right, $,),
     ValClause = string:strip(lists:foldl(TermFn, [], tuple_to_list(Data)), right, $,),
-    SQL = flat_format("INSERT INTO ~s (~s) VALUES (~s)",
+    SQL = flat_format("INSERT INTO ~s (~s) VALUES (~ts)",
                       [Table, ColClause, ValClause]),
     lager:info("~ts", [SQL]),
     Got = riakc_ts:query(Conn, SQL),
@@ -150,7 +150,7 @@ ts_insert(Conn, Table, Columns, Data) ->
 ts_insert_no_columns(Conn, Table, Data) ->
     TermFn = fun insert_term_format/2,
     ValClause = string:strip(lists:foldl(TermFn, [], tuple_to_list(Data)), right, $,),
-    SQL = flat_format("INSERT INTO ~s VALUES (~s)",
+    SQL = flat_format("INSERT INTO ~s VALUES (~ts)",
         [Table, ValClause]),
     lager:info("~ts", [SQL]),
     Got = riakc_ts:query(Conn, SQL),
@@ -505,7 +505,8 @@ get_integer() ->
 get_s(0, Acc) ->
     Acc;
 get_s(N, Acc) when is_integer(N) andalso N > 0 ->
-    get_s(N - 1, [random:uniform(255) | Acc]).
+    %% make it plain ASCII
+    get_s(N - 1, [crypto:rand_uniform($a, $z) | Acc]).
 
 get_timestamp() ->
     random:uniform(?MAXTIMESTAMP).


### PR DESCRIPTION
This fixes regressions in ts_simple_insert (specifically, by constraining generated varchars to `$a..$z`), and in ts_cluster_unicode.