### PR TITLE
fixed a couple tests

### DIFF
--- a/tests/ts_cluster_create_table_via_sql_SUITE.erl
+++ b/tests/ts_cluster_create_table_via_sql_SUITE.erl
@@ -128,12 +128,12 @@ ddl_common() ->
     ts_data:get_ddl(small).
 
 table_described() ->
-    {ok, {[<<"Column">>,<<"Type">>,<<"Is Null">>,<<"Primary Key">>, <<"Local Key">>, <<"Interval">>, <<"Unit">>],
-     [{<<"myfamily">>,   <<"varchar">>,   false,  1,  1, [], []},
-      {<<"myseries">>,   <<"varchar">>,   false,  2,  2, [], []},
-      {<<"time">>,       <<"timestamp">>, false,  3,  3, 15, <<"m">>},
-      {<<"weather">>,    <<"varchar">>,   false, [], [], [], []},
-      {<<"temperature">>,<<"double">>,    true,  [], [], [], []}]}}.
+    {ok,{[<<"Column">>,<<"Type">>,<<"Nullable">>,<<"Partition Key">>,<<"Local Key">>, <<"Interval">>,<<"Unit">>,<<"Sort Order">>],
+         [{<<"myfamily">>,<<"varchar">>,false,1,1,[],[], []},
+          {<<"myseries">>,<<"varchar">>,false,2,2,[],[], []},
+          {<<"time">>,<<"timestamp">>,false,3,3,15, <<"m">>,[]},
+          {<<"weather">>,<<"varchar">>,false,[],[],[], [],[]},
+          {<<"temperature">>,<<"double">>,true,[],[],[], [],[]}]}}.
 
 enquote_varchar(P) when is_binary(P) ->
     re:replace(P, "'", "''", [global, {return, binary}]);

--- a/tests/ts_cluster_random_query_pass_eqc.erl
+++ b/tests/ts_cluster_random_query_pass_eqc.erl
@@ -51,9 +51,8 @@ run_query(ClusterConn, NVal, NPuts, Q, NSpans) ->
 
     {Cluster, Conn} = ClusterConn,
 
-    Table = ts_data:get_default_bucket(),
-    {ok, _} = ts_setup:create_bucket_type(Cluster, DDL, Table, NVal),
-    ok = ts_setup:activate_bucket_type(Cluster, Table),
+    {ok, _} = ts_setup:create_bucket_type(Cluster, DDL, Bucket, NVal),
+    ok = ts_setup:activate_bucket_type(Cluster, Bucket),
     ok = riakc_ts:put(Conn, Bucket, Data),
     {ok, {_, Got}} = ts_ops:query(Cluster, Query),
     ?assertEqual(Data, Got),


### PR DESCRIPTION
@javajolt fixed some tests... random_query was getting passed in the wrong bucket name, create_table_via_sql was using the wrong table format (i think andrei's orderby feature might have changed the table format)...cluster_comprehensive was the hard one... the rt:pbc connections were being created once and would die if it was used for a "bad" query so creating a connection for each query solved this...then list_keys was returning keys which were tombstoned, which is the proper functionality, but for some reason this test was passing up until 1.5.0alpha4.  I changed one instance of list_keys to try to get the keys instead, which would confirm that all the keys were deleted.