### PR TITLE
Add back call to stop nodes before deleting index directories.

### DIFF
--- a/src/yokozuna_rt.erl
+++ b/src/yokozuna_rt.erl
@@ -243,6 +243,7 @@ brutal_kill_remove_index_dirs(Nodes, IndexName, Services) ->
 -spec remove_index_dirs([node()], index_name(), [atom()]) -> ok.
 remove_index_dirs(Nodes, IndexName, Services) ->
     IndexDirs = get_index_dirs(IndexName, Nodes),
+    [rt:stop(ANode) || ANode <- Nodes],
     remove_index_dirs2(Nodes, IndexDirs, Services),
     ok.
 


### PR DESCRIPTION
Somehow managed to pass on 2.0.7, but shouldn't have (and doesn't in 2.2.0).