### PR TITLE
RIAK-2583 Async Job Switches

### DIFF
--- a/src/rt.erl
+++ b/src/rt.erl
@@ -1,6 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%% Copyright (c) 2013-2014 Basho Technologies, Inc.
+%% Copyright (c) 2013-2016 Basho Technologies, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -64,6 +64,7 @@
          deploy_clusters/1,
          down/2,
          enable_search_hook/2,
+         ensure_random_seeded/0,
          expect_in_log/2,
          get_call_count/2,
          get_deps/0,
@@ -108,6 +109,8 @@
          product/1,
          priv_dir/0,
          random_sublist/2,
+         random_uniform/0,
+         random_uniform/1,
          remove/2,
          riak/2,
          riak_repl/2,
@@ -2054,23 +2057,48 @@ wait_for_control(VersionedNodes) when is_list(VersionedNodes) ->
 -spec select_random([any()]) -> any().
 select_random(List) ->
     Length = length(List),
-    Idx = random:uniform(Length),
+    Idx = random_uniform(Length),
     lists:nth(Idx, List).
 
 %% @doc Returns a random element from a given list.
 -spec random_sublist([any()], integer()) -> [any()].
 random_sublist(List, N) ->
-    % Properly seeding the process.
-    <<A:32, B:32, C:32>> = crypto:rand_bytes(12),
-    random:seed({A, B, C}),
     % Assign a random value for each element in the list.
-    List1 = [{random:uniform(), E} || E <- List],
+    List1 = [{random_uniform(), E} || E <- List],
     % Sort by the random number.
     List2 = lists:sort(List1),
     % Take the first N elements.
     List3 = lists:sublist(List2, N),
     % Remove the random numbers.
     [ E || {_,E} <- List3].
+
+-spec random_uniform() -> float().
+%% @doc Like random:uniform/0, but always seeded with quality entropy.
+random_uniform() ->
+    ok = ensure_random_seeded(),
+    random:uniform().
+
+-spec random_uniform(Range :: pos_integer()) -> pos_integer().
+%% @doc Like random:uniform/1, but always seeded with quality entropy.
+random_uniform(Range) ->
+    ok = ensure_random_seeded(),
+    random:uniform(Range).
+
+-spec ensure_random_seeded() -> ok.
+%% @doc Ensures that the random module's PRNG is seeded with the good stuff.
+ensure_random_seeded() ->
+    Key = {?MODULE, random_seeded},
+    case erlang:get(Key) of
+        true ->
+            ok;
+        _ ->
+            % crypto:rand_bytes/1 is deprecated in OTP-19
+            <<A:32/integer, B:32/integer, C:32/integer>>
+                = crypto:strong_rand_bytes(12),
+            random:seed(A, B, C),
+            erlang:put(Key, true),
+            ok
+    end.
 
 %% @doc Recusively delete files in a directory.
 -spec del_dir(string()) -> strings().

