### PR TITLE
always use current client in updowngrade tests

### DIFF
--- a/tests/ts_cluster_updowngrade_group_by_SUITE.erl
+++ b/tests/ts_cluster_updowngrade_group_by_SUITE.erl
@@ -30,7 +30,7 @@
 -define(SELECTERROR, {error, {1020, <<"Used group as a measure of time in 1000group. Only s, m, h and d are allowed.">>}}).
 
 make_initial_config(Config) ->
-    [{use_previous_client, true} | Config].
+    [{use_previous_client, false} | Config].
 
 make_scenarios() ->
     BaseScenarios =

--- a/tests/ts_cluster_updowngrade_order_by_SUITE.erl
+++ b/tests/ts_cluster_updowngrade_order_by_SUITE.erl
@@ -50,7 +50,7 @@
         " ORDER BY c").
 
 make_initial_config(Config) ->
-    [{use_previous_client, true} | Config].
+    [{use_previous_client, false} | Config].
 
 make_scenarios() ->
     BaseScenarios =

--- a/tests/ts_cluster_updowngrade_select_aggregation_SUITE.erl
+++ b/tests/ts_cluster_updowngrade_select_aggregation_SUITE.erl
@@ -26,7 +26,7 @@
 -define(PRECIPITATION_COL_INDEX, 6).
 
 make_initial_config(Config) ->
-    [{use_previous_client, true} | Config].
+    [{use_previous_client, false} | Config].
 
 make_scenarios() ->
     [#scenario{table_node_vsn             = TableNodeVsn,


### PR DESCRIPTION
There are no changes in wire protocol between 1.4 and 1.5, meaning both 1.4 and 1.5 clients should continue to work with 1.5 as well as mixed clusters. This PR turns off `use_previous_client` flag to always use the current (1.5) client during up/downgrade scenarios.