### PR TITLE
Disable use of job enable flags for this test

### DIFF
--- a/tests/pb_security.erl
+++ b/tests/pb_security.erl
@@ -58,7 +58,8 @@ confirm() ->
                     {certfile, filename:join([CertDir,"site3.basho.com/cert.pem"])},
                     {keyfile, filename:join([CertDir, "site3.basho.com/key.pem"])},
                     {cacertfile, filename:join([CertDir, "site3.basho.com/cacerts.pem"])}
-                    ]}
+                    ]},
+                {job_accept_class, undefined}
                 ]},
             {riak_search, [
                            {enabled, true}


### PR DESCRIPTION
If we leave it up to the Cuttlefish defaults, we end up with search 1.0 being disabled, which causes this test to fail. Setting the config option to `undefined` causes us to revert to the old behavior of everything being enabled.