--- a/tests/job_enable_common.erl
+++ b/tests/job_enable_common.erl
@@ -1,0 +1,362 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2016 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(job_enable_common).
+
+% Public API for use by other tests
+-export([
+    bin_bucket/1,
+    bin_key/1,
+    bin_val/1,
+    close_client/1,
+    enabled_string/1,
+    index_2i/0,
+    index_yz/0,
+    load_data/1,
+    num_buckets/0, num_buckets/1,
+    num_keys/0, num_keys/1,
+    open_client/2,
+    populated_bucket/0,
+    setup_cluster/1,
+    test_buckets/0,
+    test_keys/0,
+    test_nums/0,
+    test_operation/4,
+    test_vals/0,
+    undefined_bucket/0
+]).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("riakc/include/riakc.hrl").
+-include("job_enable_common.hrl").
+
+-define(DEFAULT_NUM_BUCKETS,    7).
+-define(DEFAULT_NUM_KEYS,       9).
+
+%% ===================================================================
+%% Test API
+%% ===================================================================
+
+enabled_string(true) ->
+    "enabled";
+enabled_string(false) ->
+    "disabled".
+
+bin_bucket(Num) ->
+    erlang:list_to_binary(["Bucket_", erlang:integer_to_list(Num)]).
+
+bin_key(Num) ->
+    erlang:list_to_binary(["Key_", erlang:integer_to_list(Num)]).
+
+bin_val(Num) ->
+    erlang:list_to_binary(["Val_", erlang:integer_to_list(Num)]).
+
+index_2i() ->
+    {integer_index, "valnum_index_2i"}.
+
+index_yz() ->
+    <<"valnum_index_yz">>.
+
+num_buckets() ->
+    Key = {?MODULE, num_buckets},
+    case erlang:get(Key) of
+        undefined ->
+            Num = ?DEFAULT_NUM_BUCKETS,
+            erlang:put(Key, Num),
+            Num;
+        Val ->
+            Val
+    end.
+
+num_buckets(Num) when erlang:is_integer(Num) andalso Num > 0 ->
+    Key = {?MODULE, num_buckets},
+    case erlang:get(Key) of
+        undefined ->
+            erlang:put(Key, Num),
+            Num;
+        Num ->
+            Num;
+        _ ->
+            erlang:erase({?MODULE, test_buckets}),
+            erlang:erase({?MODULE, populated_bucket}),
+            erlang:put(Key, Num),
+            Num
+    end.
+
+num_keys() ->
+    Key = {?MODULE, num_keys},
+    case erlang:get(Key) of
+        undefined ->
+            Num = ?DEFAULT_NUM_KEYS,
+            erlang:put(Key, Num),
+            Num;
+        Val ->
+            Val
+    end.
+
+num_keys(Num) when erlang:is_integer(Num) andalso Num > 0 ->
+    Key = {?MODULE, num_keys},
+    case erlang:get(Key) of
+        undefined ->
+            erlang:put(Key, Num),
+            Num;
+        Num ->
+            Num;
+        _ ->
+            erlang:erase({?MODULE, test_keys}),
+            erlang:erase({?MODULE, test_nums}),
+            erlang:erase({?MODULE, test_vals}),
+            erlang:put(Key, Num),
+            Num
+    end.
+
+populated_bucket() ->
+    Key = {?MODULE, populated_bucket},
+    case erlang:get(Key) of
+        undefined ->
+            Buckets = test_buckets(),
+            Bucket = lists:nth(erlang:length(Buckets) div 2, Buckets),
+            erlang:put(Key, Bucket),
+            Bucket;
+        Val ->
+            Val
+    end.
+
+undefined_bucket() ->
+    <<"Undefined_Bucket">>.
+
+test_buckets() ->
+    Key = {?MODULE, test_buckets},
+    case erlang:get(Key) of
+        undefined ->
+            New = bin_buckets(num_buckets(), []),
+            erlang:put(Key, New),
+            New;
+        Val ->
+            Val
+    end.
+
+test_keys() ->
+    Key = {?MODULE, test_keys},
+    case erlang:get(Key) of
+        undefined ->
+            New = bin_keys(num_keys(), []),
+            erlang:put(Key, New),
+            New;
+        Val ->
+            Val
+    end.
+
+test_nums() ->
+    Key = {?MODULE, test_nums},
+    case erlang:get(Key) of
+        undefined ->
+            New = lists:seq(1, num_keys()),
+            erlang:put(Key, New),
+            New;
+        Val ->
+            Val
+    end.
+
+test_vals() ->
+    Key = {?MODULE, test_vals},
+    case erlang:get(Key) of
+        undefined ->
+            New = bin_vals(num_keys(), []),
+            erlang:put(Key, New),
+            New;
+        Val ->
+            Val
+    end.
+
+open_client(http = Type, Node) ->
+    % HTTP connections are constant records, so re-use them
+    Key = {?MODULE, httpc, Node},
+    case erlang:get(Key) of
+        undefined ->
+            New = {Type, rhc, rt:httpc(Node)},
+            erlang:put(Key, New),
+            New;
+        Conn ->
+            Conn
+    end;
+open_client(pbc = Type, Node) ->
+    {Type, riakc_pb_socket, rt:pbc(Node)}.
+
+close_client({http, _Mod, _RHC}) ->
+    ok;
+close_client({pbc, Mod, PBC}) ->
+    Mod:stop(PBC).
+
+setup_cluster([Node | _] = Nodes) ->
+    lager:info("Creating a cluster of ~b nodes ...", [erlang:length(Nodes)]),
+    ?assertEqual(ok, rt:join_cluster(Nodes)),
+    load_data(Node),
+    ?assertEqual(ok, rt:wait_until_transfers_complete(Nodes)).
+
+load_data(Node) ->
+    lager:info("Writing known data to node ~p ...", [Node]),
+    PBConn = rt:pbc(Node),
+    load_data(PBConn, populated_bucket(), test_buckets()),
+    riakc_pb_socket:stop(PBConn).
+
+test_operation(Node, ?TOKEN_LIST_BUCKETS, Enabled, ClientType) ->
+    {_, Mod, Conn} = Client = open_client(ClientType, Node),
+    Result = Mod:list_buckets(Conn),
+    close_client(Client),
+    case Enabled of
+        true ->
+            ?assertMatch({ok, _}, Result),
+            {ok, Buckets} = Result,
+            ?assertEqual(test_buckets(), lists:sort(Buckets));
+        false ->
+            case ClientType of
+                pbc ->
+                    ?assertEqual({error, ?ERRMSG_LIST_BUCKETS_DISABLED}, Result);
+                http ->
+                    ?assertMatch({error, {"403", _}}, Result)
+            end
+    end;
+
+test_operation(Node, ?TOKEN_LIST_KEYS, Enabled, ClientType) ->
+    {_, Mod, Conn} = Client = open_client(ClientType, Node),
+    Result = Mod:list_keys(Conn, populated_bucket()),
+    close_client(Client),
+    case Enabled of
+        true ->
+            ?assertMatch({ok, _}, Result),
+            {ok, Keys} = Result,
+            ?assertEqual(test_keys(), lists:sort(Keys));
+        false ->
+            case ClientType of
+                pbc ->
+                    ?assertEqual({error, ?ERRMSG_LIST_KEYS_DISABLED}, Result);
+                http ->
+                    ?assertMatch({error, {"403", _}}, Result)
+            end
+    end;
+
+test_operation(Node, ?TOKEN_MAP_REDUCE, Enabled, ClientType) ->
+    Bucket = populated_bucket(),
+    {_, Mod, Conn} = Client = open_client(ClientType, Node),
+    Result = Mod:mapred(Conn, Bucket, []),
+    close_client(Client),
+    case Enabled of
+        true ->
+            ?assertMatch({ok, [{_, _}]}, Result),
+            {ok, [{_, Pairs}]} = Result,
+            Expect = case ClientType of
+                pbc ->
+                    [{Bucket, Key} || Key <- test_keys()];
+                http ->
+                    [[Bucket, Key] || Key <- test_keys()]
+            end,
+            ?assertEqual(Expect, lists:sort(Pairs));
+        false ->
+            case ClientType of
+                pbc ->
+                    ?assertEqual({error, ?ERRMSG_MAP_REDUCE_DISABLED}, Result);
+                http ->
+                    ?assertMatch({error, {"403", _}}, Result)
+            end
+    end;
+
+test_operation(Node, ?TOKEN_SEC_INDEX, Enabled, ClientType) ->
+    Bucket = populated_bucket(),
+    Index = index_2i(),
+    Num = random:uniform(num_keys()),
+    {_, Mod, Conn} = Client = open_client(ClientType, Node),
+    Result = Mod:get_index(Conn, Bucket, Index, Num),
+    close_client(Client),
+    case Enabled of
+        true ->
+            Key = bin_key(Num),
+            ?assertMatch({ok, {index_results_v1, [Key], _, _}}, Result);
+        false ->
+            case ClientType of
+                pbc ->
+                    ?assertEqual({error, ?ERRMSG_SEC_INDEX_DISABLED}, Result);
+                http ->
+                    ?assertMatch({error, {"403", _}}, Result)
+            end
+    end;
+
+%% This requires that YZ be running and that
+%%  riakc_pb_socket:create_search_index(Connection, index_yz())
+%% or equivalent has been successfully called before invoking this test.
+%% This module's load/data/1 function DOES NOT do this for you.
+test_operation(Node, ?TOKEN_YZ_SEARCH, Enabled, ClientType) ->
+    Index   = index_yz(),
+    Bucket  = populated_bucket(),
+    Num     = random:uniform(num_keys()),
+    Key     = bin_key(Num),
+    Query   = <<"_yz_rb:", Bucket/binary, " AND _yz_rk:", Key/binary>>,
+    {_, Mod, Conn} = Client = open_client(ClientType, Node),
+    Result = Mod:search(Conn, Index, Query),
+    close_client(Client),
+    case Enabled of
+        true ->
+            ?assertMatch({ok, #search_results{}}, Result);
+        false ->
+            case ClientType of
+                pbc ->
+                    ?assertEqual({error, ?ERRMSG_YZ_SEARCH_DISABLED}, Result);
+                http ->
+                    ?assertMatch({error, {"403", _}}, Result)
+            end
+    end.
+
+%% ===================================================================
+%% Internal
+%% ===================================================================
+
+bin_buckets(0, Result) ->
+    lists:sort(Result);
+bin_buckets(Count, Result) ->
+    bin_buckets((Count - 1), [bin_bucket(Count) | Result]).
+
+bin_keys(0, Result) ->
+    lists:sort(Result);
+bin_keys(Count, Result) ->
+    bin_keys((Count - 1), [bin_key(Count) | Result]).
+
+bin_vals(0, Result) ->
+    lists:sort(Result);
+bin_vals(Count, Result) ->
+    bin_vals((Count - 1), [bin_val(Count) | Result]).
+
+load_data(PBConn, Bucket, [Bucket | Buckets]) ->
+    Index = index_2i(),
+    Load = fun({Num, Key, Val}) ->
+        Obj1  = riakc_obj:new(Bucket, Key, Val),
+        Meta1 = riakc_obj:get_update_metadata(Obj1),
+        Meta2 = riakc_obj:set_secondary_index(Meta1, [{Index, [Num]}]),
+        Obj2  = riakc_obj:update_metadata(Obj1, Meta2),
+        ?assertEqual(ok, riakc_pb_socket:put(PBConn, Obj2))
+    end,
+    lists:foreach(Load, lists:zip3(test_nums(), test_keys(), test_vals())),
+    load_data(PBConn, Bucket, Buckets);
+load_data(PBConn, PopBucket, [Bucket | Buckets]) ->
+    ?assertEqual(ok, riakc_pb_socket:put(PBConn,
+        riakc_obj:new(Bucket, <<"test_key">>, <<"test_value">>))),
+    load_data(PBConn, PopBucket, Buckets);
+load_data(_, _, []) ->
+    ok.
+

--- a/tests/job_enable_common.erl
+++ b/tests/job_enable_common.erl
@@ -27,6 +27,7 @@
     bin_val/1,
     close_client/1,
     enabled_string/1,
+    get_enabled/2,
     index_2i/0,
     index_name/1,
     index_yz/0,
@@ -35,6 +36,7 @@
     num_keys/0, num_keys/1,
     open_client/2,
     populated_bucket/0,
+    set_enabled/3,
     setup_cluster/1,
     setup_yokozuna/1,
     test_buckets/0,
@@ -201,6 +203,21 @@ test_vals() ->
         Val ->
             Val
     end.
+
+get_enabled(Nodes, Class) when erlang:is_list(Nodes) ->
+    [get_enabled(Node, Class) || Node <- Nodes];
+get_enabled(Node, {App, Op}) ->
+    rpc:call(Node, riak_core_util, job_class_enabled, [App, Op]).
+
+set_enabled([], _, _) ->
+    ok;
+set_enabled([Node | Nodes], Class, Enabled) ->
+    ?assertEqual(ok, set_enabled(Node, Class, Enabled)),
+    set_enabled(Nodes, Class, Enabled);
+set_enabled(Node, {App, Op}, true) ->
+    rpc:call(Node, riak_core_util, enable_job_class, [App, Op]);
+set_enabled(Node, {App, Op}, false) ->
+    rpc:call(Node, riak_core_util, disable_job_class, [App, Op]).
 
 open_client(http = Type, Node) ->
     % HTTP connections are constant records, so re-use them

--- a/tests/job_enable_common.erl
+++ b/tests/job_enable_common.erl
@@ -28,6 +28,7 @@
     close_client/1,
     enabled_string/1,
     index_2i/0,
+    index_name/1,
     index_yz/0,
     load_data/1,
     num_buckets/0, num_buckets/1,
@@ -35,6 +36,7 @@
     open_client/2,
     populated_bucket/0,
     setup_cluster/1,
+    setup_yokozuna/1,
     test_buckets/0,
     test_keys/0,
     test_nums/0,
@@ -45,6 +47,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("riakc/include/riakc.hrl").
+-include_lib("riakhttpc/include/rhc.hrl").
 -include("job_enable_common.hrl").
 
 -define(DEFAULT_NUM_BUCKETS,    7).
@@ -73,6 +76,19 @@ index_2i() ->
 
 index_yz() ->
     <<"valnum_index_yz">>.
+
+index_name(Name) when erlang:is_atom(Name) ->
+    erlang:atom_to_list(Name);
+index_name(Name) when erlang:is_binary(Name) ->
+    erlang:binary_to_list(Name);
+index_name(Name) when erlang:is_list(Name) ->
+    Name;
+index_name({binary_index, Name}) ->
+    index_name(Name) ++ "_bin";
+index_name({integer_index, Name}) ->
+    index_name(Name) ++ "_int";
+index_name(Index) ->
+    erlang:error(badarg, [Index]).
 
 num_buckets() ->
     Key = {?MODULE, num_buckets},
@@ -211,32 +227,115 @@ setup_cluster([Node | _] = Nodes) ->
     load_data(Node),
     ?assertEqual(ok, rt:wait_until_transfers_complete(Nodes)).
 
+setup_yokozuna([Node | _]) ->
+    setup_yokozuna(Node);
+setup_yokozuna(Node) ->
+    % create the YZ search index
+    {_, Mod, Conn} = Client = open_client(pbc, Node),
+    ?assertEqual(ok, Mod:create_search_index(Conn, index_yz())),
+    close_client(Client).
+
+load_data([Node | _]) ->
+    load_data(Node);
 load_data(Node) ->
     lager:info("Writing known data to node ~p ...", [Node]),
     PBConn = rt:pbc(Node),
     load_data(PBConn, populated_bucket(), test_buckets()),
     riakc_pb_socket:stop(PBConn).
 
-test_operation(Node, ?TOKEN_LIST_BUCKETS, Enabled, ClientType) ->
+%%
+%% Notes on test_operation/4 implementation:
+%%
+%% The 'rhc' and 'riakc_pb_socket' hide a lot of implementation details,
+%% including the command they actually issue, so we rely on the error message
+%% in the response for disabled switches to confirm that the request got routed
+%% to where we wanted it to on the receiving end.
+%%
+%% This results in some odd head clause ordering below, as the approach differs
+%% for each operation. All operations for a given ?TOKEN_XXX are clustered
+%% together, but the order within the cluster varies as we match patterns as
+%% dictated by the behavior of the client modules for each.
+%%
+%% We currently uses 'riakc_pb_socket' for protobufs, but that doesn't give us
+%% access to all available operations, so some are stubbed out unless/until we
+%% dig deeper and implement them ourselves.
+%%
+%% The 'rhc' module has the same problem, but compounds it by not returning the
+%% response body on errors, so for tests where it doesn't give us what we want
+%% we skip it and use 'ibrowse' directly, building the URL from scratch.
+%% For some reason using rt:httpc(Node) and getting the host/port out of the
+%% returned #rhc{} is more reliable than calling rt:get_https_conn_info
+%% directly.
+%%
+
+% riakc_pb_socket always lists buckets with streams, so skip the non-stream
+% test unless/until we want to implement it directly.
+test_operation(_, ?TOKEN_LIST_BUCKETS, _, pbc) ->
+    ok;
+test_operation(Node, ?TOKEN_LIST_BUCKETS = Class, Enabled, http = Scheme) ->
+    URL = make_url(Node, Scheme, "/buckets?buckets=true"),
+    Result = ibrowse:send_req(URL, [], get, [], [{response_format, binary}]),
+    ?assertMatch({ok, _, _, _}, Result),
+    {_, Code, _, Body} = Result,
+    case Enabled of
+        true ->
+            {struct, PList} = mochijson2:decode(
+                unicode:characters_to_list(Body, utf8)),
+            Buckets = proplists:get_value(<<"buckets">>, PList, []),
+            ?assertEqual({"200", test_buckets()}, {Code, lists:sort(Buckets)});
+        false ->
+            ?assertEqual({"403", ?ERRMSG_BIN(Class)}, {Code, Body})
+    end;
+
+test_operation(Node, ?TOKEN_LIST_BUCKETS_S = Class, false, http = Scheme) ->
+    URL = make_url(Node, Scheme, "/buckets?buckets=stream"),
+    Result = ibrowse:send_req(URL, [], get),
+    ?assertMatch({ok, _, _, _}, Result),
+    {_, Code, _, Body} = Result,
+    ?assertEqual({"403", ?ERRMSG_TXT(Class)}, {Code, Body});
+test_operation(Node, ?TOKEN_LIST_BUCKETS_S = Class, Enabled, ClientType) ->
     {_, Mod, Conn} = Client = open_client(ClientType, Node),
+    % 'rhc' and 'riakc_pb_socket' list_buckets always use stream_list_buckets
     Result = Mod:list_buckets(Conn),
     close_client(Client),
     case Enabled of
         true ->
-            ?assertMatch({ok, _}, Result),
+            ?assertMatch({ok, L} when erlang:is_list(L), Result),
             {ok, Buckets} = Result,
             ?assertEqual(test_buckets(), lists:sort(Buckets));
         false ->
-            case ClientType of
-                pbc ->
-                    ?assertEqual({error, ?ERRMSG_LIST_BUCKETS_DISABLED}, Result);
-                http ->
-                    ?assertMatch({error, {"403", _}}, Result)
-            end
+            ?assertEqual({error, ?ERRMSG_BIN(Class)}, Result)
     end;
 
-test_operation(Node, ?TOKEN_LIST_KEYS, Enabled, ClientType) ->
+% protobuf list-keys only does streams, so skip the non-stream test
+test_operation(_, ?TOKEN_LIST_KEYS, _, pbc) ->
+    ok;
+test_operation(Node, ?TOKEN_LIST_KEYS = Class, Enabled, http = Scheme) ->
+    URL = make_url(Node, Scheme, ["/buckets/",
+        erlang:binary_to_list(populated_bucket()), "/keys?keys=true"]),
+    Result = ibrowse:send_req(URL, [], get, [], [{response_format, binary}]),
+    ?assertMatch({ok, _, _, _}, Result),
+    {_, Code, _, Body} = Result,
+    case Enabled of
+        true ->
+            {struct, PList} = mochijson2:decode(
+                unicode:characters_to_list(Body, utf8)),
+            Keys = proplists:get_value(<<"keys">>, PList, []),
+            ?assertEqual({"200", test_keys()}, {Code, lists:sort(Keys)});
+        false ->
+            ?assertEqual({"403", ?ERRMSG_BIN(Class)}, {Code, Body})
+    end;
+
+test_operation(Node, ?TOKEN_LIST_KEYS_S = Class, false, http = Scheme) ->
+    URL = make_url(Node, Scheme, ["/buckets/",
+        erlang:binary_to_list(populated_bucket()), "/keys?keys=stream"]),
+    Result = ibrowse:send_req(URL, [], get),
+    ?assertMatch({ok, _, _, _}, Result),
+    {_, Code, _, Body} = Result,
+    ?assertEqual({"403", ?ERRMSG_TXT(Class)}, {Code, Body});
+test_operation(Node, ?TOKEN_LIST_KEYS_S = Class, Enabled, ClientType) ->
     {_, Mod, Conn} = Client = open_client(ClientType, Node),
+    % 'rhc' and 'riakc_pb_socket' list_keys always use stream_list_keys
     Result = Mod:list_keys(Conn, populated_bucket()),
     close_client(Client),
     case Enabled of
@@ -245,15 +344,10 @@ test_operation(Node, ?TOKEN_LIST_KEYS, Enabled, ClientType) ->
             {ok, Keys} = Result,
             ?assertEqual(test_keys(), lists:sort(Keys));
         false ->
-            case ClientType of
-                pbc ->
-                    ?assertEqual({error, ?ERRMSG_LIST_KEYS_DISABLED}, Result);
-                http ->
-                    ?assertMatch({error, {"403", _}}, Result)
-            end
+            ?assertEqual({error, ?ERRMSG_BIN(Class)}, Result)
     end;
 
-test_operation(Node, ?TOKEN_MAP_REDUCE, Enabled, ClientType) ->
+test_operation(Node, ?TOKEN_MAP_REDUCE = Class, Enabled, ClientType) ->
     Bucket = populated_bucket(),
     {_, Mod, Conn} = Client = open_client(ClientType, Node),
     Result = Mod:mapred(Conn, Bucket, []),
@@ -272,37 +366,86 @@ test_operation(Node, ?TOKEN_MAP_REDUCE, Enabled, ClientType) ->
         false ->
             case ClientType of
                 pbc ->
-                    ?assertEqual({error, ?ERRMSG_MAP_REDUCE_DISABLED}, Result);
+                    ?assertEqual({error, ?ERRMSG_BIN(Class)}, Result);
                 http ->
                     ?assertMatch({error, {"403", _}}, Result)
             end
     end;
 
-test_operation(Node, ?TOKEN_SEC_INDEX, Enabled, ClientType) ->
+test_operation(Node, ?TOKEN_SEC_INDEX = Class, Enabled, pbc = ClientType) ->
     Bucket = populated_bucket(),
     Index = index_2i(),
     Num = random:uniform(num_keys()),
     {_, Mod, Conn} = Client = open_client(ClientType, Node),
-    Result = Mod:get_index(Conn, Bucket, Index, Num),
+    Result = Mod:get_index_eq(Conn, Bucket, Index, Num, [{stream, false}]),
     close_client(Client),
     case Enabled of
         true ->
             Key = bin_key(Num),
             ?assertMatch({ok, {index_results_v1, [Key], _, _}}, Result);
         false ->
-            case ClientType of
-                pbc ->
-                    ?assertEqual({error, ?ERRMSG_SEC_INDEX_DISABLED}, Result);
-                http ->
-                    ?assertMatch({error, {"403", _}}, Result)
-            end
+            ?assertEqual({error, ?ERRMSG_BIN(Class)}, Result)
     end;
+test_operation(Node, ?TOKEN_SEC_INDEX = Class, Enabled, http = Scheme) ->
+    Num = random:uniform(num_keys()),
+    URL = make_url(Node, Scheme, [
+        "/buckets/", erlang:binary_to_list(populated_bucket()),
+        "/index/", index_name(index_2i()), "/", erlang:integer_to_list(Num) ]),
+    Result = ibrowse:send_req(URL, [], get, [], [{response_format, binary}]),
+    ?assertMatch({ok, _, _, _}, Result),
+    {_, Code, _, Body} = Result,
+    case Enabled of
+        true ->
+            Key = bin_key(Num),
+            {struct, PList} = mochijson2:decode(
+                unicode:characters_to_list(Body, utf8)),
+            Keys = proplists:get_value(<<"keys">>, PList, []),
+            ?assertEqual({"200", [Key]}, {Code, Keys});
+        false ->
+            ?assertEqual({"403", ?ERRMSG_BIN(Class)}, {Code, Body})
+    end;
+
+test_operation(Node, ?TOKEN_SEC_INDEX_S = Class, Enabled, pbc = ClientType) ->
+    Lo = random:uniform(num_keys() - 3),
+    Hi = (Lo + 3),
+    {_, Mod, Conn} = Client = open_client(ClientType, Node),
+    {ok, ReqId} = Mod:get_index_range(
+        Conn, populated_bucket(), index_2i(), Lo, Hi, [{stream, true}]),
+    % on success result keys are sorted by receive_2i_stream/2
+    Result = receive_2i_stream(ReqId, []),
+    close_client(Client),
+    case Enabled of
+        true ->
+            Expect = [bin_key(N) || N <- lists:seq(Lo, Hi)],
+            ?assertEqual({ok, Expect}, Result);
+        false ->
+            ?assertEqual({error, ?ERRMSG_BIN(Class)}, Result)
+    end;
+test_operation(Node, ?TOKEN_SEC_INDEX_S = Class, false, http = Scheme) ->
+    Num = random:uniform(num_keys()),
+    URL = make_url(Node, Scheme, [
+        "/buckets/", erlang:binary_to_list(populated_bucket()),
+        "/index/", index_name(index_2i()), "/", erlang:integer_to_list(Num),
+        "?stream=true" ]),
+    Result = ibrowse:send_req(URL, [], get, [], [{response_format, binary}]),
+    ?assertMatch({ok, _, _, _}, Result),
+    {_, Code, _, Body} = Result,
+    ?assertEqual({"403", ?ERRMSG_BIN(Class)}, {Code, Body});
+test_operation(Node, ?TOKEN_SEC_INDEX_S, true, http = ClientType) ->
+    Bucket = populated_bucket(),
+    Index = index_2i(),
+    Num = random:uniform(num_keys()),
+    Key = bin_key(Num),
+    {_, Mod, Conn} = Client = open_client(ClientType, Node),
+    Result = Mod:get_index(Conn, Bucket, Index, Num),
+    close_client(Client),
+    ?assertMatch({ok, {index_results_v1, [Key], _, _}}, Result);
 
 %% This requires that YZ be running and that
 %%  riakc_pb_socket:create_search_index(Connection, index_yz())
 %% (or equivalent) has been successfully called before invoking this test.
 %% This module's load_data/1 function DOES NOT do this for you by default.
-test_operation(Node, ?TOKEN_YZ_SEARCH, Enabled, pbc = ClientType) ->
+test_operation(Node, ?TOKEN_YZ_SEARCH = Class, Enabled, pbc = ClientType) ->
     Index   = index_yz(),
     Bucket  = populated_bucket(),
     Num     = random:uniform(num_keys()),
@@ -315,19 +458,16 @@ test_operation(Node, ?TOKEN_YZ_SEARCH, Enabled, pbc = ClientType) ->
         true ->
             ?assertMatch({ok, #search_results{}}, Result);
         false ->
-            ?assertEqual({error, ?ERRMSG_YZ_SEARCH_DISABLED}, Result)
+            ?assertEqual({error, ?ERRMSG_BIN(Class)}, Result)
     end;
-test_operation(Node, ?TOKEN_YZ_SEARCH, Enabled, http) ->
+test_operation(Node, ?TOKEN_YZ_SEARCH = Class, Enabled, http) ->
     % The rhs module's search functions don't do anything remotely like their
     % PB equivalents, so this specific test has to depart from the pattern
     % entirely.
     Bucket = populated_bucket(),
     Num = random:uniform(num_keys()),
     Key = bin_key(Num),
-    % more reliable than calling rt:get_https_conn_info directly
-    RHC = rt:httpc(Node),
-    URL = lists:flatten([
-            "http://", rhc:ip(RHC), ":", erlang:integer_to_list(rhc:port(RHC)),
+    URL = make_url(Node, [
             "/search/query/", erlang:binary_to_list(index_yz()),
             "?wt=json&q=_yz_rb:", erlang:binary_to_list(Bucket),
             "%20AND%20_yz_rk:", erlang:binary_to_list(Key) ]),
@@ -337,7 +477,9 @@ test_operation(Node, ?TOKEN_YZ_SEARCH, Enabled, http) ->
         true ->
             ?assertMatch({ok, "200", _, _}, Result);
         false ->
-            ?assertMatch({ok, "403", _, _}, Result)
+            ?assertMatch({ok, "403", _, _}, Result),
+            {_, _, _, Body} = Result,
+            ?assertEqual(Body, ?ERRMSG_TXT(Class))
     end.
 
 %% ===================================================================
@@ -376,4 +518,38 @@ load_data(PBConn, PopBucket, [Bucket | Buckets]) ->
     load_data(PBConn, PopBucket, Buckets);
 load_data(_, _, []) ->
     ok.
+
+make_url(#rhc{ip = IP, port = Port, options = Opts}, Parts) ->
+    case proplists:get_value(is_ssl, Opts) of
+        true ->
+            make_url(https, IP, Port, Parts);
+        _ ->
+            make_url(http, IP, Port, Parts)
+    end;
+make_url(Node, Parts) ->
+    make_url(Node, http, Parts).
+
+make_url(Node, Scheme, Parts) ->
+    % seems to be more reliable than calling rt:get_https_conn_info directly
+    #rhc{ip = IP, port = Port} = rt:httpc(Node),
+    make_url(Scheme, IP, Port, Parts).
+
+make_url(Scheme, Host, Port, Parts) ->
+    lists:flatten([io_lib:format("~s://~s:~b", [Scheme, Host, Port]), Parts]).
+
+receive_2i_stream(ReqId, Result) ->
+    receive
+        {ReqId, {done, _}} ->
+            {ok, lists:sort(lists:flatten(Result))};
+        {ReqId, {error, Reason}} ->
+            {error, Reason};
+        {ReqId, {index_stream_result_v1, [Val], _}} ->
+            receive_2i_stream(ReqId, [Val | Result]);
+        % sent once before 'done'
+        {ReqId, {index_stream_result_v1, [], _}} ->
+            receive_2i_stream(ReqId, Result);
+        % not clear if it can send more than one
+        {ReqId, {index_stream_result_v1, Vals, _}} when erlang:is_list(Vals) ->
+            receive_2i_stream(ReqId, Vals ++ Result)
+    end.
 

--- a/tests/job_enable_common.hrl
+++ b/tests/job_enable_common.hrl
@@ -1,0 +1,44 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2016 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-ifndef(job_enable_common_included).
+-define(job_enable_common_included, true).
+
+-define(ADVANCED_CONFIG_KEY,    'job_accept_class').
+-define(CUTTLEFISH_PREFIX,      "async.enable").
+
+-define(TOKEN_LIST_BUCKETS,     'list_buckets').
+-define(TOKEN_LIST_KEYS,        'list_keys').
+-define(TOKEN_MAP_REDUCE,       'map_reduce').
+-define(TOKEN_SEC_INDEX,        'secondary_index').
+-define(TOKEN_YZ_SEARCH,        'riak_search').
+
+-define(ERRMSG_LIST_BUCKETS_DISABLED,
+    <<"Operation 'list_buckets' is not enabled">>).
+-define(ERRMSG_LIST_KEYS_DISABLED,
+    <<"Operation 'list_keys' is not enabled">>).
+-define(ERRMSG_MAP_REDUCE_DISABLED,
+    <<"Operation 'map_reduce' is not enabled">>).
+-define(ERRMSG_SEC_INDEX_DISABLED,
+    <<"Secondary index queries have been disabled in the configuration">>).
+-define(ERRMSG_YZ_SEARCH_DISABLED,
+    <<"Operation 'riak_search' is not enabled">>).
+
+-endif. % job_enable_common_included

--- a/tests/job_enable_common.hrl
+++ b/tests/job_enable_common.hrl
@@ -31,14 +31,14 @@
 -define(TOKEN_YZ_SEARCH,        'riak_search').
 
 -define(ERRMSG_LIST_BUCKETS_DISABLED,
-    <<"Operation 'list_buckets' is not enabled">>).
+        <<"Operation 'list_buckets' is not enabled">>).
 -define(ERRMSG_LIST_KEYS_DISABLED,
-    <<"Operation 'list_keys' is not enabled">>).
+        <<"Operation 'list_keys' is not enabled">>).
 -define(ERRMSG_MAP_REDUCE_DISABLED,
-    <<"Operation 'map_reduce' is not enabled">>).
+        <<"Operation 'map_reduce' is not enabled">>).
 -define(ERRMSG_SEC_INDEX_DISABLED,
-    <<"Secondary index queries have been disabled in the configuration">>).
+        <<"Operation 'secondary_index' is not enabled">>).
 -define(ERRMSG_YZ_SEARCH_DISABLED,
-    <<"Operation 'riak_search' is not enabled">>).
+        <<"Operation 'riak_search' is not enabled">>).
 
 -endif. % job_enable_common_included

--- a/tests/job_enable_common.hrl
+++ b/tests/job_enable_common.hrl
@@ -25,15 +25,35 @@
 -define(CUTTLEFISH_PREFIX,      "cluster.job").
 
 -define(TOKEN_LIST_BUCKETS,     {riak_kv, list_buckets}).
--define(TOKEN_LIST_KEYS,        {riak_kv, list_keys}).
--define(TOKEN_SEC_INDEX,        {riak_kv, secondary_index}).
 -define(TOKEN_LIST_BUCKETS_S,   {riak_kv, stream_list_buckets}).
+-define(TOKEN_LIST_KEYS,        {riak_kv, list_keys}).
 -define(TOKEN_LIST_KEYS_S,      {riak_kv, stream_list_keys}).
--define(TOKEN_SEC_INDEX_S,      {riak_kv, stream_secondary_index}).
 -define(TOKEN_MAP_REDUCE,       {riak_kv, map_reduce}).
--define(TOKEN_MAP_REDUCE_JS,    {riak_kv, map_reduce}).
--define(TOKEN_YZ_SEARCH,        {yokozuna, query}).
+-define(TOKEN_MAP_REDUCE_JS,    {riak_kv, map_reduce_js}).
+-define(TOKEN_SEC_INDEX,        {riak_kv, secondary_index}).
+-define(TOKEN_SEC_INDEX_S,      {riak_kv, stream_secondary_index}).
 -define(TOKEN_OLD_SEARCH,       {riak_search, query}).
+-define(TOKEN_YZ_SEARCH,        {yokozuna, query}).
+
+% Defaults for Riak 2.2
+% 'true' == 'enabled', 'false' == 'disabled'
+-define(JOB_CLASS_DEFAULTS, [
+    {?TOKEN_LIST_BUCKETS,   true},
+    {?TOKEN_LIST_BUCKETS_S, true},
+    {?TOKEN_LIST_KEYS,      true},
+    {?TOKEN_LIST_KEYS_S,    true},
+    {?TOKEN_MAP_REDUCE,     true},
+    {?TOKEN_MAP_REDUCE_JS,  true},
+    {?TOKEN_SEC_INDEX,      true},
+    {?TOKEN_SEC_INDEX_S,    true},
+    {?TOKEN_OLD_SEARCH,     false},
+    {?TOKEN_YZ_SEARCH,      true}
+]).
+
+-define(COMMON_CONFIG,  [
+    {"storage_backend", "leveldb"}, % required by ?TOKEN_SEC_INDEX
+    {"search",          "on"}       % required by ?TOKEN_YZ_SEARCH
+]).
 
 -define(ERRMSG_BIN(Tok), riak_core_util:job_class_disabled_message(binary, Tok)).
 -define(ERRMSG_TXT(Tok), riak_core_util:job_class_disabled_message(text, Tok)).

--- a/tests/job_enable_common.hrl
+++ b/tests/job_enable_common.hrl
@@ -21,8 +21,10 @@
 -ifndef(job_enable_common_included).
 -define(job_enable_common_included, true).
 
--define(ADVANCED_CONFIG_KEY,    'job_accept_class').
+-define(APP_CONFIG_KEY,         'job_accept_class').
 -define(CUTTLEFISH_PREFIX,      "cluster.job").
+-define(CUTTLEFISH_KEY(App, Op),
+    io_lib:format(?CUTTLEFISH_PREFIX ".~s.~s", [App, Op])).
 
 -define(TOKEN_LIST_BUCKETS,     {riak_kv, list_buckets}).
 -define(TOKEN_LIST_BUCKETS_S,   {riak_kv, stream_list_buckets}).

--- a/tests/job_enable_common.hrl
+++ b/tests/job_enable_common.hrl
@@ -22,23 +22,20 @@
 -define(job_enable_common_included, true).
 
 -define(ADVANCED_CONFIG_KEY,    'job_accept_class').
--define(CUTTLEFISH_PREFIX,      "async.enable").
+-define(CUTTLEFISH_PREFIX,      "cluster.job").
 
--define(TOKEN_LIST_BUCKETS,     'list_buckets').
--define(TOKEN_LIST_KEYS,        'list_keys').
--define(TOKEN_MAP_REDUCE,       'map_reduce').
--define(TOKEN_SEC_INDEX,        'secondary_index').
--define(TOKEN_YZ_SEARCH,        'riak_search').
+-define(TOKEN_LIST_BUCKETS,     {riak_kv, list_buckets}).
+-define(TOKEN_LIST_KEYS,        {riak_kv, list_keys}).
+-define(TOKEN_SEC_INDEX,        {riak_kv, secondary_index}).
+-define(TOKEN_LIST_BUCKETS_S,   {riak_kv, stream_list_buckets}).
+-define(TOKEN_LIST_KEYS_S,      {riak_kv, stream_list_keys}).
+-define(TOKEN_SEC_INDEX_S,      {riak_kv, stream_secondary_index}).
+-define(TOKEN_MAP_REDUCE,       {riak_kv, map_reduce}).
+-define(TOKEN_MAP_REDUCE_JS,    {riak_kv, map_reduce}).
+-define(TOKEN_YZ_SEARCH,        {yokozuna, query}).
+-define(TOKEN_OLD_SEARCH,       {riak_search, query}).
 
--define(ERRMSG_LIST_BUCKETS_DISABLED,
-        <<"Operation 'list_buckets' is not enabled">>).
--define(ERRMSG_LIST_KEYS_DISABLED,
-        <<"Operation 'list_keys' is not enabled">>).
--define(ERRMSG_MAP_REDUCE_DISABLED,
-        <<"Operation 'map_reduce' is not enabled">>).
--define(ERRMSG_SEC_INDEX_DISABLED,
-        <<"Operation 'secondary_index' is not enabled">>).
--define(ERRMSG_YZ_SEARCH_DISABLED,
-        <<"Operation 'riak_search' is not enabled">>).
+-define(ERRMSG_BIN(Tok), riak_core_util:job_class_disabled_message(binary, Tok)).
+-define(ERRMSG_TXT(Tok), riak_core_util:job_class_disabled_message(text, Tok)).
 
 -endif. % job_enable_common_included

--- a/tests/verify_feature_enable_flags.erl
+++ b/tests/verify_feature_enable_flags.erl
@@ -81,10 +81,10 @@ verify_features_disabled_http(Client) ->
     verify_mapred_disabled_http(Client).
 
 verify_features_disabled_pb(Client) ->
-    verify_list_buckets_disabled_pd(Client),
-    verify_list_keys_disabled_pd(Client),
-    verify_secondary_index_disabled_pd(Client).
-    %%verify_map_reduce_disabled_pd().
+    verify_list_buckets_disabled_pb(Client),
+    verify_list_keys_disabled_pb(Client),
+    verify_secondary_index_disabled_pb(Client),
+    verify_mapred_disabled_pb(Client).
 
 verify_features_enabled_http(Client) ->
     verify_list_buckets_enabled_http(Client),
@@ -98,18 +98,22 @@ verify_features_enabled_pb(Client) ->
     verify_secondary_index_enabled_pb(Client).
     %%verify_map_reduce_enabled_pb().
 
-verify_list_buckets_disabled_pd(Client) ->
+verify_list_buckets_disabled_pb(Client) ->
     Expected = {error, <<"Operation 'list_buckets' is not enabled">>},
     ?assertEqual(Expected, riakc_pb_socket:list_buckets(Client)).
 
-verify_list_keys_disabled_pd(Client) ->
+verify_list_keys_disabled_pb(Client) ->
     Expected = {error, <<"Operation 'list_keys' is not enabled">>},
     ?assertEqual(Expected, riakc_pb_socket:list_keys(Client, <<"basic_test">>)).
 
-verify_secondary_index_disabled_pd(Client) ->
+verify_secondary_index_disabled_pb(Client) ->
     Expected = {error, <<"Secondary index queries have been disabled in the configuration">>},
     ?assertEqual(Expected, riakc_pb_socket:get_index(Client, <<"2i_test">>,
                                                      {integer_index, "test_idx"}, 42)).
+
+verify_mapred_disabled_pb(Client) ->
+    Expected = {error, <<"Operation 'map_reduce' is not enabled">>},
+    ?assertEqual(Expected, riakc_pb_socket:mapred(Client, <<"basic_test">>, [])).
 
 verify_list_buckets_enabled_pb(Client) ->
     {ok, Buckets} = riakc_pb_socket:list_buckets(Client),

--- a/tests/verify_feature_enable_flags.erl
+++ b/tests/verify_feature_enable_flags.erl
@@ -1,0 +1,86 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2016 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(verify_feature_enable_flags).
+
+-behavior(riak_test).
+-export([confirm/0]).
+-include_lib("eunit/include/eunit.hrl").
+
+%% Start with all job classes disabled - we'll slowly enable
+%% and verify all the flags over the course of the test
+-define(CFG, [{riak_core, [{job_accept_class, []}]}]).
+-define(JOB_CLASSES, [list_buckets, list_keys, secondary_index, map_reduce]).
+
+confirm() ->
+    lager:info("Deploying 1 node"),
+    [Node] = rt:deploy_nodes(1, ?CFG),
+    Client = rt:pbc(Node),
+
+    write_test_data(Client),
+
+    verify_features_disabled(Client),
+
+    ok = rpc:call(Node, application, set_env, [riak_core, job_accept_class, ?JOB_CLASSES]),
+    verify_features_enabled(Client),
+
+    pass.
+
+write_test_data(Client) ->
+    BasicObjs = make_objs(<<"basic_test">>),
+
+    [O1, O2, O3] = make_objs(<<"2i_test">>),
+    MD1 = riakc_obj:get_update_metadata(O2),
+    MD2 = riakc_obj:set_secondary_index(MD1, [{{integer_index, "test_idx"}, [42]}]),
+    O2WithIdx = riakc_obj:update_metadata(O2, MD2),
+    SecIdxObjs = [O1, O2WithIdx, O3],
+
+    MapRed1 = riakc_obj:new(<<"mapred_test">>, <<"mine">>, term_to_binary(["eggs", "bacon"])),
+    MapRed2 = riakc_obj:new(<<"mapred_test">>, <<"yours">>, term_to_binary(["bread", "bacon"])),
+    MapRedObjs = [MapRed1, MapRed2],
+
+    [ok = riakc_pb_socket:put(Client, O) || O <- BasicObjs ++ SecIdxObjs ++ MapRedObjs].
+
+make_objs(Bucket) ->
+    [riakc_obj:new(Bucket,
+                   list_to_binary([N + $1]), %% Keys = ["1", "2", "3"]
+                   list_to_binary([N + $A])) %% Vals = ["A", "B", "C"]
+     || N <- lists:seq(0, 2)].
+
+verify_features_disabled(Client) ->
+    verify_list_buckets_disabled(Client).
+    %%verify_list_keys_disabled(),
+    %%verify_secondary_index_disabled(),
+    %%verify_map_reduce_disabled().
+
+verify_features_enabled(Client) ->
+    verify_list_buckets_enabled(Client).
+    %%verify_list_keys_enabled(),
+    %%verify_secondary_index_enabled(),
+    %%verify_map_reduce_enabled().
+
+verify_list_buckets_disabled(Client) ->
+    Expected = {error, <<"Operation 'list_buckets' is not enabled">>},
+    ?assertEqual(Expected, riakc_pb_socket:list_buckets(Client)).
+
+verify_list_buckets_enabled(Client) ->
+    {ok, Buckets} = riakc_pb_socket:list_buckets(Client),
+    SortedBuckets = lists:sort(Buckets),
+    ?assertEqual(SortedBuckets, [<<"2i_test">>, <<"basic_test">>, <<"mapred_test">>]).

--- a/tests/verify_feature_enable_flags.erl
+++ b/tests/verify_feature_enable_flags.erl
@@ -95,8 +95,8 @@ verify_features_enabled_http(Client) ->
 verify_features_enabled_pb(Client) ->
     verify_list_buckets_enabled_pb(Client),
     verify_list_keys_enabled_pb(Client),
-    verify_secondary_index_enabled_pb(Client).
-    %%verify_map_reduce_enabled_pb().
+    verify_secondary_index_enabled_pb(Client),
+    verify_mapred_enabled_pb(Client).
 
 verify_list_buckets_disabled_pb(Client) ->
     Expected = {error, <<"Operation 'list_buckets' is not enabled">>},
@@ -128,6 +128,12 @@ verify_list_keys_enabled_pb(Client) ->
 verify_secondary_index_enabled_pb(Client) ->
     Result = riakc_pb_socket:get_index_eq(Client, <<"2i_test">>, {integer_index, "test_idx"}, 42),
     ?assertMatch({ok, {index_results_v1, [<<"2">>], _, _}}, Result).
+
+verify_mapred_enabled_pb(Client) ->
+    {ok, [{_, Results}]} = riakc_pb_socket:mapred(Client, <<"basic_test">>, []),
+    SortedResults = lists:sort(Results),
+    Expected = [{<<"basic_test">>, integer_to_binary(K)} || K <- lists:seq(1, 3)],
+    ?assertEqual(Expected, SortedResults).
 
 verify_list_buckets_disabled_http(Client) ->
     Result = rhc:list_buckets(Client),

--- a/tests/verify_job_enable_ac.erl
+++ b/tests/verify_job_enable_ac.erl
@@ -99,20 +99,20 @@ run_test(Client, Test) ->
     ?MODULE:Test(Client).
 
 verify_list_buckets_disabled_pb(Client) ->
-    Expected = {error, ?ERRMSG_LIST_BUCKETS_DISABLED},
+    Expected = {error, ?ERRMSG_BIN(?TOKEN_LIST_BUCKETS)},
     ?assertEqual(Expected, riakc_pb_socket:list_buckets(Client)).
 
 verify_list_keys_disabled_pb(Client) ->
-    Expected = {error, ?ERRMSG_LIST_KEYS_DISABLED},
+    Expected = {error, ?ERRMSG_BIN(?TOKEN_LIST_KEYS)},
     ?assertEqual(Expected, riakc_pb_socket:list_keys(Client, <<"basic_test">>)).
 
 verify_secondary_index_disabled_pb(Client) ->
-    Expected = {error, ?ERRMSG_SEC_INDEX_DISABLED},
+    Expected = {error, ?ERRMSG_BIN(?TOKEN_SEC_INDEX)},
     ?assertEqual(Expected, riakc_pb_socket:get_index(Client, <<"2i_test">>,
                                                      {integer_index, "test_idx"}, 42)).
 
 verify_mapred_disabled_pb(Client) ->
-    Expected = {error, ?ERRMSG_MAP_REDUCE_DISABLED},
+    Expected = {error, ?ERRMSG_BIN(?TOKEN_MAP_REDUCE)},
     ?assertEqual(Expected, riakc_pb_socket:mapred(Client, <<"basic_test">>, [])).
 
 verify_list_buckets_enabled_pb(Client) ->

--- a/tests/verify_job_enable_ac.erl
+++ b/tests/verify_job_enable_ac.erl
@@ -18,7 +18,8 @@
 %%
 %% -------------------------------------------------------------------
 
--module(verify_feature_enable_flags).
+%% Verify functionality of async job enable/disable flags in advanced.config.
+-module(verify_job_enable_ac).
 
 -behavior(riak_test).
 -compile(export_all).

--- a/tests/verify_job_enable_ac.erl
+++ b/tests/verify_job_enable_ac.erl
@@ -29,7 +29,7 @@
 
 %% Start with all job classes disabled - we'll slowly enable
 %% and verify all the flags over the course of the test
--define(CFG, [{riak_core, [{?ADVANCED_CONFIG_KEY, []}]}]).
+-define(CFG, [{riak_core, [{?APP_CONFIG_KEY, []}]}]).
 -define(ALL_BUCKETS, [<<"2i_test">>, <<"basic_test">>]).
 -define(BASIC_TEST_KEYS, [<<"1">>, <<"2">>, <<"3">>]).
 -define(JOB_CLASSES,
@@ -57,7 +57,7 @@ confirm() ->
 
     lager:info("Enabling all job classes"),
     ok = rpc:call(Node, application, set_env,
-        [riak_core, ?ADVANCED_CONFIG_KEY, ?JOB_CLASSES]),
+        [riak_core, ?APP_CONFIG_KEY, ?JOB_CLASSES]),
 
     run_tests(HttpClient, [verify_list_buckets_enabled_http,
                            verify_list_keys_enabled_http,

--- a/tests/verify_job_enable_ac.erl
+++ b/tests/verify_job_enable_ac.erl
@@ -32,12 +32,8 @@
 -define(CFG, [{riak_core, [{?ADVANCED_CONFIG_KEY, []}]}]).
 -define(ALL_BUCKETS, [<<"2i_test">>, <<"basic_test">>]).
 -define(BASIC_TEST_KEYS, [<<"1">>, <<"2">>, <<"3">>]).
--define(JOB_CLASSES, [
-    ?TOKEN_LIST_BUCKETS,
-    ?TOKEN_LIST_KEYS,
-    ?TOKEN_MAP_REDUCE,
-    ?TOKEN_SEC_INDEX
-]).
+-define(JOB_CLASSES,
+    [Class || {Class, Enabled} <- ?JOB_CLASS_DEFAULTS, Enabled]).
 
 confirm() ->
     lager:info("Deploying 1 node"),
@@ -99,11 +95,11 @@ run_test(Client, Test) ->
     ?MODULE:Test(Client).
 
 verify_list_buckets_disabled_pb(Client) ->
-    Expected = {error, ?ERRMSG_BIN(?TOKEN_LIST_BUCKETS)},
+    Expected = {error, ?ERRMSG_BIN(?TOKEN_LIST_BUCKETS_S)},
     ?assertEqual(Expected, riakc_pb_socket:list_buckets(Client)).
 
 verify_list_keys_disabled_pb(Client) ->
-    Expected = {error, ?ERRMSG_BIN(?TOKEN_LIST_KEYS)},
+    Expected = {error, ?ERRMSG_BIN(?TOKEN_LIST_KEYS_S)},
     ?assertEqual(Expected, riakc_pb_socket:list_keys(Client, <<"basic_test">>)).
 
 verify_secondary_index_disabled_pb(Client) ->

--- a/tests/verify_job_enable_rc.erl
+++ b/tests/verify_job_enable_rc.erl
@@ -34,15 +34,12 @@
     ?TOKEN_LIST_BUCKETS_S,
     ?TOKEN_LIST_KEYS,
     ?TOKEN_LIST_KEYS_S,
+    ?TOKEN_MAP_REDUCE,
+%   ?TOKEN_MAP_REDUCE_JS,
     ?TOKEN_SEC_INDEX,
     ?TOKEN_SEC_INDEX_S,
-    ?TOKEN_MAP_REDUCE,
+%   ?TOKEN_OLD_SEARCH,
     ?TOKEN_YZ_SEARCH
-%   ?TOKEN_OLD_SEARCH
-]).
--define(COMMON_CONFIG,  [
-    {"storage_backend", "leveldb"}, % required by ?TOKEN_SEC_INDEX above
-    {"search",          "on"}       % required by ?TOKEN_YZ_SEARCH above
 ]).
 
 %% ===================================================================

--- a/tests/verify_job_enable_rc.erl
+++ b/tests/verify_job_enable_rc.erl
@@ -1,6 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%% Copyright (c) 2012-2016 Basho Technologies, Inc.
+%% Copyright (c) 2016 Basho Technologies, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -19,190 +19,69 @@
 %% -------------------------------------------------------------------
 
 %% Verify functionality of async job enable/disable flags in riak.conf.
+%% Toggling flags at runtime is tested in verify_job_enable_ac.
 -module(verify_job_enable_rc).
 
 -behavior(riak_test).
 -export([confirm/0]).
 
-% exports for use by other tests
--export([
-    close_client/1,
-    listkeys_bucket/0,
-    open_client/2,
-    setup_cluster/1,
-    test_buckets/0,
-    test_keys/0,
-    test_operation/4,
-    undefined_bucket/0
-]).
-
 -include_lib("eunit/include/eunit.hrl").
+-include("job_enable_common.hrl").
 
--define(NUM_BUCKETS,        1200).
--define(NUM_KEYS,           1000).
--define(LISTKEYS_BUCKET,    <<"listkeys_bucket">>).
--define(UNDEFINED_BUCKET,   <<"880bf69d-5dab-44ee-8762-d24c6f759ce1">>).
+-define(TEST_ORDER, [true, false]).
+-define(TEST_OPS,   [
+    ?TOKEN_LIST_BUCKETS,
+    ?TOKEN_LIST_KEYS,
+    ?TOKEN_MAP_REDUCE,
+    ?TOKEN_SEC_INDEX
+%   ?TOKEN_YZ_SEARCH
+]).
 
 %% ===================================================================
 %% Test API
 %% ===================================================================
 
 confirm() ->
-    Config1 = {cuttlefish, [
-        {"async.enable.list_buckets",   "on"},
-        {"async.enable.list_keys",      "on"}
-    ]},
-    Config2 = {cuttlefish, [
-        {"async.enable.list_buckets",   "off"},
-        {"async.enable.list_keys",      "off"}
-    ]},
-    Config3 = {cuttlefish, [
-        {"async.enable.list_buckets",   "on"},
-        {"async.enable.list_keys",      "off"}
-    ]},
-    Config4 = {cuttlefish, [
-        {"async.enable.list_buckets",   "off"},
-        {"async.enable.list_keys",      "on"}
-    ]},
-    Configs = [Config1, Config2, Config3, Config4],
+    Configs = [
+        {current, {cuttlefish,
+            [{"storage_backend", "leveldb"}] ++ config(?TEST_OPS, Bool, [])}}
+        % make it a 4 node cluster so things get scattered around
+        % everything's enabled on the trailing nodes
+        || Bool <- ?TEST_ORDER ++ [true, true]],
 
     lager:info("Deploying ~b nodes ...", [erlang:length(Configs)]),
     Nodes = rt:deploy_nodes(Configs),
 
-    setup_cluster(Nodes),
+    job_enable_common:setup_cluster(Nodes),
 
-    Tests = [
-        {list_buckets,  [true, false, true, false]},
-        {list_keys,     [true, false, false, true]}
-    ],
-    [run_test(Op, Enabled, Nodes) || {Op, Enabled} <- Tests].
+    [run_test(Operation, ?TEST_ORDER, Nodes) || Operation <- ?TEST_OPS],
 
-run_test(Operation, [Switch | Switches], [Node | Nodes]) ->
-    Enabled = enabled_string(Switch),
-    [begin
-        lager:info("Tesing ~s ~s ~s on ~p", [Operation, Type, Enabled, Node]),
-        test_operation(Node, Operation, Switch, Type)
-     end || Type <- [pbc, http] ],
-    run_test(Operation, Switches, Nodes);
-run_test(_, [], []) ->
-    ok.
-
-%% ===================================================================
-%% Private API
-%% ===================================================================
-
-listkeys_bucket() ->
-    ?LISTKEYS_BUCKET.
-
-undefined_bucket() ->
-    ?UNDEFINED_BUCKET.
-
-test_buckets() ->
-    Key = {?MODULE, test_buckets},
-    case erlang:get(Key) of
-        undefined ->
-            New = binval_list(?NUM_BUCKETS, "Bucket", []),
-            erlang:put(Key, New),
-            New;
-        Val ->
-            Val
-    end.
-
-test_keys() ->
-    Key = {?MODULE, test_keys},
-    case erlang:get(Key) of
-        undefined ->
-            New = binval_list(?NUM_KEYS, "Key", []),
-            erlang:put(Key, New),
-            New;
-        Val ->
-            Val
-    end.
-
-open_client(http = Type, Node) ->
-    % HTTP connections are constant records, so re-use them
-    Key = {?MODULE, httpc, Node},
-    case erlang:get(Key) of
-        undefined ->
-            New = {Type, rhc, rt:httpc(Node)},
-            erlang:put(Key, New),
-            New;
-        Conn ->
-            Conn
-    end;
-open_client(pbc = Type, Node) ->
-    {Type, riakc_pb_socket, rt:pbc(Node)}.
-
-close_client({http, _Mod, _RHC}) ->
-    ok;
-close_client({pbc, Mod, PBC}) ->
-    Mod:stop(PBC).
-
-setup_cluster([Node | _] = Nodes) ->
-    lager:info("Creating a cluster of ~b nodes ...", [erlang:length(Nodes)]),
-    ?assertEqual(ok, rt:join_cluster(Nodes)),
-
-    lager:info("Writing some known data to the clusetr ..."),
-    PB = rt:pbc(Node),
-    lists:foreach(fun(Key) ->
-        riakc_pb_socket:put(PB,
-            riakc_obj:new(?LISTKEYS_BUCKET, Key, Key))
-    end, test_keys()),
-    lists:foreach(fun(Bucket) ->
-        riakc_pb_socket:put(PB,
-            riakc_obj:new(Bucket, <<"test_key">>, <<"test_value">>))
-    end, test_buckets()),
-    riakc_pb_socket:stop(PB),
-    ok.
-
-test_operation(Node, 'list_buckets', Enabled, ClientType) ->
-    {_, Mod, Conn} = Client = open_client(ClientType, Node),
-    {Status, Result} = Mod:list_buckets(Conn),
-    close_client(Client),
-    case Enabled of
-        true ->
-            ?assertEqual(ok, Status),
-            ?assertEqual(test_buckets(), lists:sort(Result));
-        false ->
-            Expect = <<"Operation 'list_buckets' is not enabled">>,
-            ?assertEqual(error, Status),
-            ?assertEqual(Expect, Result)
-%%            case ClientType of
-%%                pbc ->
-%%                    ?assertEqual(Expect, Result);
-%%                http ->
-%%                    ?assertEqual({"403", Expect}, Result)
-%%            end
-    end;
-
-test_operation(Node, 'list_keys', Enabled, ClientType) ->
-    {_, Mod, Conn} = Client = open_client(ClientType, Node),
-    {Status, Result} = Mod:list_keys(Conn, ?LISTKEYS_BUCKET),
-    close_client(Client),
-    case Enabled of
-        true ->
-            ?assertEqual(ok, Status),
-            ?assertEqual(test_keys(), lists:sort(Result));
-        false ->
-            Expect = <<"Operation 'list_keys' is not enabled">>,
-            ?assertEqual(error, Status),
-            ?assertEqual(Expect, Result)
-    end.
+    pass.
 
 %% ===================================================================
 %% Internal
 %% ===================================================================
 
-binval_list(0, _, Result) ->
-    Result;
-binval_list(Count, Prefix, Result) ->
-    binval_list((Count - 1), Prefix, [
-        erlang:list_to_binary([Prefix, erlang:integer_to_list(Count)])
-        | Result]).
+config([Operation | Operations], Bool, Result) ->
+    Key = lists:flatten(io_lib:format(?CUTTLEFISH_PREFIX ".~s", [Operation])),
+    Val = case Bool of
+        true ->
+            "on";
+        false ->
+            "off"
+    end,
+    config(Operations, Bool, [{Key, Val} | Result]);
+config([], _, Result) ->
+    Result.
 
-enabled_string(true) ->
-    "enabled";
-enabled_string(false) ->
-    "disabled".
+run_test(Operation, [Switch | Switches], [Node | Nodes]) ->
+    Enabled = job_enable_common:enabled_string(Switch),
+    [begin
+        lager:info("Tesing ~s ~s ~s on ~p", [Operation, Type, Enabled, Node]),
+        job_enable_common:test_operation(Node, Operation, Switch, Type)
+    end || Type <- [pbc, http] ],
+    run_test(Operation, Switches, Nodes);
+run_test(_, [], _) ->
+    ok.
 
 

--- a/tests/verify_job_enable_rc.erl
+++ b/tests/verify_job_enable_rc.erl
@@ -35,10 +35,10 @@
     ?TOKEN_LIST_KEYS,
     ?TOKEN_LIST_KEYS_S,
     ?TOKEN_MAP_REDUCE,
-%   ?TOKEN_MAP_REDUCE_JS,
+    ?TOKEN_MAP_REDUCE_JS,
     ?TOKEN_SEC_INDEX,
     ?TOKEN_SEC_INDEX_S,
-%   ?TOKEN_OLD_SEARCH,
+    ?TOKEN_OLD_SEARCH,
     ?TOKEN_YZ_SEARCH
 ]).
 
