### PR TITLE
add wait for decode_query_results_at_vnode capability to updowngrade tests

### DIFF
--- a/tests/ts_cluster_updowngrade_group_by_SUITE.erl
+++ b/tests/ts_cluster_updowngrade_group_by_SUITE.erl
@@ -40,8 +40,8 @@ make_scenarios() ->
                    need_query_node_transition = NeedQueryNodeTransition,
                    need_pre_cluster_mixed     = NeedPreClusterMixed,
                    need_post_cluster_mixed    = NeedPostClusterMixed,
-                   ensure_full_caps     = [{{riak_kv, sql_select_version}, v3}, {{riak_kv, riak_ql_ddl_rec_version}, v2}],
-                   ensure_degraded_caps = [{{riak_kv, sql_select_version}, v2}, {{riak_kv, riak_ql_ddl_rec_version}, v1}],
+                   ensure_full_caps     = [{{riak_kv, sql_select_version}, v3}, {{riak_kv, riak_ql_ddl_rec_version}, v2}, {{riak_kv, decode_query_results_at_vnode}, true}],
+                   ensure_degraded_caps = [{{riak_kv, sql_select_version}, v2}, {{riak_kv, riak_ql_ddl_rec_version}, v1}, {{riak_kv, decode_query_results_at_vnode}, false}],
                    convert_config_to_previous = fun ts_updown_util:convert_riak_conf_to_previous/1}
          || TableNodeVsn            <- [previous, current],
             QueryNodeVsn            <- [previous, current],

--- a/tests/ts_cluster_updowngrade_order_by_SUITE.erl
+++ b/tests/ts_cluster_updowngrade_order_by_SUITE.erl
@@ -60,8 +60,8 @@ make_scenarios() ->
                    need_query_node_transition = NeedQueryNodeTransition,
                    need_pre_cluster_mixed     = NeedPreClusterMixed,
                    need_post_cluster_mixed    = NeedPostClusterMixed,
-                   ensure_full_caps     = [{{riak_kv, sql_select_version}, v3}, {{riak_kv, riak_ql_ddl_rec_version}, v2}],
-                   ensure_degraded_caps = [{{riak_kv, sql_select_version}, v2}, {{riak_kv, riak_ql_ddl_rec_version}, v1}],
+                   ensure_full_caps     = [{{riak_kv, sql_select_version}, v3}, {{riak_kv, riak_ql_ddl_rec_version}, v2}, {{riak_kv, decode_query_results_at_vnode}, true}],
+                   ensure_degraded_caps = [{{riak_kv, sql_select_version}, v2}, {{riak_kv, riak_ql_ddl_rec_version}, v1}, {{riak_kv, decode_query_results_at_vnode}, false}],
                    convert_config_to_previous = fun ts_updown_util:convert_riak_conf_to_previous/1}
          || TableNodeVsn            <- [previous, current],
             QueryNodeVsn            <- [current],

--- a/tests/ts_cluster_updowngrade_select_aggregation_SUITE.erl
+++ b/tests/ts_cluster_updowngrade_select_aggregation_SUITE.erl
@@ -35,8 +35,8 @@ make_scenarios() ->
                need_query_node_transition = NeedQueryNodeTransition,
                need_pre_cluster_mixed     = NeedPreClusterMixed,
                need_post_cluster_mixed    = NeedPostClusterMixed,
-               ensure_full_caps     = [{{riak_kv, sql_select_version}, v3}, {{riak_kv, riak_ql_ddl_rec_version}, v2}],
-               ensure_degraded_caps = [{{riak_kv, sql_select_version}, v2}, {{riak_kv, riak_ql_ddl_rec_version}, v1}],
+               ensure_full_caps     = [{{riak_kv, sql_select_version}, v3}, {{riak_kv, riak_ql_ddl_rec_version}, v2}, {{riak_kv, decode_query_results_at_vnode}, true}],
+               ensure_degraded_caps = [{{riak_kv, sql_select_version}, v2}, {{riak_kv, riak_ql_ddl_rec_version}, v1}, {{riak_kv, decode_query_results_at_vnode}, false}],
                convert_config_to_previous = fun ts_updown_util:convert_riak_conf_to_previous/1}
      || TableNodeVsn            <- [previous, current],
         QueryNodeVsn            <- [previous, current],


### PR DESCRIPTION
This will ensure updowngrade with parallel decoding feature by @erikleitch. Has to be merged *after* https://github.com/basho/riak_kv/pull/1538.