### PR TITLE
RTS-1050: Add tests for EXPLAIN command

### DIFF
--- a/priv/riak_shell/riak_shell_regression1.log
+++ b/priv/riak_shell/riak_shell_regression1.log
@@ -24,6 +24,19 @@
 |GeoCheckin|
 +----------+
 "}}.
+{{command, "EXPLAIN SELECT * FROM GeoCheckin WHERE myfamily = 'family1' AND myseries = 'series1' AND time >= 2 AND time <= 7000000 AND weather='fair';\n"}, {result, "+-----+-------------------------------------+------------+-------------------------------------+-----------+----------+
+|Subqu|        Range Scan Start Key         |Is Start Inc|         Range Scan End Key          |Is End Incl|  Filter  |
++-----+-------------------------------------+------------+-------------------------------------+-----------+----------+
+|  1  |myfamily = 'family1', myseries = 'ser|   false    |myfamily = 'family1', myseries = 'ser|   false   |weather = |
+|  2  |myfamily = 'family1', myseries = 'ser|   false    |myfamily = 'family1', myseries = 'ser|   false   |weather = |
+|  3  |myfamily = 'family1', myseries = 'ser|   false    |myfamily = 'family1', myseries = 'ser|   false   |weather = |
+|  4  |myfamily = 'family1', myseries = 'ser|   false    |myfamily = 'family1', myseries = 'ser|   false   |weather = |
+|  5  |myfamily = 'family1', myseries = 'ser|   false    |myfamily = 'family1', myseries = 'ser|   false   |weather = |
+|  6  |myfamily = 'family1', myseries = 'ser|   false    |myfamily = 'family1', myseries = 'ser|   false   |weather = |
+|  7  |myfamily = 'family1', myseries = 'ser|   false    |myfamily = 'family1', myseries = 'ser|   false   |weather = |
+|  8  |myfamily = 'family1', myseries = 'ser|   false    |myfamily = 'family1', myseries = 'ser|   false   |weather = |
++-----+-------------------------------------+------------+-------------------------------------+-----------+----------+
+"}}.
 {{command, "insert into GeoCheckin (myfamily, myseries, time, weather, temperature) values ('family1','series1',1,'snow',25.2);\n"}, {result, ""}}.
 {{command, "insert into GeoCheckin (myfamily, myseries, time, weather, temperature) values ('family1','series1',2,'rain',24.5);\n"}, {result, ""}}.
 {{command, "insert into GeoCheckin (myfamily, myseries, time, weather, temperature) values ('family1','series1',3,'rain',23.0);\n"}, {result, ""}}.

--- a/priv/riak_shell/riak_shell_regression1.log
+++ b/priv/riak_shell/riak_shell_regression1.log
@@ -24,18 +24,18 @@
 |GeoCheckin|
 +----------+
 "}}.
-{{command, "EXPLAIN SELECT * FROM GeoCheckin WHERE myfamily = 'family1' AND myseries = 'series1' AND time >= 2 AND time <= 7000000 AND weather='fair';\n"}, {result, "+-----+-------------------------------------+------------+-------------------------------------+-----------+----------+
-|Subqu|        Range Scan Start Key         |Is Start Inc|         Range Scan End Key          |Is End Incl|  Filter  |
-+-----+-------------------------------------+------------+-------------------------------------+-----------+----------+
-|  1  |myfamily = 'family1', myseries = 'ser|   false    |myfamily = 'family1', myseries = 'ser|   false   |weather = |
-|  2  |myfamily = 'family1', myseries = 'ser|   false    |myfamily = 'family1', myseries = 'ser|   false   |weather = |
-|  3  |myfamily = 'family1', myseries = 'ser|   false    |myfamily = 'family1', myseries = 'ser|   false   |weather = |
-|  4  |myfamily = 'family1', myseries = 'ser|   false    |myfamily = 'family1', myseries = 'ser|   false   |weather = |
-|  5  |myfamily = 'family1', myseries = 'ser|   false    |myfamily = 'family1', myseries = 'ser|   false   |weather = |
-|  6  |myfamily = 'family1', myseries = 'ser|   false    |myfamily = 'family1', myseries = 'ser|   false   |weather = |
-|  7  |myfamily = 'family1', myseries = 'ser|   false    |myfamily = 'family1', myseries = 'ser|   false   |weather = |
-|  8  |myfamily = 'family1', myseries = 'ser|   false    |myfamily = 'family1', myseries = 'ser|   false   |weather = |
-+-----+-------------------------------------+------------+-------------------------------------+-----------+----------+
+{{command, "EXPLAIN SELECT * FROM GeoCheckin WHERE myfamily = 'family1' AND myseries = 'series1' AND time >= 2 AND time <= 7000000 AND weather='fair';"}, {result, "+-----+------------------------------------+------------+-------------------------------------+-----------+-----------+
+|Subqu|        Range Scan Start Key        |Is Start Inc|         Range Scan End Key          |Is End Incl|  Filter   |
++-----+------------------------------------+------------+-------------------------------------+-----------+-----------+
+|  1  |myfamily = 'family1', myseries = 'se|   false    |myfamily = 'family1', myseries = 'ser|   false   |(weather = |
+|  2  |myfamily = 'family1', myseries = 'se|   false    |myfamily = 'family1', myseries = 'ser|   false   |(weather = |
+|  3  |myfamily = 'family1', myseries = 'se|   false    |myfamily = 'family1', myseries = 'ser|   false   |(weather = |
+|  4  |myfamily = 'family1', myseries = 'se|   false    |myfamily = 'family1', myseries = 'ser|   false   |(weather = |
+|  5  |myfamily = 'family1', myseries = 'se|   false    |myfamily = 'family1', myseries = 'ser|   false   |(weather = |
+|  6  |myfamily = 'family1', myseries = 'se|   false    |myfamily = 'family1', myseries = 'ser|   false   |(weather = |
+|  7  |myfamily = 'family1', myseries = 'se|   false    |myfamily = 'family1', myseries = 'ser|   false   |(weather = |
+|  8  |myfamily = 'family1', myseries = 'se|   false    |myfamily = 'family1', myseries = 'ser|   false   |(weather = |
++-----+------------------------------------+------------+-------------------------------------+-----------+-----------+
 "}}.
 {{command, "EXPLAIN SELECT * FROM GeoCheckin;\n"}, {result, "Error (1001): The query must have a where clause."}}.
 {{command, "insert into GeoCheckin (myfamily, myseries, time, weather, temperature) values ('family1','series1',1,'snow',25.2);\n"}, {result, ""}}.

--- a/priv/riak_shell/riak_shell_regression1.log
+++ b/priv/riak_shell/riak_shell_regression1.log
@@ -37,6 +37,7 @@
 |  8  |myfamily = 'family1', myseries = 'ser|   false    |myfamily = 'family1', myseries = 'ser|   false   |weather = |
 +-----+-------------------------------------+------------+-------------------------------------+-----------+----------+
 "}}.
+{{command, "EXPLAIN SELECT * FROM GeoCheckin;\n"}, {result, "Error (1001): The query must have a where clause."}}.
 {{command, "insert into GeoCheckin (myfamily, myseries, time, weather, temperature) values ('family1','series1',1,'snow',25.2);\n"}, {result, ""}}.
 {{command, "insert into GeoCheckin (myfamily, myseries, time, weather, temperature) values ('family1','series1',2,'rain',24.5);\n"}, {result, ""}}.
 {{command, "insert into GeoCheckin (myfamily, myseries, time, weather, temperature) values ('family1','series1',3,'rain',23.0);\n"}, {result, ""}}.

--- a/tests/ts_simple_explain_query.erl
+++ b/tests/ts_simple_explain_query.erl
@@ -34,7 +34,7 @@ confirm() ->
     ts_util:create_and_activate_bucket_type(ClusterConn, DDL, "MyTable"),
     Qry = "EXPLAIN SELECT myint, myfloat, myoptional FROM MyTable WHERE "
         "myfamily='wingo' AND myseries='dingo' AND time > 0 AND time < 2000000 "
-        "AND (mybool=true OR myvarchar='banana')",
+        "AND ((mybool=true AND myvarchar='banana') OR (myoptional=7))",
 
     Got = ts_util:single_query(Conn, Qry),
     Expected =
@@ -47,18 +47,18 @@ confirm() ->
                 false,
                 "myfamily = 'wingo', myseries = 'dingo', time = 900000",
                 false,
-                "mybool = true OR myvarchar = 'banana'"},
-            {2,
+                "((myoptional = 7) OR ((mybool = true) AND (myvarchar = 'banana')))"},
+             {2,
                 "myfamily = 'wingo', myseries = 'dingo', time = 900000",
                 false,
                 "myfamily = 'wingo', myseries = 'dingo', time = 1800000",
                 false,
-                "mybool = true OR myvarchar = 'banana'"},
-            {3,
+                "((myoptional = 7) OR ((mybool = true) AND (myvarchar = 'banana')))"},
+             {3,
                 "myfamily = 'wingo', myseries = 'dingo', time = 1800000",
                 false,
                 "myfamily = 'wingo', myseries = 'dingo', time = 2000000",
                 false,
-                "mybool = true OR myvarchar = 'banana'"}]}},
+                "((myoptional = 7) OR ((mybool = true) AND (myvarchar = 'banana')))"}]}},
     ?assertEqual(Expected, Got),
     pass.

--- a/tests/ts_simple_explain_query.erl
+++ b/tests/ts_simple_explain_query.erl
@@ -34,7 +34,7 @@ confirm() ->
     ts_util:create_and_activate_bucket_type(ClusterConn, DDL, "MyTable"),
     Qry = "EXPLAIN SELECT myint, myfloat, myoptional FROM MyTable WHERE "
         "myfamily='wingo' AND myseries='dingo' AND time > 0 AND time < 2000000 "
-        "AND mybool=true AND myvarchar='banana'",
+        "AND (mybool=true OR myvarchar='banana')",
 
     Got = ts_util:single_query(Conn, Qry),
     Expected =
@@ -47,18 +47,18 @@ confirm() ->
                 false,
                 "myfamily = 'wingo', myseries = 'dingo', time = 900000",
                 false,
-                "mybool = true AND myvarchar = 'banana'"},
+                "mybool = true OR myvarchar = 'banana'"},
             {2,
                 "myfamily = 'wingo', myseries = 'dingo', time = 900000",
                 false,
                 "myfamily = 'wingo', myseries = 'dingo', time = 1800000",
                 false,
-                "mybool = true AND myvarchar = 'banana'"},
+                "mybool = true OR myvarchar = 'banana'"},
             {3,
                 "myfamily = 'wingo', myseries = 'dingo', time = 1800000",
                 false,
                 "myfamily = 'wingo', myseries = 'dingo', time = 2000000",
                 false,
-                "mybool = true AND myvarchar = 'banana'"}]}},
+                "mybool = true OR myvarchar = 'banana'"}]}},
     ?assertEqual(Expected, Got),
     pass.

