### PR TITLE
Prevent tree upgrades which can block replication from completing

### DIFF
--- a/tests/replication_object_reformat.erl
+++ b/tests/replication_object_reformat.erl
@@ -23,7 +23,15 @@
             [
              {anti_entropy, {on, []}},
              {anti_entropy_build_limit, {100, 1000}},
-             {anti_entropy_concurrency, 100}
+             {anti_entropy_concurrency, 100},
+             %% In mixed clusters, don't allow the object has version
+             %% to upgrade from `legacy` as the replication will no
+             %% no longer be able to complete
+             {override_capability,
+               [{object_hash_version,
+                 [{use, legacy},
+                  {prefer, legacy}]
+                }]}
             ]
         },
         {riak_repl,


### PR DESCRIPTION
Use capability override to make sure that neither side
of the replication link upgrades its object hash version
because if once side updates its trees and the other hasn't
completed the process yet (or in mixed clusters doesn't even
support it) the AAE full sync cannot complete.