### PR TITLE
Update client libraries to use develop-2.2

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -15,8 +15,8 @@
         {getopt, ".*", {git, "git://github.com/jcomellas/getopt", {tag, "v0.4"}}},
         {meck, "0.8.2", {git, "git://github.com/basho/meck.git", {tag, "0.8.2"}}},
         {mapred_verify, ".*", {git, "git://github.com/basho/mapred_verify", {branch, "master"}}},
-        {riakc, "2.1.2", {git, "git://github.com/basho/riak-erlang-client", {tag, "2.1.2"}}},
-        {riakhttpc, ".*", {git, "git://github.com/basho/riak-erlang-http-client", {tag, "2.1.2"}}},
+        {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {branch, "develop-2.2"}}},
+        {riakhttpc, ".*", {git, "git://github.com/basho/riak-erlang-http-client", {branch, "develop-2.2"}}},
         {kvc, "1.3.0", {git, "https://github.com/etrepum/kvc", {tag, "v1.3.0"}}},
         {druuid, ".*", {git, "git://github.com/kellymclaughlin/druuid.git", {tag, "0.2"}}}
        ]}.


### PR DESCRIPTION
This pulls in the latest client code, as well as newer riak_pb stuff
which is needed for the latest develop-2.2 Riak code.
