### PR TITLE
Allow devrels to be looked up by name instead of alias

### DIFF
--- a/src/rt.erl
+++ b/src/rt.erl
@@ -65,6 +65,7 @@
          down/2,
          enable_search_hook/2,
          expect_in_log/2,
+         find_version_by_name/1,
          get_call_count/2,
          get_deps/0,
          get_ip/1,
@@ -1782,6 +1783,11 @@ get_version(Vsn) ->
 -spec get_version() -> binary().
 get_version() ->
     ?HARNESS:get_version().
+
+%% @doc Finds a list of all test nodes with a matching name.
+-spec find_version_by_name([binary()]) -> [atom()].
+find_version_by_name(Names) ->
+    ?HARNESS:find_version_by_name(Names).
 
 %% @doc Return all functions in the module as atoms that end with 'test'.
 -spec grep_test_functions(module()) -> [atom()].

--- a/src/rtdev.erl
+++ b/src/rtdev.erl
@@ -747,6 +747,27 @@ get_version(Vsn) ->
 get_version() ->
     get_version(current).
 
+%% Check all of the versions and find the devrel matching
+%% Any of the binary version names, e.g., <<"riak_ts-1.3.1">>
+find_version_by_name(Names) when is_list(Names) ->
+    Versions = rt:versions(),
+    Matches = lists:foldl(
+        fun(Name, Acc) ->
+            find_version_by_name(Versions, Name) ++ Acc
+        end, [], Names),
+    Matches.
+
+find_version_by_name(Versions, Name) ->
+    Match = lists:filter(
+        fun(Vsn) ->
+            NodeName = binary_to_list(rt:get_version(Vsn)),
+            case string:str(NodeName, Name) of
+                0 -> false;
+                _ -> true
+            end
+        end, Versions),
+    Match.
+
 teardown() ->
     rt_cover:maybe_stop_on_nodes(),
     %% Stop all discoverable nodes, not just nodes we'll be using for this test.

--- a/src/rtdev.erl
+++ b/src/rtdev.erl
@@ -760,13 +760,18 @@ find_version_by_name(Names) when is_list(Names) ->
 find_version_by_name(Versions, Name) ->
     Match = lists:filter(
         fun(Vsn) ->
-            NodeName = binary_to_list(rt:get_version(Vsn)),
+            NodeName = node_name_as_string(rt:get_version(Vsn)),
             case string:str(NodeName, Name) of
                 0 -> false;
                 _ -> true
             end
         end, Versions),
     Match.
+
+node_name_as_string(unknown) ->
+    "";
+node_name_as_string(BinName) when is_binary(BinName) ->
+    binary_to_list(BinName).
 
 teardown() ->
     rt_cover:maybe_stop_on_nodes(),


### PR DESCRIPTION
As long as the legacy version riak_ts-1.3.1 is installed, i.e., is in current, previous or legacy (or specially installed) this test should now pass.  Previously `ts_cluster_capabilities_SUITE` assumed a specially named devrel install of `riak_ts-1.3.1`.  This works better for GiddyUp and once the legacy version is no longer supported this test will start failing and should be updated or removed from the test suite.