### PR TITLE
Increased rt_retry_delay for replication_upgrade test

### DIFF
--- a/tests/replication_upgrade.erl
+++ b/tests/replication_upgrade.erl
@@ -4,6 +4,13 @@
 -include_lib("eunit/include/eunit.hrl").
 
 confirm() ->
+
+    OldDelay = rt_config:get(rt_retry_delay, 1000),
+    lager:info("OldDelay is ~p", [OldDelay]),
+    rt_config:set(rt_retry_delay, 5000),
+    NewDelay = rt_config:get(rt_retry_delay),
+    lager:info("NewDelay is ~p", [NewDelay]),
+
     TestMetaData = riak_test_runner:metadata(),
     FromVersion = proplists:get_value(upgrade_version, TestMetaData, previous),
 
@@ -93,4 +100,6 @@ confirm() ->
                                rt:log_to_nodes(Nodes, "Replication with upgraded node: ~p", [Node]),
                                replication:replication(ANodes, BNodes, true)
                        end, NodeUpgrades),
+    lager:info("Resetting Delay to is ~p", [OldDelay]),
+    rt_config:set(rt_retry_delay, OldDelay),
     pass.

--- a/tests/replication_upgrade.erl
+++ b/tests/replication_upgrade.erl
@@ -5,11 +5,11 @@
 
 confirm() ->
 
-    OldDelay = rt_config:get(rt_retry_delay, 1000),
-    lager:info("OldDelay is ~p", [OldDelay]),
-    rt_config:set(rt_retry_delay, 5000),
+    OrigDelay = rt_config:get(rt_retry_delay, 1000),
+    lager:info("Original rt_retry_delay is ~p", [OrigDelay]),
+    rt_config:set(rt_retry_delay, OrigDelay*5),
     NewDelay = rt_config:get(rt_retry_delay),
-    lager:info("NewDelay is ~p", [NewDelay]),
+    lager:info("New rt_retry_delay is ~p", [NewDelay]),
 
     TestMetaData = riak_test_runner:metadata(),
     FromVersion = proplists:get_value(upgrade_version, TestMetaData, previous),
@@ -100,6 +100,6 @@ confirm() ->
                                rt:log_to_nodes(Nodes, "Replication with upgraded node: ~p", [Node]),
                                replication:replication(ANodes, BNodes, true)
                        end, NodeUpgrades),
-    lager:info("Resetting Delay to is ~p", [OldDelay]),
-    rt_config:set(rt_retry_delay, OldDelay),
+    lager:info("Resetting rt_retry_delay to ~p", [OrigDelay]),
+    rt_config:set(rt_retry_delay, OrigDelay),
     pass.


### PR DESCRIPTION
@javajolt @macintux 
I added some code to set the rt_rety_delay to 5 seconds before the test is run and then reset rt_rety_delay to the previous value.