### PR TITLE
Add support for gsets

### DIFF
--- a/tests/verify_crdt_capability.erl
+++ b/tests/verify_crdt_capability.erl
@@ -69,7 +69,8 @@ confirm() ->
                                                         riak_dt_orswot,
                                                         riak_dt_map,
                                                         pncounter,
-                                                        riak_kv_hll])),
+                                                        riak_kv_hll,
+                                                        riak_dt_gset])),
     ?assertMatch(ok, rhc:counter_incr(PrevHttp, ?BUCKET, ?KEY, 1)),
     ?assertMatch({ok, 5}, rhc:counter_val(PrevHttp, ?BUCKET, ?KEY)),
 


### PR DESCRIPTION
Customer bet365 have added gset support to riak. See https://github.com/basho/riak_kv/pull/1518 (for example.)

This PR extends the existing datatype tests to include the new GSET integration. The majority of testing of the data type itself is via quickcheck and is in the riak_dt repo.