@@ -69,24 +69,16 @@ confirm() ->
 %% Internal
 %% ===================================================================
 
-config([{Mod, Op} | Operations], Bool, Result) ->
-    Key = lists:flatten(io_lib:format(?CUTTLEFISH_PREFIX ".~s.~s", [Mod, Op])),
-    Val = case Bool of
-        true ->
-            "enabled";
-        false ->
-            "disabled"
-    end,
-    config(Operations, Bool, [{Key, Val} | Result]);
+config([{App, Op} | Operations], Enabled, Result) ->
+    Key = lists:flatten(?CUTTLEFISH_KEY(App, Op)),
+    Val = job_enable_common:enabled_string(Enabled),
+    config(Operations, Enabled, [{Key, Val} | Result]);
 config([], _, Result) ->
     Result.
 
-run_test(Operation, [Switch | Switches], [Node | Nodes]) ->
-    Enabled = job_enable_common:enabled_string(Switch),
-    [begin
-        lager:info("Tesing ~p ~s ~s on ~p", [Operation, Type, Enabled, Node]),
-        job_enable_common:test_operation(Node, Operation, Switch, Type)
-    end || Type <- [pbc, http] ],
+run_test(Operation, [Enabled | Switches], [Node | Nodes]) ->
+    [job_enable_common:test_operation(Node, Operation, Enabled, ClientType)
+        || ClientType <- [pbc, http] ],
     run_test(Operation, Switches, Nodes);
 run_test(_, [], _) ->
     ok.

