### PR TITLE
Fix riak_kv_get_fsm intercept used by overload

### DIFF
--- a/intercepts/riak_kv_get_fsm_intercepts.erl
+++ b/intercepts/riak_kv_get_fsm_intercepts.erl
@@ -23,9 +23,9 @@
 -include("intercept.hrl").
 -define(M, riak_kv_get_fsm_orig).
 
-count_start_link_4(From, Bucket, Key, GetOptions) ->
-    ?I_INFO("sending startlink/4 through proxy"),
-    case ?M:start_link_orig(From, Bucket, Key, GetOptions) of
+count_start_4(From, Bucket, Key, GetOptions) ->
+    ?I_INFO("sending start/4 through proxy"),
+    case ?M:start_orig(From, Bucket, Key, GetOptions) of
         {error, overload} ->
             ?I_INFO("riak_kv_get_fsm not started due to overload.");
         {ok, _} ->

--- a/tests/overload.erl
+++ b/tests/overload.erl
@@ -263,7 +263,7 @@ run_test(Nodes, BKV) ->
     timer:sleep(5000),
     rt:load_modules_on_nodes([?MODULE], Nodes),
     overload_proxy:start_link(),
-    rt_intercept:add(Node1, {riak_kv_get_fsm, [{{start_link, 4}, count_start_link_4}]}),
+    rt_intercept:add(Node1, {riak_kv_get_fsm, [{{start, 4}, count_start_4}]}),
 
     Victim = get_victim(Node1, BKV),
     lager:info("Suspending vnode ~p/~p",


### PR DESCRIPTION
The get FSM normally uses `start/4` instead of `start_link/4` now, which
caused the overload test to break. Fixed the intercept name and all is
working again now.