### PR TITLE
Update the replication parameters which are now TS defaults

### DIFF
--- a/priv/riak_shell/riak_shell_regression1.log
+++ b/priv/riak_shell/riak_shell_regression1.log
@@ -96,17 +96,17 @@ temperature DOUBLE,
 PRIMARY KEY ((region, state, QUANTUM(time, 15, 'm')),
 region, state, time))
 WITH (active = true,
-allow_mult = true,
-dvv_enabled = true,
-dw = quorum,
-last_write_wins = false,
+allow_mult = false,
+dvv_enabled = false,
+dw = one,
+last_write_wins = true,
 n_val = 3,
 notfound_ok = true,
 postcommit = '',
 pr = 0,
 pw = 0,
-r = quorum,
-rw = quorum,
+r = one,
+rw = one,
 w = quorum)"}}.
 {{command, "h; "}, {result, "Error: invalid function call : history_EXT:h []
 You can rerun a command by finding the command in the history list

--- a/tests/ts_simple_show_create_table.erl
+++ b/tests/ts_simple_show_create_table.erl
@@ -49,17 +49,17 @@ confirm() ->
     "PRIMARY KEY ((somechars, somebool, QUANTUM(sometime, 1, 'h')),\n"
     "somechars, somebool, sometime))\n"
     "WITH (active = true,\n"
-    "allow_mult = true,\n"
-    "dvv_enabled = true,\n"
-    "dw = quorum,\n"
-    "last_write_wins = false,\n"
+    "allow_mult = false,\n"
+    "dvv_enabled = false,\n"
+    "dw = one,\n"
+    "last_write_wins = true,\n"
     "n_val = 2,\n"
     "notfound_ok = true,\n"
     "postcommit = '',\n"
     "pr = 0,\n"
     "pw = 0,\n"
-    "r = quorum,\n"
-    "rw = quorum,\n"
+    "r = one,\n"
+    "rw = one,\n"
     "w = quorum)",
     ?assertEqual(Expected, Got),
     pass.


### PR DESCRIPTION
Changes to replication values changed the expected outputs https://bashoeng.atlassian.net/browse/RTS-1469 and https://github.com/basho/riak_core/pull/870

