### PR TITLE
fixed riak_control test to handle riak_ts

### DIFF
--- a/tests/riak_control.erl
+++ b/tests/riak_control.erl
@@ -114,6 +114,7 @@ verify_resource(Node0, Resource) ->
     Node = rt:http_url(Node0),
     Output = os:cmd(io_lib:format("curl -s -S ~s~p", [Node, Resource])),
     lager:info("Verifying node ~p resource ~p.", [Node, Resource]),
+    lager:info("~p~n", [mochijson2:decode(Output)]),
     mochijson2:decode(Output).
 
 %% @doc Verify that riak_kv is still running on all nodes.
@@ -190,6 +191,11 @@ validate_partitions({ControlVsn, ControlNode}, VersionedNodes) ->
                              [{<<"partitions">>, NodePartitions},
                                  {<<"default_n_val">>, _}]} = verify_resource(ControlNode, "/admin/partitions"),
                          NodePartitions;
+                     <<"riak_ts", _/binary>> ->
+                         {struct,
+                              [{<<"partitions">>, NodePartitions},
+                                  {<<"default_n_val">>, _}]} = verify_resource(ControlNode, "/admin/partitions"),
+                             NodePartitions;
                      _ ->
                          {struct,
                              [{<<"partitions">>, NodePartitions}]} = verify_resource(ControlNode, "/admin/partitions"),
@@ -203,6 +209,8 @@ validate_partitions({ControlVsn, ControlNode}, VersionedNodes) ->
         <<"riak_ee-2.", _/binary>> ->
             true;
         <<"riak-2.", _/binary>> ->
+            true;
+        <<"riak_ts", _/binary>> ->
             true;
         _ ->
             MixedCluster = mixed_cluster(VersionedNodes),

--- a/tests/riak_control.erl
+++ b/tests/riak_control.erl
@@ -114,7 +114,6 @@ verify_resource(Node0, Resource) ->
     Node = rt:http_url(Node0),
     Output = os:cmd(io_lib:format("curl -s -S ~s~p", [Node, Resource])),
     lager:info("Verifying node ~p resource ~p.", [Node, Resource]),
-    lager:info("~p~n", [mochijson2:decode(Output)]),
     mochijson2:decode(Output).
 
 %% @doc Verify that riak_kv is still running on all nodes.


### PR DESCRIPTION
@javajolt ok the diff looks better now, fixed riak_control to handle riak_ts version the same way it handles riak-2. and riak_ee-2.
Test results:
Test Results:
## riak_control-eleveldb: pass

0 Tests Failed
1 Tests Passed
That's 100.0% for those keeping score
