### PR TITLE
The existing failure logging for some reason is not printing out

### DIFF
--- a/tests/ts_updowngrade_test.part
+++ b/tests/ts_updowngrade_test.part
@@ -54,7 +54,7 @@ run_this_test(Config) ->
     case ts_updown_util:run_scenarios(Config, make_scenarios()) of
         [] ->
             pass;
-        _ ->
-            ct:fail("There were failing queries", [])
+        Errors ->
+            ct:fail("There were failing queries~n~p", [Errors])
     end.
 


### PR DESCRIPTION
the failures to the ct results page or the logs

Additional logging has been added in a belt-and-braces style