### PR TITLE
Fixed ts_simple_http_api_SUITE to wait for service before running test

### DIFF
--- a/tests/replication_upgrade.erl
+++ b/tests/replication_upgrade.erl
@@ -4,6 +4,13 @@
 -include_lib("eunit/include/eunit.hrl").
 
 confirm() ->
+
+    OldDelay = rt_config:get(rt_retry_delay, 1000),
+    lager:info("OldDelay is ~p", [OldDelay]),
+    rt_config:set(rt_retry_delay, 5000),
+    NewDelay = rt_config:get(rt_retry_delay),
+    lager:info("NewDelay is ~p", [NewDelay]),
+
     TestMetaData = riak_test_runner:metadata(),
     FromVersion = proplists:get_value(upgrade_version, TestMetaData, previous),
 
@@ -93,4 +100,6 @@ confirm() ->
                                rt:log_to_nodes(Nodes, "Replication with upgraded node: ~p", [Node]),
                                replication:replication(ANodes, BNodes, true)
                        end, NodeUpgrades),
+    lager:info("Resetting Delay to is ~p", [OldDelay]),
+    rt_config:set(rt_retry_delay, OldDelay),
     pass.

--- a/tests/replication_upgrade.erl
+++ b/tests/replication_upgrade.erl
@@ -5,11 +5,11 @@
 
 confirm() ->
 
-    OldDelay = rt_config:get(rt_retry_delay, 1000),
-    lager:info("OldDelay is ~p", [OldDelay]),
-    rt_config:set(rt_retry_delay, 5000),
+    OrigDelay = rt_config:get(rt_retry_delay, 1000),
+    lager:info("Original rt_retry_delay is ~p", [OrigDelay]),
+    rt_config:set(rt_retry_delay, OrigDelay*5),
     NewDelay = rt_config:get(rt_retry_delay),
-    lager:info("NewDelay is ~p", [NewDelay]),
+    lager:info("New rt_retry_delay is ~p", [NewDelay]),
 
     TestMetaData = riak_test_runner:metadata(),
     FromVersion = proplists:get_value(upgrade_version, TestMetaData, previous),
@@ -100,6 +100,6 @@ confirm() ->
                                rt:log_to_nodes(Nodes, "Replication with upgraded node: ~p", [Node]),
                                replication:replication(ANodes, BNodes, true)
                        end, NodeUpgrades),
-    lager:info("Resetting Delay to is ~p", [OldDelay]),
-    rt_config:set(rt_retry_delay, OldDelay),
+    lager:info("Resetting rt_retry_delay to ~p", [OrigDelay]),
+    rt_config:set(rt_retry_delay, OrigDelay),
     pass.

--- a/tests/ts_simple_http_api_SUITE.erl
+++ b/tests/ts_simple_http_api_SUITE.erl
@@ -36,7 +36,7 @@ suite() ->
 init_per_suite(Config) ->
     application:start(ibrowse),
     [Node|_] = Cluster = ts_util:build_cluster(single),
-    rt:wait_for_service(Node, riak_kv),
+    rt:wait_for_service(Node, [riak_kv, riak_pipe, riak_repl]),
     [{cluster, Cluster} | Config].
 
 end_per_suite(_Config) ->


### PR DESCRIPTION
added wait_for_service on riak_pipe and riak_repl @javajolt 