### PR TITLE
Upload debug logs to Giddyup

### DIFF
--- a/src/riak_test_escript.erl
+++ b/src/riak_test_escript.erl
@@ -297,25 +297,44 @@ run_test(Test, Outdir, TestMetaData, Report, HarnessArgs, NumTests) ->
         1 -> keep_them_up;
         _ -> rt:teardown()
     end,
-    CoverageFile = rt_cover:maybe_export_coverage(Test, CoverDir, erlang:phash2(TestMetaData)),
+    CoverageFile = rt_cover:maybe_export_coverage(Test,
+                                                  CoverDir,
+                                                  erlang:phash2(TestMetaData)),
     case Report of
         undefined -> ok;
         _ ->
-            {value, {log, L}, TestResult} = lists:keytake(log, 1, SingleTestResult),
+            {value, {log, L}, TestResult} =
+                lists:keytake(log, 1, SingleTestResult),
             case giddyup:post_result(TestResult) of
                 error -> woops;
                 {ok, Base} ->
                     %% Now push up the artifacts, starting with the test log
                     giddyup:post_artifact(Base, {"riak_test.log", L}),
-                    [ giddyup:post_artifact(Base, File) || File <- rt:get_node_logs() ],
-                    [giddyup:post_artifact(Base, {filename:basename(CoverageFile) ++ ".gz",
-                                                  zlib:gzip(element(2,file:read_file(CoverageFile)))}) || CoverageFile /= cover_disabled ],
-                    ResultPlusGiddyUp = TestResult ++ [{giddyup_url, list_to_binary(Base)}],
-                    [ rt:post_result(ResultPlusGiddyUp, WebHook) || WebHook <- get_webhooks() ]
+                    [giddyup:post_artifact(Base, File)
+                     || File <- rt:get_node_logs()],
+                    maybe_post_debug_logs(Base),
+                    [giddyup:post_artifact(
+                       Base,
+                       {filename:basename(CoverageFile) ++ ".gz",
+                        zlib:gzip(element(2,file:read_file(CoverageFile)))})
+                     || CoverageFile /= cover_disabled],
+                    ResultPlusGiddyUp = TestResult ++
+                                        [{giddyup_url, list_to_binary(Base)}],
+                    [rt:post_result(ResultPlusGiddyUp, WebHook) ||
+                     WebHook <- get_webhooks()]
             end
     end,
     rt_cover:stop(),
     [{coverdata, CoverageFile} | SingleTestResult].
+
+maybe_post_debug_logs(Base) ->
+    case rt_config:get(giddyup_post_debug_logs, true) of
+        true ->
+            [giddyup:post_artifact(Base, File)
+             || File <- rt:get_node_debug_logs()];
+        _ ->
+            false
+    end.
 
 get_webhooks() ->
     Hooks = lists:foldl(fun(E, Acc) -> [parse_webhook(E) | Acc] end,

--- a/src/rt.erl
+++ b/src/rt.erl
@@ -1825,6 +1825,9 @@ setup_harness(Test, Args) ->
 get_node_logs() ->
     ?HARNESS:get_node_logs().
 
+get_node_debug_logs() ->
+    ?HARNESS:get_node_debug_logs().
+
 %% @doc Performs a search against the log files on `Node' and returns all
 %% matching lines.
 -spec search_logs(node(), Pattern::iodata()) ->

--- a/src/rtdev.erl
+++ b/src/rtdev.erl
@@ -26,6 +26,8 @@
 -define(DEVS(N), lists:concat(["dev", N, "@127.0.0.1"])).
 -define(DEV(N), list_to_atom(?DEVS(N))).
 -define(PATH, (rt_config:get(rtdev_path))).
+-define(DEBUG_LOG_FILE(N),
+        "dev" ++ integer_to_list(N) ++ "@127.0.0.1-riak-debug.tar.gz").
 
 get_deps() ->
     lists:flatten(io_lib:format("~s/dev/dev1/lib", [relpath(current)])).
@@ -51,6 +53,17 @@ riak_admin_cmd(Path, N, Args) ->
     ArgStr = string:join(Quoted, " "),
     ExecName = rt_config:get(exec_name, "riak"),
     io_lib:format("~s/dev/dev~b/bin/~s-admin ~s", [Path, N, ExecName, ArgStr]).
+
+riak_debug_cmd(Path, N, Args) ->
+    Quoted =
+        lists:map(fun(Arg) when is_list(Arg) ->
+                          lists:flatten([$", Arg, $"]);
+                     (_) ->
+                          erlang:error(badarg)
+                  end, Args),
+    ArgStr = string:join(Quoted, " "),
+    ExecName = rt_config:get(exec_name, "riak"),
+    io_lib:format("~s/dev/dev~b/bin/~s-debug ~s", [Path, N, ExecName, ArgStr]).
 
 run_git(Path, Cmd) ->
     lager:info("Running: ~s", [gitcmd(Path, Cmd)]),
@@ -764,6 +777,26 @@ get_node_logs() ->
           {ok, Port} = file:open(Filename, [read, binary]),
           {lists:nthtail(RootLen, Filename), Port}
       end || Filename <- filelib:wildcard(Root ++ "/*/dev/dev*/log/*") ].
+
+get_node_debug_logs() ->
+    NodeMap = rt_config:get(rt_nodes),
+    rt:pmap(fun(Node) ->
+                    get_node_debug_logs(Node)
+            end,
+            NodeMap).
+
+get_node_debug_logs({_Node, NodeNum}) ->
+    Path = relpath(node_version(NodeNum)),
+    Args = ["--logs"],
+    Cmd = riak_debug_cmd(Path, NodeNum, Args),
+    file:delete(?DEBUG_LOG_FILE(NodeNum)),
+    {ExitCode, Result} = wait_for_cmd(spawn_cmd(Cmd)),
+    case ExitCode of
+        0 ->
+            ?DEBUG_LOG_FILE(NodeNum);
+        _ ->
+            exit({ExitCode, Result})
+    end.
 
 %% @doc Performs a search against the log files on `Node' and returns all
 %% matching lines.


### PR DESCRIPTION
This can be disabled by setting the `giddyup_post_debug_logs` config value to `false` (it is `true` by default).