### PR TITLE
Add copy_conf function and fix verify_riak_object_reformat test

### DIFF
--- a/src/rt.erl
+++ b/src/rt.erl
@@ -55,6 +55,7 @@
          cmd/2,
          connection_info/1,
          console/2,
+         copy_conf/3,
          count_calls/2,
          create_and_activate_bucket_type/3,
          del_dir/1,
@@ -1695,6 +1696,10 @@ attach_direct(Node, Expected) ->
 %% @see rt:attach/2
 console(Node, Expected) ->
     ?HARNESS:console(Node, Expected).
+
+%% @doc Copies config files from one set of nodes to another
+copy_conf(NumNodes, FromVersion, ToVersion) ->
+    ?HARNESS:copy_conf(NumNodes, FromVersion, ToVersion).
 
 %%%===================================================================
 %%% Search

--- a/src/rtdev.erl
+++ b/src/rtdev.erl
@@ -178,6 +178,21 @@ upgrade(Node, NewVersion, Config, UpgradeCallback) ->
     rt:wait_until_pingable(Node),
     ok.
 
+-spec copy_conf(integer(), atom() | string(), atom() | string()) -> ok.
+copy_conf(NumNodes, FromVersion, ToVersion) ->
+    lager:info("Copying config from ~p to ~p", [FromVersion, ToVersion]),
+
+    FromPath = relpath(FromVersion),
+    ToPath = relpath(ToVersion),
+
+    [copy_node_conf(N, FromPath, ToPath) || N <- lists:seq(1, NumNodes)].
+
+copy_node_conf(NodeNum, FromPath, ToPath) ->
+    Command = io_lib:format("cp -p -P -R \"~s/dev/dev~b/etc\" \"~s/dev/dev~b\"",
+                            [FromPath, NodeNum, ToPath, NodeNum]),
+    os:cmd(Command),
+    ok.
+
 -spec set_conf(atom() | string(), [{string(), string()}]) -> ok.
 set_conf(all, NameValuePairs) ->
     lager:info("rtdev:set_conf(all, ~p)", [NameValuePairs]),

--- a/src/rtssh.erl
+++ b/src/rtssh.erl
@@ -282,6 +282,9 @@ upgrade(Node, NewVersion, Config, _UpgradeCallback) ->
     rt:wait_until_pingable(Node),
     ok.
 
+copy_conf(_, _, _) ->
+    throw({error, not_implemented}).
+
 run_riak(Node, Cmd) ->
     Exec = riakcmd(Node, Cmd),
     lager:info("Running: ~s :: ~s", [get_host(Node), Exec]),

--- a/tests/verify_riak_object_reformat.erl
+++ b/tests/verify_riak_object_reformat.erl
@@ -37,7 +37,7 @@ confirm() ->
 
     %% Use previous version's riak.conf so that when we
     %% downgrade we don't crash on unknown config keys:
-    rtdev:copy_conf(?N, previous, current),
+    rt:copy_conf(?N, previous, current),
 
     Nodes = [Node1|_] = rt:build_cluster(?N),
 

--- a/tests/verify_riak_object_reformat.erl
+++ b/tests/verify_riak_object_reformat.erl
@@ -34,6 +34,11 @@ confirm() ->
     rt:update_app_config(all, [{riak_kv, [{object_format, v1}]}]),
     TestMetaData = riak_test_runner:metadata(),
     DowngradeVsn = proplists:get_value(upgrade_version, TestMetaData, previous),
+
+    %% Use previous version's riak.conf so that when we
+    %% downgrade we don't crash on unknown config keys:
+    rtdev:copy_conf(?N, previous, current),
+
     Nodes = [Node1|_] = rt:build_cluster(?N),
 
     [rt:wait_until_capability(N, {riak_kv, object_format}, v1, v0) || N <- Nodes],


### PR DESCRIPTION
The new `copy_conf` utility function copies config from one devrel to another. This is particularly useful when the first thing a test does is downgrade to a previous release which doesn't support some new config option that's been recently added. By copying the old config into the new devrel before we start up the nodes, we can automatically avoid specifying any new, incompatible config keys for that particular test.

This PR also uses `copy_conf` to fix the `verify_riak_object_reformat` test, which had been failing during the initial downgrade due to unrecognized cuttlefish keys.