### PR TITLE
Fix intermittent failure in w1c part of overload test (and do some misc code cleanups)

### DIFF
--- a/tests/overload.erl
+++ b/tests/overload.erl
@@ -81,15 +81,13 @@ default_config(#config{
         {riak_api, [{pb_backlog, 1024}]}].
 
 confirm() ->
-    Nodes = setup(),
+    [Node1 | _] = Nodes = setup(),
 
     ok = create_bucket_type(Nodes, ?NORMAL_TYPE, [{n_val, 3}]),
     ok = create_bucket_type(Nodes, ?CONSISTENT_TYPE, [{consistent, true}, {n_val, 5}]),
     ok = create_bucket_type(Nodes, ?WRITE_ONCE_TYPE, [{write_once, true}, {n_val, 1}]),
-    rt:wait_until(ring_manager_check_fun(hd(Nodes))),
+    rt:wait_until(ring_manager_check_fun(Node1)),
 
-
-    Node1 = hd(Nodes),
     write_once(Node1, ?NORMAL_BKV),
     write_once(Node1, ?CONSISTENT_BKV),
     write_once(Node1, ?WRITE_ONCE_BKV),

--- a/tests/overload.erl
+++ b/tests/overload.erl
@@ -86,7 +86,6 @@ confirm() ->
     ok = create_bucket_type(Nodes, ?NORMAL_TYPE, [{n_val, 3}]),
     ok = create_bucket_type(Nodes, ?CONSISTENT_TYPE, [{consistent, true}, {n_val, 5}]),
     ok = create_bucket_type(Nodes, ?WRITE_ONCE_TYPE, [{write_once, true}, {n_val, 1}]),
-    rt:wait_until(ring_manager_check_fun(Node1)),
 
     write_once(Node1, ?NORMAL_BKV),
     write_once(Node1, ?CONSISTENT_BKV),

--- a/tests/overload.erl
+++ b/tests/overload.erl
@@ -136,8 +136,8 @@ test_no_overload_protection(Nodes, BKV) ->
     lager:info("Testing with no overload protection"),
     ProcFun = build_predicate_eq(test_no_overload_protection, ?NUM_REQUESTS,
                                   "ProcFun", "Procs"),
-    QueueFun = build_predicate_gte(test_no_overload_protection, ?NUM_REQUESTS,
-                                   "QueueFun", "Queue Size"),
+    QueueFun = build_predicate_eq(test_no_overload_protection, ?NUM_REQUESTS,
+                                  "QueueFun", "Queue Size"),
     verify_test_results(run_test(Nodes, BKV), BKV, ProcFun, QueueFun).
 
 verify_test_results({_NumProcs, QueueLen}, {?CONSISTENT_BUCKET, _, _}, _ProcFun, QueueFun) ->

--- a/tests/overload.erl
+++ b/tests/overload.erl
@@ -114,7 +114,7 @@ setup() ->
 test_no_overload_protection(_Nodes, ?CONSISTENT_BKV) ->
     ok;
 test_no_overload_protection(Nodes, BKV) ->
-    lager:info("Setting default configuration for no overload protestion test."),
+    lager:info("Setting default configuration for no overload protection test."),
     rt:pmap(fun(Node) ->
         rt:update_app_config(Node, default_config())
     end, Nodes),

--- a/tests/overload.erl
+++ b/tests/overload.erl
@@ -548,12 +548,6 @@ run_count(Node) ->
     lager:info("fsm count:~p", [get_num_running_gen_fsm(Node)]),
     run_count(Node).
 
-run_queue_len({Idx, Node}) ->
-    timer:sleep(500),
-    Len = vnode_queue_len(Node, Idx),
-    lager:info("queue len on ~p is:~p", [Node, Len]),
-    run_queue_len({Idx, Node}).
-
 get_num_running_gen_fsm(Node) ->
     Procs = rpc:call(Node, erlang, processes, []),
     ProcInfo = [ rpc:call(Node, erlang, process_info, [P]) || P <- Procs, P /= undefined ],

--- a/tests/overload.erl
+++ b/tests/overload.erl
@@ -291,10 +291,10 @@ run_test(Nodes, BKV) ->
     overload_proxy:stop(),
     {NumProcs2 - NumProcs1, QueueLen}.
 
-get_victim(ExcludeNode, {Bucket, Key, _}) ->
+get_victim(Node, {Bucket, Key, _}) ->
     Hash = riak_core_util:chash_std_keyfun({Bucket, Key}),
-    PL = lists:sublist(riak_core_ring:preflist(Hash, rt:get_ring(ExcludeNode)), 5),
-    hd([IdxNode || {_, Node}=IdxNode <- PL, Node /= ExcludeNode]).
+    PL = riak_core_ring:preflist(Hash, rt:get_ring(Node)),
+    hd(PL).
 
 ring_manager_check_fun(Node) ->
     fun() ->


### PR DESCRIPTION
This PR (probably) addresses this test failure:

http://giddyup.basho.com/#/projects/riak_ee/scorecards/284/284-1884-overload-centos-6-64-memory/266291/artifacts/11106706

My hypothesis to explain the test failure is that it was caused by the way the `get_victim` function is implemented and used. I haven't been able to confirm this 100% for sure, but by tweaking the code to force picking the wrong node in `get_victim`, I was able to trigger a test failure that appeared identical.

There's no reason I can find to rule out any particular vnode when choosing the victim. The way this function is used in this test, it seems we're trying to make sure we pick a vnode on a different node from the one we're connecting to, but I removed this check and forced it to pick a vnode on the same node, and the test still passed fine.

So the place this causes trouble then is the w1c tests, because there we use n=1; if we skip the first entry in the preflist because it's on the excluded node, then we will pick a victim vnode that is not actually being read from by the get fsms, and the test will fail.

This PR also includes a couple other commits with some misc code cleanups that I added while I was working on the test.