### PR TITLE
Modified rtdev:get_node_debug_logs to return filename and file handle

### DIFF
--- a/src/rtdev.erl
+++ b/src/rtdev.erl
@@ -801,7 +801,8 @@ get_node_debug_logs({_Node, NodeNum}) ->
     {ExitCode, Result} = wait_for_cmd(spawn_cmd(Cmd)),
     case ExitCode of
         0 ->
-            DebugLogFile;
+            {ok, Port} = file:open(DebugLogFile, [read, binary]),
+            {DebugLogFile, Port};
         _ ->
             exit({ExitCode, Result})
     end.


### PR DESCRIPTION
so that the debuglog archive can be uploaded.