### PR TITLE
Add Status field to SQL "SHOW TABLES" result

### DIFF
--- a/tests/ts_simple_pb_security_SUITE.erl
+++ b/tests/ts_simple_pb_security_SUITE.erl
@@ -752,11 +752,11 @@ with_security_when_user_is_given_permissions_user_can_show_tables_test(Ctx) ->
     {ok, {Columns, Rows}} = riakc_ts:query(Pid, "SHOW TABLES"),
     {_Saver, TableList} = ?config(saved_config, Ctx),
     ?assertEqual(
-        [<<"Table">>],
+        [<<"Table">>, <<"Status">>],
         Columns
     ),
-    ?assertEqual(
-        lists:sort(Rows),
-        lists:sort(TableList)
-    ),
+    ActualRows = lists:sort(Rows),
+    ExpectedRows = [{TableName, <<"Active">>} ||
+        {TableName} <- lists:sort(TableList) ],
+    ?assertEqual(ExpectedRows, ActualRows),
     add_no_table_to_list(Ctx).

--- a/tests/ts_simple_show_tables.erl
+++ b/tests/ts_simple_show_tables.erl
@@ -50,8 +50,10 @@ confirm() ->
         end,
         Tables),
     Got1 = ts_ops:query(Cluster, "SHOW TABLES"),
+    ExpectedRows = [{TableName, <<"Active">>} ||
+        {TableName} <- lists:sort(Tables) ],
     ?assertEqual(
-        {ok, {[<<"Table">>], lists:usort(Tables)}},
+        {ok, {[<<"Table">>, <<"Status">>], ExpectedRows}},
         Got1
     ),
     pass.


### PR DESCRIPTION
- added Status field to SQL "SHOW TABLES" result.

Related PRs:
- https://github.com/basho/riak_kv/pull/1514
- https://github.com/basho/private_basho_docs/pull/250
