### PR TITLE
Improve join cluster retry logic

### DIFF
--- a/src/rt.erl
+++ b/src/rt.erl
@@ -467,38 +467,38 @@ staged_join(Node, PNode) ->
     ?assertEqual(ok, join_with_retry(Fun)),
     ok.
 
-plan_and_commit(Node) ->
+plan_and_commit(Node, AllNodes) ->
     timer:sleep(500),
     lager:info("planning cluster join"),
     case rpc:call(Node, riak_core_claimant, plan, []) of
         {error, ring_not_ready} ->
             lager:info("plan: ring not ready"),
             timer:sleep(100),
-            plan_and_commit(Node);
+            plan_and_commit(Node, AllNodes);
         {ok, _, _} ->
             lager:info("plan: done"),
-            do_commit(Node)
+            do_commit(Node, AllNodes)
     end.
 
-do_commit(Node) ->
+do_commit(Node, AllNodes) ->
     lager:info("planning cluster commit"),
     case rpc:call(Node, riak_core_claimant, commit, []) of
         {error, plan_changed} ->
             lager:info("commit: plan changed"),
             timer:sleep(100),
             maybe_wait_for_changes(Node),
-            plan_and_commit(Node);
+            plan_and_commit(Node, AllNodes);
         {error, ring_not_ready} ->
             lager:info("commit: ring not ready"),
             timer:sleep(100),
             maybe_wait_for_changes(Node),
-            do_commit(Node);
+            do_commit(Node, AllNodes);
         {error, nothing_planned} ->
             %% Assume plan actually committed somehow
             lager:info("commit: nothing planned"),
             ok;
         ok ->
-            ok
+            try_nodes_ready(AllNodes)
     end.
 
 maybe_wait_for_changes(Node) ->
@@ -1187,8 +1187,7 @@ join_cluster(Nodes) ->
             %% ok do a staged join and then commit it, this eliminates the
             %% large amount of redundant handoff done in a sequential join
             [staged_join(Node, Node1) || Node <- OtherNodes],
-            plan_and_commit(Node1),
-            try_nodes_ready(Nodes)
+            ?assertEqual(ok, wait_until(fun() -> ok == plan_and_commit(Node1, Nodes) end))
     end,
 
     ?assertEqual(ok, wait_until_nodes_ready(Nodes)),
@@ -1216,9 +1215,9 @@ product(Node) ->
 try_nodes_ready(Nodes) ->
     try_nodes_ready(Nodes, 10, 500).
 
-try_nodes_ready([Node1 | _Nodes], 0, _SleepMs) ->
-    lager:info("Nodes not ready after initial plan/commit, retrying"),
-    plan_and_commit(Node1);
+try_nodes_ready(_Nodes, 0, _SleepMs) ->
+    lager:info("Nodes not ready after plan/commit, retrying"),
+    not_ready;
 try_nodes_ready(Nodes, N, SleepMs) ->
     ReadyNodes = [Node || Node <- Nodes, is_ready(Node) =:= true],
     case ReadyNodes of

--- a/src/rt.erl
+++ b/src/rt.erl
@@ -1189,8 +1189,6 @@ join_cluster(Nodes) ->
             ?assertEqual(ok, wait_until(fun() -> ok == plan_and_commit(Node1, Nodes) end))
     end,
 
-    ?assertEqual(ok, wait_until_nodes_ready(Nodes)),
-
     %% Ensure each node owns a portion of the ring
     wait_until_nodes_agree_about_ownership(Nodes),
     ?assertEqual(ok, wait_until_no_pending_changes(Nodes)),

--- a/src/rt.erl
+++ b/src/rt.erl
@@ -1188,7 +1188,7 @@ join_cluster(Nodes) ->
             %% large amount of redundant handoff done in a sequential join
             [staged_join(Node, Node1) || Node <- OtherNodes],
             plan_and_commit(Node1),
-            try_nodes_ready(Nodes, 3, 500)
+            try_nodes_ready(Nodes)
     end,
 
     ?assertEqual(ok, wait_until_nodes_ready(Nodes)),
@@ -1212,6 +1212,9 @@ product(Node) ->
        HasRiak -> riak;
        true -> unknown
     end.
+
+try_nodes_ready(Nodes) ->
+    try_nodes_ready(Nodes, 3, 500).
 
 try_nodes_ready([Node1 | _Nodes], 0, _SleepMs) ->
     lager:info("Nodes not ready after initial plan/commit, retrying"),

--- a/src/rt.erl
+++ b/src/rt.erl
@@ -494,9 +494,8 @@ do_commit(Node, AllNodes) ->
             maybe_wait_for_changes(Node),
             do_commit(Node, AllNodes);
         {error, nothing_planned} ->
-            %% Assume plan actually committed somehow
-            lager:info("commit: nothing planned"),
-            ok;
+            lager:info("commit: nothing planned...why???"),
+            {error, nothing_planned};
         ok ->
             try_nodes_ready(AllNodes)
     end.

--- a/src/rt.erl
+++ b/src/rt.erl
@@ -1214,7 +1214,7 @@ product(Node) ->
     end.
 
 try_nodes_ready(Nodes) ->
-    try_nodes_ready(Nodes, 3, 500).
+    try_nodes_ready(Nodes, 10, 500).
 
 try_nodes_ready([Node1 | _Nodes], 0, _SleepMs) ->
     lager:info("Nodes not ready after initial plan/commit, retrying"),


### PR DESCRIPTION
There is a weird issue we've repeatedly seen during testing where we end up planning and committing a join during cluster setup, only to get back `{error, nothing_planned}`. The current code ends up ignoring and continuing on if it happens more than once, yet sometimes it seems the plan really didn't commit for whatever reason. I'm not sure if retrying more times will fix the issue...but it should at least shed some light on whether we're just seeing the problem coincidentally occur twice in a row, or whether the cluster is getting stuck in some kind of bad state where no amount of retrying will get us unstuck.

We should still address this issue on the Riak side eventually, but it's been present for multiple releases now with no sign of immediate harm. So even if these changes don't help us resolve the issue, it might at least cut down on the number of false positives we're seeing during release testing.

This PR also ends up simplifying some of the riak_test join code a little bit.