### PR TITLE
Query buffer suite chmod fix kc

### DIFF
--- a/tests/ts_simple_aggregation.erl
+++ b/tests/ts_simple_aggregation.erl
@@ -160,14 +160,16 @@ verify_aggregation(ClusterType) ->
     StdDev5 = math:sqrt(lists:foldl(StdDevFun5, 0, C5) / Count5),
     Sample4 = math:sqrt(lists:foldl(StdDevFun4, 0, C4) / (Count4-1)),
     Sample5 = math:sqrt(lists:foldl(StdDevFun5, 0, C5) / (Count5-1)),
+    POPSTD = 2.8722813232690143, %%this is the std of 1-10, calculated using numpy
     Qry9 = "SELECT STDDEV_POP(temperature), STDDEV_POP(pressure)," ++
            " STDDEV(temperature), STDDEV(pressure), " ++
-           " STDDEV_SAMP(temperature), STDDEV_SAMP(pressure) FROM " ++ Bucket ++ Where,
+           " STDDEV_SAMP(temperature), STDDEV_SAMP(pressure)," ++
+           " STDDEV_POP(time) FROM " ++ Bucket ++ Where,
     Got9 = ts_ops:query(Cluster, Qry9),
     Expected9 = {ok, {[<<"STDDEV_POP(temperature)">>, <<"STDDEV_POP(pressure)">>,
                   <<"STDDEV(temperature)">>, <<"STDDEV(pressure)">>,
-                  <<"STDDEV_SAMP(temperature)">>, <<"STDDEV_SAMP(pressure)">>],
-                 [{StdDev4, StdDev5, Sample4, Sample5, Sample4, Sample5}]}},
+                  <<"STDDEV_SAMP(temperature)">>, <<"STDDEV_SAMP(pressure)">>, <<"STDDEV_POP(time)">>],
+                 [{StdDev4, StdDev5, Sample4, Sample5, Sample4, Sample5, POPSTD}]}},
     Result9 = ts_data:assert_float(test_name(ClusterType, "Standard Deviation"), Expected9, Got9),
 
     Qry10 = "SELECT SUM(temperature), MIN(pressure), AVG(pressure) FROM " ++ Bucket ++ Where,

--- a/tests/ts_simple_aggregation_fail.erl
+++ b/tests/ts_simple_aggregation_fail.erl
@@ -66,15 +66,10 @@ confirm() ->
     Expected6 = {error, {1001, <<".*Function 'STDDEV_SAMP' called with arguments of the wrong type [[]boolean[]].*">>}},
     Result6 = ts_data:assert_error_regex("STDDEV_SAMP - boolean", Expected6, Got6),
 
-    %Qry7 = "SELECT STDDEV_POP(time) FROM " ++ Bucket,
-    %Got7 = ts_ops:query(Cluster, Qry7),
-    %Expected7 = {error, {1001, <<".*Function 'STDDEV_POP' called with arguments of the wrong type [[]timestamp[]].*">>}},
-    %Result7 = ts_data:assert_error_regex("STDDEV_POP - timestamp", Expected7, Got7),
-
-    Qry8 = "SELECT Mean(mybool) FROM " ++ Bucket,
-    Got8 = ts_ops:query(Cluster, Qry8),
-    Expected8 = {error, {1001, <<".*Function 'AVG' called with arguments of the wrong type [[]boolean[]].*">>}},
-    Result8 = ts_data:assert_error_regex("MEAN - boolean", Expected8, Got8),
+    Qry7 = "SELECT Mean(mybool) FROM " ++ Bucket,
+    Got7 = ts_ops:query(Cluster, Qry7),
+    Expected7 = {error, {1001, <<".*Function 'AVG' called with arguments of the wrong type [[]boolean[]].*">>}},
+    Result7 = ts_data:assert_error_regex("MEAN - boolean", Expected7, Got7),
 
     ts_data:results([
              Result1,
@@ -83,8 +78,7 @@ confirm() ->
              Result4,
              Result5,
              Result6,
-     %        Result7,
-             Result8
+             Result7
             ]),
 
     pass.

