### PR TITLE
ts_simple_query_buffers: query generator failed to emit ORDER BY-less ones

### DIFF
--- a/tests/ts_qbuf_util.erl
+++ b/tests/ts_qbuf_util.erl
@@ -92,7 +92,7 @@ full_query(Table, OptionalClauses) ->
             Item <- [order_by, limit, offset]],
     fmt("~s~s~s~s",
         [base_query(Table),
-         [fmt(" order by ~s", [make_orderby_list(OrderBy)]) || OrderBy /= undefined],
+         [fmt(" order by ~s", [make_orderby_list(OrderBy)]) || OrderBy /= []],
          [fmt(" limit ~b", [Limit])                         || Limit   /= undefined],
          [fmt(" offset ~b", [Offset])                       || Offset  /= undefined]]).
 


### PR DESCRIPTION
as well as queries with number of ORDER BY elements less than 4. Now fixed.

This ensures the conditions that elicited the bug being fixed in https://github.com/basho/riak_kv/pull/1539, are properly recreated.