### PR TITLE
Regression test extended to cover more feature, includes bug fixes

### DIFF
--- a/priv/riak_shell/riak_shell_regression1.log
+++ b/priv/riak_shell/riak_shell_regression1.log
@@ -8,12 +8,12 @@
 "}}.
 {{command, "show_nodes; "}, {result, "The connected nodes are: ['dev1@127.0.0.1','dev2@127.0.0.1','dev3@127.0.0.1']"}}.
 {{command, "CREATE TABLE GeoCheckin (myfamily varchar not null, myseries varchar not null, time  timestamp not null, weather  varchar not null, temperature double, PRIMARY KEY ((myfamily, myseries, quantum(time, 15, 'm')), myfamily, myseries, time));\n"}, {result, ""}}.
-{{command, "describe GeoCheckin;\n"}, {result, "Column,Type,Is Null,Primary Key,Local Key,Interval,Unit
-myfamily,varchar,false,1,1,,
-myseries,varchar,false,2,2,,
-time,timestamp,false,3,3,15,m
-weather,varchar,false,,,,
-temperature,double,true,,,,
+{{command, "describe GeoCheckin;\n"}, {result, "Column,Type,Nullable,Partition Key,Local Key,Interval,Unit,Sort Order
+myfamily,varchar,false,1,1,,,
+myseries,varchar,false,2,2,,,
+time,timestamp,false,3,3,15,m,
+weather,varchar,false,,,,,
+temperature,double,true,,,,,
 "}}.
 {{command, "SHOW TABLES;\n"}, {result, "Table
 GeoCheckin
@@ -44,7 +44,7 @@ GeoCheckin
 {{command, "insert into GeoCheckin (myfamily, myseries, time, weather, temperature) values ('family1','series1',10,'hail',38.1);\n"}, {result, ""}}.
 {{command, "select time, weather, temperature from GeoCheckin where myfamily='family1' and myseries='seriesX' and time > 10 and time < 1000;\n"}, {result, ""}}.
 {{command, "select * from GeoCheckin;\n"}, {result, "Error (1001): The query must have a where clause."}}.
-{{command, "select * from GeoCheckin where myfamily = 'family1' and myseries = 'series1' and time >= 1420113600000 and time <= 1420119300000;\n"}, {result, "Error (1001): Too many subqueries (7)"}}.
+{{command, "select * from GeoCheckin where myfamily = 'family1' and myseries = 'series1' and time >= 1420113600000 and time <= 1420119300000;\n"}, {result, []}}.
 {{command, "select * from GeoCheckin where myfamily = 'family1' and myseries = 'series1' and time >= 1 and time <= 2;\n"},
  {result,
 "myfamily,myseries,time,weather,temperature
@@ -80,3 +80,133 @@ family1,series1,1970-01-01T00:00:00.007Z,cloudy,27.9
 555,1.1,10.0,0.01123
 555,1.1,10.0,0.01123
 "}}.
+{{command, "h; "}, {result, "Error: invalid function call : history_EXT:h []
+You can rerun a command by finding the command in the history list
+with `show_history;` and using the number next to it as the argument
+to `history` or `h`: `history 3;` or `h 3;` for example."}}.
+{{command, "help ; "}, {result, "The following functions are available
+
+Extension 'connection':
+    connect, connection_prompt, ping, reconnect, show_connection, show_cookie
+    show_nodes
+
+Extension 'debug':
+    load, observer
+
+Extension 'history':
+    clear_history, h, history, show_history
+
+Extension 'log':
+    date_log, log, logfile, regression_log, replay_log, show_log_status
+
+Extension 'shell':
+    about, q, quit, show_config, show_version
+
+You can get more help by calling help with the
+extension name and function name like 'help shell quit;'
+
+For SQL help type 'help SQL'"}}.
+{{command, "help ; "}, {result, "The following functions are available
+
+Extension 'connection':
+    connect, connection_prompt, ping, reconnect, show_connection, show_cookie
+    show_nodes
+
+Extension 'debug':
+    load, observer
+
+Extension 'history':
+    clear_history, h, history, show_history
+
+Extension 'log':
+    date_log, log, logfile, regression_log, replay_log, show_log_status
+
+Extension 'shell':
+    about, q, quit, show_config, show_version
+
+You can get more help by calling help with the
+extension name and function name like 'help shell quit;'
+
+For SQL help type 'help SQL'"}}.
+{{command, "date_log; "}, {result, "Error: invalid function call : log_EXT:date_log []
+Toggle adding a timestamp to the name of the log file with `date_log on ;`
+and off with `date_log off ;`
+The filename will be something like \"riak_shell.2016_02_15-16:42:22.log\"
+You will get a new log file for each session of riak-shell.
+
+The default can be set in the config file."}}.
+{{command, "date_log off; "}, {result, "Log files will not contain a date/time stamp."}}.
+{{command, "help; "}, {result, "The following functions are available
+
+Extension 'connection':
+    connect, connection_prompt, ping, reconnect, show_connection, show_cookie
+    show_nodes
+
+Extension 'debug':
+    load, observer
+
+Extension 'history':
+    clear_history, h, history, show_history
+
+Extension 'log':
+    date_log, log, logfile, regression_log, replay_log, show_log_status
+
+Extension 'shell':
+    about, q, quit, show_config, show_version
+
+You can get more help by calling help with the
+extension name and function name like 'help shell quit;'
+
+For SQL help type 'help SQL'"}}.
+{{command, "help sql ; "}, {result, "The following SQL help commands are supported:
+CREATE   - using CREATE TABLE statements
+DELETE   - deleting data with DELETE FROM
+DESCRIBE - examining table structures
+EXPLAIN  - understanding SELECT query execution paths
+INSERT   - inserting data with INSERT INTO statements
+SELECT   - querying data
+SHOW     - listing tables
+
+SELECT can be used with ORDER BY, GROUP BY and LIMIT clauses. It supports arithmetic on column values and has a variety of aggregation functions: COUNT, SUM, MEAN, AVG, MAX, MIN, STDDEV, STDDEV_SAMP and STDDEV_POP
+
+To get more help type 'help SQL SELECT' (replacing SELECT with another statement as appropriate)"}}.
+{{command, "help sql select; "}, {result, "You can use the SELECT statement to query your Time Series data.
+(this example uses the table definition from 'help SQL CREATE' and the data from 'help SQL INSERT')
+
+An example of the format is shown below:
+
+(1)>SELECT * FROM mytable where keyfield = 'keyvalue' and timefield > '2016-11-30 19:15:00' and timefield < '2016-11-30 19:45:00';
+
+You can specify individual field names, and apply functions or arithmetic to them:
+
+(2)>SELECT otherfield1 FROM mytable where keyfield = 'keyvalue' and timefield > '2016-11-30 19:15:00' and timefield < '2016-11-30 19:45:00';
+
+(3)>SELECT otherfield1/2 FROM mytable where keyfield = 'keyvalue' and timefield > '2016-11-30 19:15:00' and timefield < '2016-11-30 19:45:00';
+
+(4)>SELECT MEAN(otherfield1) FROM mytable where keyfield = 'keyvalue' and timefield > '2016-11-30 19:15:00' and timefield < '2016-11-30 19:45:00';
+
+The functions supported are:
+* COUNT
+* SUM
+* MEAN and AVG
+* MIN
+* MAX
+* STDEV and STDDEV_SAMP
+* STDDEVPOP
+
+You can also decorate SELECT statements with ORDER BY, GROUP BY and LIMIT
+
+For more details please go to http://docs.basho.com/riak/ts
+"}}.
+{{command, "help history; "}, {result, "The following functions are available
+
+Extension 'history':
+    clear_history, h, history, show_history
+
+You can get more help by calling help with the
+extension name and function name like 'help history clear_history;'
+
+For SQL help type 'help SQL'"}}.
+{{command, "help history h; "}, {result, "You can rerun a command by finding the command in the history list
+with `show_history;` and using the number next to it as the argument
+to `history` or `h`: `history 3;` or `h 3;` for example."}}.


### PR DESCRIPTION
* replay tests crashed on replaying help commands
* replaying about; would crash the shell

In addition the regression for ORDER BY and elimination of 'too many quanta' errors that
is occassioned by the ORDER BY temporary tables changes have been fixed