### PR TITLE
fixed riak_control_authentication to handle riak_ts version

### DIFF
--- a/tests/riak_control_authentication.erl
+++ b/tests/riak_control_authentication.erl
@@ -99,6 +99,8 @@ determine_test_suite(Vsn) ->
             verify_authentication_post20(Vsn);
         <<"riak-2.", _/binary>> ->
             verify_authentication_post20(Vsn);
+        <<"riak_ts", _/binary>> ->
+            verify_authentication_post20(Vsn);
         _ ->
             verify_authentication_pre20(Vsn)
     end.


### PR DESCRIPTION
riak_control_authentication now handle riak_ts version @javajolt 
Test Results:
## riak_control_authentication-eleveldb: pass

0 Tests Failed
1 Tests Passed
That's 100.0% for those keeping score
