### PR TITLE
Revert changes to plan/commit retry logic

### DIFF
--- a/src/rt.erl
+++ b/src/rt.erl
@@ -494,8 +494,9 @@ do_commit(Node, AllNodes) ->
             maybe_wait_for_changes(Node),
             do_commit(Node, AllNodes);
         {error, nothing_planned} ->
-            lager:info("commit: nothing planned...why???"),
-            {error, nothing_planned};
+            %% Assume plan actually committed somehow
+            lager:info("commit: nothing planned"),
+            ok;
         ok ->
             try_nodes_ready(AllNodes)
     end.

--- a/src/rt.erl
+++ b/src/rt.erl
@@ -1189,6 +1189,8 @@ join_cluster(Nodes) ->
             ?assertEqual(ok, wait_until(fun() -> ok == plan_and_commit(Node1, Nodes) end))
     end,
 
+    ?assertEqual(ok, wait_until_nodes_ready(Nodes)),
+
     %% Ensure each node owns a portion of the ring
     wait_until_nodes_agree_about_ownership(Nodes),
     ?assertEqual(ok, wait_until_no_pending_changes(Nodes)),


### PR DESCRIPTION
This is a partial revert of #1153. The changes that were made to the retry logic did not work around the problem, and instead would cause the test to fall into an infinite loop. The bug we're trying to work around seems to be occurring when the ring is overwritten by some other operation, causing the planned "join" operations to be lost. Thus, trying to plan and commit again just causes us to once again get back "nothing planned".

The changes to the `try_node_ready` retry logic should still be helpful though, so we're not reverting the entirety of #1153, just the last several commits.