### PR TITLE
Add additional logging to sibling debug log in object_value. [JIRA: RIAK-2971]

### DIFF
--- a/src/rt.erl
+++ b/src/rt.erl
@@ -1399,7 +1399,7 @@ object_value(1, Obj, _SquashSiblings) ->
 object_value(_ValueCount, Obj, false) ->
     riak_object:get_value(Obj);
 object_value(_ValueCount, Obj, true) ->
-    lager:debug("Siblings detected for ~p:~p", [riak_object:bucket(Obj), riak_object:key(Obj)]),
+    lager:debug("Siblings detected for ~p:~p~n~p", [riak_object:bucket(Obj), riak_object:key(Obj), Obj]),
     Contents = riak_object:get_contents(Obj),
     case lists:foldl(fun sibling_compare/2, {true, undefined}, Contents) of
         {true, {_, _, _, Value}} ->


### PR DESCRIPTION
Needed to help figure out why certain repl tests have failed on
occasion.