--- a/tests/verify_job_enable_rc.erl
+++ b/tests/verify_job_enable_rc.erl
@@ -1,0 +1,208 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2012-2016 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% Verify functionality of async job enable/disable flags in riak.conf.
+-module(verify_job_enable_rc).
+
+-behavior(riak_test).
+-export([confirm/0]).
+
+% exports for use by other tests
+-export([
+    close_client/1,
+    listkeys_bucket/0,
+    open_client/2,
+    setup_cluster/1,
+    test_buckets/0,
+    test_keys/0,
+    test_operation/4,
+    undefined_bucket/0
+]).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(NUM_BUCKETS,        1200).
+-define(NUM_KEYS,           1000).
+-define(LISTKEYS_BUCKET,    <<"listkeys_bucket">>).
+-define(UNDEFINED_BUCKET,   <<"880bf69d-5dab-44ee-8762-d24c6f759ce1">>).
+
+%% ===================================================================
+%% Test API
+%% ===================================================================
+
+confirm() ->
+    Config1 = {cuttlefish, [
+        {"async.enable.list_buckets",   "on"},
+        {"async.enable.list_keys",      "on"}
+    ]},
+    Config2 = {cuttlefish, [
+        {"async.enable.list_buckets",   "off"},
+        {"async.enable.list_keys",      "off"}
+    ]},
+    Config3 = {cuttlefish, [
+        {"async.enable.list_buckets",   "on"},
+        {"async.enable.list_keys",      "off"}
+    ]},
+    Config4 = {cuttlefish, [
+        {"async.enable.list_buckets",   "off"},
+        {"async.enable.list_keys",      "on"}
+    ]},
+    Configs = [Config1, Config2, Config3, Config4],
+
+    lager:info("Deploying ~b nodes ...", [erlang:length(Configs)]),
+    Nodes = rt:deploy_nodes(Configs),
+
+    setup_cluster(Nodes),
+
+    Tests = [
+        {list_buckets,  [true, false, true, false]},
+        {list_keys,     [true, false, false, true]}
+    ],
+    [run_test(Op, Enabled, Nodes) || {Op, Enabled} <- Tests].
+
+run_test(Operation, [Switch | Switches], [Node | Nodes]) ->
+    Enabled = enabled_string(Switch),
+    [begin
+        lager:info("Tesing ~s ~s ~s on ~p", [Operation, Type, Enabled, Node]),
+        test_operation(Node, Operation, Switch, Type)
+     end || Type <- [pbc, http] ],
+    run_test(Operation, Switches, Nodes);
+run_test(_, [], []) ->
+    ok.
+
+%% ===================================================================
+%% Private API
+%% ===================================================================
+
+listkeys_bucket() ->
+    ?LISTKEYS_BUCKET.
+
+undefined_bucket() ->
+    ?UNDEFINED_BUCKET.
+
+test_buckets() ->
+    Key = {?MODULE, test_buckets},
+    case erlang:get(Key) of
+        undefined ->
+            New = binval_list(?NUM_BUCKETS, "Bucket", []),
+            erlang:put(Key, New),
+            New;
+        Val ->
+            Val
+    end.
+
+test_keys() ->
+    Key = {?MODULE, test_keys},
+    case erlang:get(Key) of
+        undefined ->
+            New = binval_list(?NUM_KEYS, "Key", []),
+            erlang:put(Key, New),
+            New;
+        Val ->
+            Val
+    end.
+
+open_client(http = Type, Node) ->
+    % HTTP connections are constant records, so re-use them
+    Key = {?MODULE, httpc, Node},
+    case erlang:get(Key) of
+        undefined ->
+            New = {Type, rhc, rt:httpc(Node)},
+            erlang:put(Key, New),
+            New;
+        Conn ->
+            Conn
+    end;
+open_client(pbc = Type, Node) ->
+    {Type, riakc_pb_socket, rt:pbc(Node)}.
+
+close_client({http, _Mod, _RHC}) ->
+    ok;
+close_client({pbc, Mod, PBC}) ->
+    Mod:stop(PBC).
+
+setup_cluster([Node | _] = Nodes) ->
+    lager:info("Creating a cluster of ~b nodes ...", [erlang:length(Nodes)]),
+    ?assertEqual(ok, rt:join_cluster(Nodes)),
+
+    lager:info("Writing some known data to the clusetr ..."),
+    PB = rt:pbc(Node),
+    lists:foreach(fun(Key) ->
+        riakc_pb_socket:put(PB,
+            riakc_obj:new(?LISTKEYS_BUCKET, Key, Key))
+    end, test_keys()),
+    lists:foreach(fun(Bucket) ->
+        riakc_pb_socket:put(PB,
+            riakc_obj:new(Bucket, <<"test_key">>, <<"test_value">>))
+    end, test_buckets()),
+    riakc_pb_socket:stop(PB),
+    ok.
+
+test_operation(Node, 'list_buckets', Enabled, ClientType) ->
+    {_, Mod, Conn} = Client = open_client(ClientType, Node),
+    {Status, Result} = Mod:list_buckets(Conn),
+    close_client(Client),
+    case Enabled of
+        true ->
+            ?assertEqual(ok, Status),
+            ?assertEqual(test_buckets(), lists:sort(Result));
+        false ->
+            Expect = <<"Operation 'list_buckets' is not enabled">>,
+            ?assertEqual(error, Status),
+            ?assertEqual(Expect, Result)
+%%            case ClientType of
+%%                pbc ->
+%%                    ?assertEqual(Expect, Result);
+%%                http ->
+%%                    ?assertEqual({"403", Expect}, Result)
+%%            end
+    end;
+
+test_operation(Node, 'list_keys', Enabled, ClientType) ->
+    {_, Mod, Conn} = Client = open_client(ClientType, Node),
+    {Status, Result} = Mod:list_keys(Conn, ?LISTKEYS_BUCKET),
+    close_client(Client),
+    case Enabled of
+        true ->
+            ?assertEqual(ok, Status),
+            ?assertEqual(test_keys(), lists:sort(Result));
+        false ->
+            Expect = <<"Operation 'list_keys' is not enabled">>,
+            ?assertEqual(error, Status),
+            ?assertEqual(Expect, Result)
+    end.
+
+%% ===================================================================
+%% Internal
+%% ===================================================================
+
+binval_list(0, _, Result) ->
+    Result;
+binval_list(Count, Prefix, Result) ->
+    binval_list((Count - 1), Prefix, [
+        erlang:list_to_binary([Prefix, erlang:integer_to_list(Count)])
+        | Result]).
+
+enabled_string(true) ->
+    "enabled";
+enabled_string(false) ->
+    "disabled".
+
+

