### PR TITLE
Added support for specifying an upgrade callback function, which can …

### DIFF
--- a/src/rt.erl
+++ b/src/rt.erl
@@ -143,6 +143,7 @@
          update_app_config/2,
          upgrade/2,
          upgrade/3,
+         upgrade/4,
          versions/0,
          wait_for_any_webmachine_route/2,
          wait_for_cluster_service/2,
@@ -389,12 +390,25 @@ stop_and_wait(Node) ->
 
 %% @doc Upgrade a Riak `Node' to the specified `NewVersion'.
 upgrade(Node, NewVersion) ->
-    ?HARNESS:upgrade(Node, NewVersion).
+    upgrade(Node, NewVersion, fun no_op/1).
+
+%% @doc Upgrade a Riak `Node' to the specified `NewVersion'.
+%% Upgrade Callback will be called after the node is stopped but before
+%% the upgraded node is started.
+upgrade(Node, NewVersion, UpgradeCallback) when is_function(UpgradeCallback) ->
+    ?HARNESS:upgrade(Node, NewVersion, UpgradeCallback);
 
 %% @doc Upgrade a Riak `Node' to the specified `NewVersion' and update
 %% the config based on entries in `Config'.
 upgrade(Node, NewVersion, Config) ->
-    ?HARNESS:upgrade(Node, NewVersion, Config).
+    upgrade(Node, NewVersion, Config, fun no_op/1).
+
+%% @doc Upgrade a Riak `Node' to the specified `NewVersion' and update
+%% the config based on entries in `Config'.
+%% Upgrade Callback will be called after the node is stopped but before
+%% the upgraded node is started.
+upgrade(Node, NewVersion, Config, UpgradeCallback) ->
+    ?HARNESS:upgrade(Node, NewVersion, Config, UpgradeCallback).
 
 %% @doc Upgrade a Riak node to a specific version using the alternate
 %%      leave/upgrade/rejoin approach
@@ -2169,6 +2183,10 @@ assert_supported(Capabilities, Capability, Value) ->
                           proplists:get_value('$supported', Capabilities))),
     ok.
 
+
+-spec no_op(term()) -> ok.
+no_op(_Params) ->
+    ok.
 
 -ifdef(TEST).
 

--- a/src/rtdev.erl
+++ b/src/rtdev.erl
@@ -124,10 +124,10 @@ relpath(root, Path) ->
 relpath(_, _) ->
     throw("Version requested but only one path provided").
 
-upgrade(Node, NewVersion) ->
-    upgrade(Node, NewVersion, same).
+upgrade(Node, NewVersion, UpgradeCallback) when is_function(UpgradeCallback) ->
+    upgrade(Node, NewVersion, same, UpgradeCallback).
 
-upgrade(Node, NewVersion, Config) ->
+upgrade(Node, NewVersion, Config, UpgradeCallback) ->
     N = node_id(Node),
     Version = node_version(N),
     lager:info("Upgrading ~p : ~p -> ~p", [Node, Version, NewVersion]),
@@ -154,6 +154,13 @@ upgrade(Node, NewVersion, Config) ->
         same -> ok;
         _ -> update_app_config(Node, Config)
     end,
+    Params = [
+        {old_data_dir, io_lib:format("~s/dev/dev~b/data", [OldPath, N])},
+        {new_data_dir, io_lib:format("~s/dev/dev~b/data", [NewPath, N])},
+        {old_version, Version},
+        {new_version, NewVersion}
+    ],
+    ok = UpgradeCallback(Params),
     start(Node),
     rt:wait_until_pingable(Node),
     ok.

--- a/src/rtssh.erl
+++ b/src/rtssh.erl
@@ -250,10 +250,12 @@ stop(Node) ->
     run_riak(Node, "stop"),
     ok.
 
-upgrade(Node, NewVersion) ->
-    upgrade(Node, NewVersion, same).
+upgrade(Node, NewVersion, UpgradeCallback) when is_function(UpgradeCallback) ->
+    upgrade(Node, NewVersion, same, UpgradeCallback).
 
-upgrade(Node, NewVersion, Config) ->
+%% upgrade callback unsupported for this driver until there is a need.
+%% c.f., rtdev:upgrade/4
+upgrade(Node, NewVersion, Config, _UpgradeCallback) ->
     Version = node_version(Node),
     lager:info("Upgrading ~p : ~p -> ~p", [Node, Version, NewVersion]),
     stop(Node),


### PR DESCRIPTION
…be passed to the rt:upgrade function and which gets called after the from node is stopped and upgraded, and before the to node is started.  This allows tests to perform any additional steps as part of the upgrade.  The paths of the old and new data directories are passed elements of a prop list, which is passed into the callback as its sole argument.