### PR TITLE
Pass in tests to riak_test script as comma separated values

### DIFF
--- a/src/riak_test_escript.erl
+++ b/src/riak_test_escript.erl
@@ -215,6 +215,7 @@ parse_command_line_tests(ParsedArgs) ->
         lists:foldl(fun extract_test_names/2,
                     {[], []},
                     proplists:get_all_values(tests, ParsedArgs)),
+
     [code:add_patha(CodePath) || CodePath <- CodePaths,
                                  CodePath /= "."],
     Dirs = proplists:get_all_values(dir, ParsedArgs),
@@ -236,8 +237,10 @@ parse_command_line_tests(ParsedArgs) ->
         end, [], lists:usort(DirTests ++ SpecificTests)).
 
 extract_test_names(Test, {CodePaths, TestNames}) ->
-    {[filename:dirname(Test) | CodePaths],
-     [filename:rootname(filename:basename(Test)) | TestNames]}.
+    CommaSepTests = string:tokens(Test, [$,]),
+    CodePathList = [filename:dirname(TestName) || TestName <- CommaSepTests],
+    TestNameList = [filename:rootname(filename:basename(TestName)) || TestName <- CommaSepTests],
+    {CodePathList++CodePaths, TestNameList++TestNames}.
 
 which_tests_to_run(undefined, CommandLineTests) ->
     {Tests, NonTests} =

--- a/src/riak_test_escript.erl
+++ b/src/riak_test_escript.erl
@@ -258,11 +258,11 @@ process_tests(Test, Acc) ->
 get_test_with_valid_prefix(Test, []) ->
     Test;
 
-get_test_with_valid_prefix(Test, TestPaths) ->
-    [FirstPath|Rest] = TestPaths,
-    case filelib:wildcard(FirstPath++"/"++Test) of
+get_test_with_valid_prefix(Test, [FirstPath|Rest]) ->
+    TestPath = FirstPath++"/"++Test,
+    case filelib:wildcard(TestPath) of
           [] -> get_test_with_valid_prefix(Test, Rest);
-          _  -> FirstPath++"/"++Test
+          _  -> TestPath
     end.
 
 which_tests_to_run(undefined, CommandLineTests) ->


### PR DESCRIPTION
Added some code to riak_test_escript to allow passing in of comma separated test values after the -t flag. Example usage would be:
```
 ./riak_test -c rtdev -t test_a,test_b,test_c
```

If you pass in repeated tests, the test is only run once. The following examples will run test_a once:
```
 ./riak_test -c rtdev -t test_a,test_a,test_a
 ./riak_test -c rtdev -t test_a,test_b,test_a
 ./riak_test -c rtdev -t test_b,test_a,test_a
```

tests must be comma separated with no whitespace in between.
@javajolt 