--- a/tests/verify_job_switch_defaults.erl
+++ b/tests/verify_job_switch_defaults.erl
@@ -1,0 +1,55 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2016 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(verify_job_switch_defaults).
+
+-behavior(riak_test).
+-export([confirm/0]).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("job_enable_common.hrl").
+
+%% ===================================================================
+%% Test API
+%% ===================================================================
+
+confirm() ->
+    Configs = [{current, {cuttlefish, ?COMMON_CONFIG}}],
+    lager:info("Deploying ~b nodes ...", [erlang:length(Configs)]),
+    [Node | _] = Nodes = rt:deploy_nodes(Configs),
+
+    job_enable_common:setup_cluster(Nodes),
+    job_enable_common:setup_yokozuna(Nodes),
+
+    [test_job_switch(Node, Class, Enabled)
+        || {Class, Enabled} <- ?JOB_CLASS_DEFAULTS],
+
+    pass.
+
+%% ===================================================================
+%% Internal
+%% ===================================================================
+
+test_job_switch(Node, Class, Enabled) ->
+    lager:info("verifying ~p default ~s",
+        [Class, job_enable_common:enabled_string(Enabled)]),
+    ?assertEqual(Enabled, job_enable_common:get_enabled(Node, Class)),
+    ?assertEqual(ok, job_enable_common:set_enabled(Node, Class, not Enabled)),
+    ?assertEqual(not Enabled, job_enable_common:get_enabled(Node, Class)).


### PR DESCRIPTION
Adds system-level tests for:
* RPC enable/disable management.
* Operation functionality through HTTP and protobuf interfaces.

Test Modules:
* verify_job_enable_ac
* verify_job_enable_rc
* verify_job_switch_defaults

Also adds `rt:random_uniform/0` and `rt:random_uniform/1` wrappers around `random:uniform/n` that ensure the process's PRNG is seeded _once_ with quality entropy.

Prerequisites:
- [x] [riak_core PR #851 (RIAK-2668)](https://github.com/basho/riak_core/pull/851)
- [x] [riak_kv PR #1459](https://github.com/basho/riak_kv/pull/1459)
- [x] [riak_search PR #184 (RIAK-1872) (RIAK-1920) (RIAK-1944) (RIAK-2349)](https://github.com/basho/riak_search/pull/184)
- [x] [yokozuna PR #671 (RIAK-2187)](https://github.com/basho/yokozuna/pull/671)
- [x] [riak PR #868](https://github.com/basho/riak/pull/868)
- [x] [riak_ee PR #405 (RIAK-1410)](https://github.com/basho/riak_ee/pull/405)
