### PR TITLE
moved a test that previously was expected to fail to the passing tests…

### DIFF
--- a/tests/ts_simple_aggregation.erl
+++ b/tests/ts_simple_aggregation.erl
@@ -160,14 +160,16 @@ verify_aggregation(ClusterType) ->
     StdDev5 = math:sqrt(lists:foldl(StdDevFun5, 0, C5) / Count5),
     Sample4 = math:sqrt(lists:foldl(StdDevFun4, 0, C4) / (Count4-1)),
     Sample5 = math:sqrt(lists:foldl(StdDevFun5, 0, C5) / (Count5-1)),
+    POPSTD = 2.8722813232690143, %%this is the std of 1-10, calculated using numpy
     Qry9 = "SELECT STDDEV_POP(temperature), STDDEV_POP(pressure)," ++
            " STDDEV(temperature), STDDEV(pressure), " ++
-           " STDDEV_SAMP(temperature), STDDEV_SAMP(pressure) FROM " ++ Bucket ++ Where,
+           " STDDEV_SAMP(temperature), STDDEV_SAMP(pressure)," ++
+           " STDDEV_POP(time) FROM " ++ Bucket ++ Where,
     Got9 = ts_ops:query(Cluster, Qry9),
     Expected9 = {ok, {[<<"STDDEV_POP(temperature)">>, <<"STDDEV_POP(pressure)">>,
                   <<"STDDEV(temperature)">>, <<"STDDEV(pressure)">>,
-                  <<"STDDEV_SAMP(temperature)">>, <<"STDDEV_SAMP(pressure)">>],
-                 [{StdDev4, StdDev5, Sample4, Sample5, Sample4, Sample5}]}},
+                  <<"STDDEV_SAMP(temperature)">>, <<"STDDEV_SAMP(pressure)">>, <<"STDDEV_POP(time)">>],
+                 [{StdDev4, StdDev5, Sample4, Sample5, Sample4, Sample5, POPSTD}]}},
     Result9 = ts_data:assert_float(test_name(ClusterType, "Standard Deviation"), Expected9, Got9),
 
     Qry10 = "SELECT SUM(temperature), MIN(pressure), AVG(pressure) FROM " ++ Bucket ++ Where,

--- a/tests/ts_simple_aggregation_fail.erl
+++ b/tests/ts_simple_aggregation_fail.erl
@@ -66,15 +66,10 @@ confirm() ->
     Expected6 = {error, {1001, <<".*Function 'STDDEV_SAMP' called with arguments of the wrong type [[]boolean[]].*">>}},
     Result6 = ts_data:assert_error_regex("STDDEV_SAMP - boolean", Expected6, Got6),
 
-    %Qry7 = "SELECT STDDEV_POP(time) FROM " ++ Bucket,
-    %Got7 = ts_ops:query(Cluster, Qry7),
-    %Expected7 = {error, {1001, <<".*Function 'STDDEV_POP' called with arguments of the wrong type [[]timestamp[]].*">>}},
-    %Result7 = ts_data:assert_error_regex("STDDEV_POP - timestamp", Expected7, Got7),
-
-    Qry8 = "SELECT Mean(mybool) FROM " ++ Bucket,
-    Got8 = ts_ops:query(Cluster, Qry8),
-    Expected8 = {error, {1001, <<".*Function 'AVG' called with arguments of the wrong type [[]boolean[]].*">>}},
-    Result8 = ts_data:assert_error_regex("MEAN - boolean", Expected8, Got8),
+    Qry7 = "SELECT Mean(mybool) FROM " ++ Bucket,
+    Got7 = ts_ops:query(Cluster, Qry7),
+    Expected7 = {error, {1001, <<".*Function 'AVG' called with arguments of the wrong type [[]boolean[]].*">>}},
+    Result7 = ts_data:assert_error_regex("MEAN - boolean", Expected7, Got7),
 
     ts_data:results([
              Result1,
@@ -83,8 +78,7 @@ confirm() ->
              Result4,
              Result5,
              Result6,
-     %        Result7,
-             Result8
+             Result7
             ]),
 
     pass.

--- a/tests/ts_simple_aggregation_fail.erl
+++ b/tests/ts_simple_aggregation_fail.erl
@@ -66,10 +66,10 @@ confirm() ->
     Expected6 = {error, {1001, <<".*Function 'STDDEV_SAMP' called with arguments of the wrong type [[]boolean[]].*">>}},
     Result6 = ts_data:assert_error_regex("STDDEV_SAMP - boolean", Expected6, Got6),
 
-    Qry7 = "SELECT STDDEV_POP(time) FROM " ++ Bucket,
-    Got7 = ts_ops:query(Cluster, Qry7),
-    Expected7 = {error, {1001, <<".*Function 'STDDEV_POP' called with arguments of the wrong type [[]timestamp[]].*">>}},
-    Result7 = ts_data:assert_error_regex("STDDEV_POP - timestamp", Expected7, Got7),
+    %Qry7 = "SELECT STDDEV_POP(time) FROM " ++ Bucket,
+    %Got7 = ts_ops:query(Cluster, Qry7),
+    %Expected7 = {error, {1001, <<".*Function 'STDDEV_POP' called with arguments of the wrong type [[]timestamp[]].*">>}},
+    %Result7 = ts_data:assert_error_regex("STDDEV_POP - timestamp", Expected7, Got7),
 
     Qry8 = "SELECT Mean(mybool) FROM " ++ Bucket,
     Got8 = ts_ops:query(Cluster, Qry8),
@@ -83,7 +83,7 @@ confirm() ->
              Result4,
              Result5,
              Result6,
-             Result7,
+     %        Result7,
              Result8
             ]),
 


### PR DESCRIPTION
STDDEV_POP of a timestamp was previously a bad query but this pr https://github.com/basho/riak_ql/commit/e97d348229f5f69cc43fb1da4de4be31c899bc37#diff-aa3e471f8ce4c5b6477e8c5c4eb1928cR56 changed that... Moved this failing test to ts_simple_aggregation as a passing test. @javajolt 