--- a/tests/ts_simple_aggregation_fail.erl
+++ b/tests/ts_simple_aggregation_fail.erl
@@ -66,10 +66,10 @@ confirm() ->
     Expected6 = {error, {1001, <<".*Function 'STDDEV_SAMP' called with arguments of the wrong type [[]boolean[]].*">>}},
     Result6 = ts_data:assert_error_regex("STDDEV_SAMP - boolean", Expected6, Got6),
 
-    Qry7 = "SELECT STDDEV_POP(time) FROM " ++ Bucket,
-    Got7 = ts_ops:query(Cluster, Qry7),
-    Expected7 = {error, {1001, <<".*Function 'STDDEV_POP' called with arguments of the wrong type [[]timestamp[]].*">>}},
-    Result7 = ts_data:assert_error_regex("STDDEV_POP - timestamp", Expected7, Got7),
+    %Qry7 = "SELECT STDDEV_POP(time) FROM " ++ Bucket,
+    %Got7 = ts_ops:query(Cluster, Qry7),
+    %Expected7 = {error, {1001, <<".*Function 'STDDEV_POP' called with arguments of the wrong type [[]timestamp[]].*">>}},
+    %Result7 = ts_data:assert_error_regex("STDDEV_POP - timestamp", Expected7, Got7),
 
     Qry8 = "SELECT Mean(mybool) FROM " ++ Bucket,
     Got8 = ts_ops:query(Cluster, Qry8),
@@ -83,7 +83,7 @@ confirm() ->
              Result4,
              Result5,
              Result6,
-             Result7,
+     %        Result7,
              Result8
             ]),
 

--- a/tests/ts_simple_query_buffers_SUITE.erl
+++ b/tests/ts_simple_query_buffers_SUITE.erl
@@ -389,11 +389,11 @@ col_no({[A|_], _, _}) ->
 
 modify_dir_access(take_away, QBufDir) ->
     ct:pal("take away access to ~s\n", [QBufDir]),
-    file:rename(QBufDir, QBufDir++".boo"),
-    file:write_file(QBufDir, "nothing here");
+    ok = file:rename(QBufDir, QBufDir++".boo"),
+    ok = file:write_file(QBufDir, "nothing here");
 
 modify_dir_access(give_back, QBufDir) ->
     ct:pal("restore access to ~s\n", [QBufDir]),
-    file:delete(QBufDir),
-    file:rename(QBufDir++".boo", QBufDir).
+    ok = file:delete(QBufDir),
+    ok = file:rename(QBufDir++".boo", QBufDir).
 

--- a/tests/ts_simple_query_buffers_SUITE.erl
+++ b/tests/ts_simple_query_buffers_SUITE.erl
@@ -218,7 +218,8 @@ init_per_testcase(query_orderby_ldb_io_error, Cfg) ->
     QBufDir = filename:join([rtdev:node_path(Node), "data/query_buffers"]),
     Cmd = get_write_perm_cmd(take_away, QBufDir),
     ct:log("running ~s", [Cmd]),
-    "" = os:cmd(Cmd),
+    CmdOut = "" = os:cmd(Cmd),
+    ct:log("~s: '~s'", [Cmd, CmdOut]),
     Cfg;
 
 init_per_testcase(_, Cfg) ->
@@ -239,7 +240,8 @@ end_per_testcase(query_orderby_ldb_io_error, Cfg) ->
     QBufDir = filename:join([rtdev:node_path(Node), "data/query_buffers"]),
     Cmd = get_write_perm_cmd(give_back, QBufDir),
     ct:log("running ~s", [Cmd]),
-    "" = os:cmd(Cmd),
+    CmdOut = "" = os:cmd(Cmd),
+    ct:log("~s: '~s'", [Cmd, CmdOut]),
     ok;
 end_per_testcase(_, Cfg) ->
     Cfg.


### PR DESCRIPTION
@javajolt @hmmr 
ok so this test needs to remove and restore write permission to the query buffer directory to test that the proper error is passed. The way it was doing this is through chmod but since riak_test is run using root user in basho_builds, chmod is rendered useless. To regain the expect behavior there are two function chattr and chflags that are now used.  The reason for using two different functions is that linux uses one and osx uses the other.  As far as I can tell these are the only two functions that will remove and restore write permissions for root user for their respectifve OSes. I inlcuded the option of using the OSX chlags so that local testing will have the same behavior as the basho_builds runs.