### PR TITLE
Downgrade riak.conf to 1.3 repl_object_reformat

### DIFF
--- a/src/rtdev.erl
+++ b/src/rtdev.erl
@@ -155,6 +155,10 @@ upgrade(Node, NewVersion, Config) ->
     rt_config:set(rt_versions, VersionMap),
     case Config of
         same -> ok;
+        _ when is_function(Config) ->
+            RiakConfPath =
+                io_lib:format("~s/dev/dev~b/etc/riak.conf", [NewPath, N]),
+            Config(RiakConfPath);
         _ -> update_app_config(Node, Config)
     end,
     start(Node),

--- a/tests/replication_object_reformat.erl
+++ b/tests/replication_object_reformat.erl
@@ -82,7 +82,7 @@ verify_replication(AVersion, BVersion, Start, End, Realtime) ->
 
                           lager:info("Downgrading node ~p to previous.",
                                      [BFirst]),
-                          rt:upgrade(BFirst, previous),
+                          rt:upgrade(BFirst, previous, fun ts_updown_util:convert_riak_conf_to_1_3/1),
 
                           lager:info("Waiting for riak_kv to start on node ~p.",
                                      [BFirst]),
@@ -149,7 +149,7 @@ verify_replication(AVersion, BVersion, Start, End, Realtime) ->
 
             lager:info("Downgrading node ~p to previous.",
                        [BFirst]),
-            rt:upgrade(BFirst, previous),
+            rt:upgrade(BFirst, previous, fun ts_updown_util:convert_riak_conf_to_1_3/1),
 
             lager:info("Waiting for riak_kv to start on node ~p.",
                        [BFirst]),

--- a/tests/ts_updown_util.erl
+++ b/tests/ts_updown_util.erl
@@ -23,6 +23,7 @@
 -module(ts_updown_util).
 
 -export([
+         convert_riak_conf_to_1_3/1,
          setup/1,
          maybe_shutdown_client_node/1,
          run_scenarios/2,

--- a/tests/ts_updown_util.erl
+++ b/tests/ts_updown_util.erl
@@ -288,7 +288,8 @@ transition_node(Node, Version) ->
     end,
     ok = rt:wait_for_service(Node, riak_kv).
 
-%%
+%% riak.conf created under 1.4 cannot be read by 1.3 because the properties
+%% have been renamed so they need to be replaced with the 1.3 versions.
 convert_riak_conf_to_1_3(RiakConfPath) ->
     {ok, Content1} = file:read_file(RiakConfPath),
     Content2 = binary:replace(
@@ -302,7 +303,8 @@ convert_riak_conf_to_1_3(RiakConfPath) ->
     Content4 = convert_timeout_config_to_1_3(Content3),
     ok = file:write_file(RiakConfPath, Content4).
 
-%%
+%% The timeout property needs some special care because 1.3 uses 10000 for
+%% milliseconds and 1.4 uses 10s for a number and unit.
 convert_timeout_config_to_1_3(Content) ->
     Re =  "(riak_kv.query.timeseries.timeout)\s*=\s*([0-9]*)([smh])",
     re:replace(Content, Re, "timeseries_query_timeout_ms = 10000").


### PR DESCRIPTION
Based off of https://github.com/basho/riak_test/pull/1128

Convert riak.conf to 1.3 readable configuration when downgrading.