### PR TITLE
Fix for replication_upgrade and replication2_upgrade tests

### DIFF
--- a/tests/replication2_upgrade.erl
+++ b/tests/replication2_upgrade.erl
@@ -74,7 +74,7 @@ confirm() ->
     ok = lists:foreach(fun(Node) ->
                                lager:info("Upgrade node: ~p", [Node]),
                                rt:log_to_nodes(Nodes, "Upgrade node: ~p", [Node]),
-                               rtdev:upgrade(Node, current),
+                               rt:upgrade(Node, current),
                                %% The upgrade did a wait for pingable
                                rt:wait_for_service(Node, [riak_kv, riak_pipe, riak_repl]),
                                [rt:wait_until_ring_converged(N) || N <- [ANodes, BNodes]],

--- a/tests/replication_upgrade.erl
+++ b/tests/replication_upgrade.erl
@@ -66,7 +66,7 @@ confirm() ->
     ok = lists:foreach(fun(Node) ->
                                lager:info("Upgrade node: ~p", [Node]),
                                rt:log_to_nodes(Nodes, "Upgrade node: ~p", [Node]),
-                               rtdev:upgrade(Node, current),
+                               rt:upgrade(Node, current),
                                rt:wait_until_pingable(Node),
                                rt:wait_for_service(Node, [riak_kv, riak_pipe, riak_repl]),
                                [rt:wait_until_ring_converged(N) || N <- [ANodes, BNodes]],


### PR DESCRIPTION
Changed call from rtdev:upgrade to rt:upgrade, which has the expected signature