--- a/tests/ts_simple_explain_query.erl
+++ b/tests/ts_simple_explain_query.erl
@@ -1,0 +1,64 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2016 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(ts_simple_explain_query).
+
+-behavior(riak_test).
+
+-export([confirm/0]).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% Test basic table description
+
+confirm() ->
+    DDL = ts_util:get_ddl(big, "MyTable"),
+    ClusterConn = {_Cluster, Conn} = ts_util:cluster_and_connect(single),
+    ts_util:create_and_activate_bucket_type(ClusterConn, DDL, "MyTable"),
+    Qry = "EXPLAIN SELECT myint, myfloat, myoptional FROM MyTable WHERE "
+        "myfamily='wingo' AND myseries='dingo' AND time > 0 AND time < 2000000 "
+        "AND mybool=true AND myvarchar='banana'",
+
+    Got = ts_util:single_query(Conn, Qry),
+    Expected =
+        {ok,{[<<"Subquery">>,<<"Range Scan Start Key">>,
+            <<"Is Start Inclusive?">>,
+            <<"Range Scan End Key">>,
+            <<"Is End Inclusive?">>,<<"Filter">>],
+            [{1,
+                "myfamily = 'wingo', myseries = 'dingo', time = 1",
+                false,
+                "myfamily = 'wingo', myseries = 'dingo', time = 900000",
+                false,
+                "mybool = true AND myvarchar = 'banana'"},
+            {2,
+                "myfamily = 'wingo', myseries = 'dingo', time = 900000",
+                false,
+                "myfamily = 'wingo', myseries = 'dingo', time = 1800000",
+                false,
+                "mybool = true AND myvarchar = 'banana'"},
+            {3,
+                "myfamily = 'wingo', myseries = 'dingo', time = 1800000",
+                false,
+                "myfamily = 'wingo', myseries = 'dingo', time = 2000000",
+                false,
+                "mybool = true AND myvarchar = 'banana'"}]}},
+    ?assertEqual(Expected, Got),
+    pass.

--- a/tests/ts_util.erl
+++ b/tests/ts_util.erl
@@ -315,6 +315,7 @@ get_valid_big_data(N) ->
         N + 0.1,
         get_bool(X),
         N + 100000,
+        get_varchar(),
         get_optional(X, X)
     } || X <- Times].
 
@@ -415,6 +416,7 @@ get_ddl(big, Table) ->
     " myfloat     double      not null,"
     " mybool      boolean     not null,"
     " mytimestamp timestamp   not null,"
+    " myvarchar   varchar     not null,"
     " myoptional  sint64,"
     " PRIMARY KEY ((myfamily, myseries, quantum(time, 15, 'm')),"
     " myfamily, myseries, time))";


### PR DESCRIPTION
I fear that the `riak_shell` test may fail because I think it truncates the output based on the size of the window.  Maybe I could standardize to 80 columns? Not sure how GiddyUp runs it...