### PR TITLE
Fixed ts_simple_select_iso8601 to include both pass and failing cases

### DIFF
--- a/tests/ts_simple_select_iso8601.erl
+++ b/tests/ts_simple_select_iso8601.erl
@@ -31,7 +31,7 @@
 -define(LOWER, "2016-08-02 10:15:00").
 -define(UPPER, "2016-08-02 10:45:00").
 
--define(TESTS, [
+-define(PASS_TESTS, [
                 %% Test format, illustrated:
 
                 %% We expect 9 seconds between 10:19:50 and 10:20:00,
@@ -69,15 +69,17 @@
                 },
 
                 {0,
-                 {">", "2016-08-02 10:19"},
-                 {"<", "2016-08-02 10:20"}
-                },
-
-                {0,
                  {">", "2016-08-02 10:19.99"},
                  {"<", "2016-08-02 10:20"}
                 }
                ]).
+
+-define(FAIL_TESTS, [
+                {0,
+                  {">", "2016-08-02 10:19"},
+                  {"<", "2016-08-02 10:20"}
+                }
+              ]).
 
 
 
@@ -107,5 +109,17 @@ confirm() ->
               {ok, {_Cols, Data}} = ts_util:single_query(Conn, Qry),
 
               ?assertEqual(Tally, length(Data))
-      end, ?TESTS),
+      end, ?PASS_TESTS),
+
+    lists:foreach(
+      fun({_Tally, {Op1, String1}, {Op2, String2}}) ->
+              Qry = lists:flatten(
+                      io_lib:format(QryFmt, [Op1, String1,
+                                             Op2, String2])),
+
+              RetMsg = ts_util:single_query(Conn, Qry),
+              %% Assert that RetMsg returns a tuple with error in first place {error, {}}
+              ?assertMatch({error, {_ErrCode, _ErrMsg}}, RetMsg)
+      end, ?FAIL_TESTS),
+
     pass.

--- a/tests/ts_simple_select_iso8601.erl
+++ b/tests/ts_simple_select_iso8601.erl
@@ -76,6 +76,7 @@
 
 -define(FAIL_TESTS, [
                 {
+                  {1001,<<"The upper and lower boundaries are equal or adjacent. No results are possible.">>},
                   {">", "2016-08-02 10:19"},
                   {"<", "2016-08-02 10:20"}
                 }
@@ -112,14 +113,14 @@ confirm() ->
       end, ?PASS_TESTS),
 
     lists:foreach(
-      fun({{Op1, String1}, {Op2, String2}}) ->
+      fun({{ErrCode, ErrMsg}, {Op1, String1}, {Op2, String2}}) ->
               Qry = lists:flatten(
                       io_lib:format(QryFmt, [Op1, String1,
                                              Op2, String2])),
 
               RetMsg = ts_util:single_query(Conn, Qry),
-              %% Assert that RetMsg returns a tuple with error in first place {error, {}}
-              ?assertMatch({error, {_ErrCode, _ErrMsg}}, RetMsg)
+              ExpectMsg = {error, {ErrCode, ErrMsg}},
+              ?assertMatch(ExpectMsg, RetMsg)
       end, ?FAIL_TESTS),
 
     pass.

--- a/tests/ts_simple_select_iso8601.erl
+++ b/tests/ts_simple_select_iso8601.erl
@@ -73,10 +73,10 @@
                  {"<", "2016-08-02 10:20"}
                 }
                ]).
-
+%% expected error code is the first entry
 -define(FAIL_TESTS, [
                 {
-                  {1001,<<"The upper and lower boundaries are equal or adjacent. No results are possible.">>},
+                  1001,
                   {">", "2016-08-02 10:19"},
                   {"<", "2016-08-02 10:20"}
                 }
@@ -113,14 +113,13 @@ confirm() ->
       end, ?PASS_TESTS),
 
     lists:foreach(
-      fun({{ErrCode, ErrMsg}, {Op1, String1}, {Op2, String2}}) ->
+      fun({ErrCode, {Op1, String1}, {Op2, String2}}) ->
               Qry = lists:flatten(
                       io_lib:format(QryFmt, [Op1, String1,
                                              Op2, String2])),
 
               RetMsg = ts_util:single_query(Conn, Qry),
-              ExpectMsg = {error, {ErrCode, ErrMsg}},
-              ?assertMatch(ExpectMsg, RetMsg)
+              ?assertMatch({error, {ErrCode, _}}, RetMsg)
       end, ?FAIL_TESTS),
 
     pass.

--- a/tests/ts_simple_select_iso8601.erl
+++ b/tests/ts_simple_select_iso8601.erl
@@ -75,7 +75,7 @@
                ]).
 
 -define(FAIL_TESTS, [
-                {0,
+                {
                   {">", "2016-08-02 10:19"},
                   {"<", "2016-08-02 10:20"}
                 }
@@ -112,7 +112,7 @@ confirm() ->
       end, ?PASS_TESTS),
 
     lists:foreach(
-      fun({_Tally, {Op1, String1}, {Op2, String2}}) ->
+      fun({{Op1, String1}, {Op2, String2}}) ->
               Qry = lists:flatten(
                       io_lib:format(QryFmt, [Op1, String1,
                                              Op2, String2])),


### PR DESCRIPTION
So here is what I got with testing the test:

```
14:41:52.751 [info] <0.332.0> 3 - Now run the query SELECT * FROM GeoCheckin WHERE time > '2016-08-02 10:19' and time < '2016-08-02 10:20' AND myfamily = 'family1' AND myseries ='seriesX' 
14:41:52.752 [info] <0.332.0> Result is {error,{1001,<<"The upper and lower boundaries are equal or adjacent. No results are possible.">>}}
14:41:52.752 [notice] <0.2.0> ts_simple_select_iso8601 Test Run Complete pass
```

@javajolt @macintux 
