### PR TITLE
[RTS-1298] Fix ts_simple_http_security_SUITE HTTP put of NULL.

### DIFF
--- a/tests/ts_simple_http_security_SUITE.erl
+++ b/tests/ts_simple_http_security_SUITE.erl
@@ -175,7 +175,7 @@ make_data() ->
     [{list_to_binary(fmt("A~5..0b", [I rem 2])),
       <<"B">>,
       I + 1,
-      if I rem 5 == 0 -> []; el/=se -> I end}  %% sprinkle some NULLs
+      if I rem 5 == 0 -> null; el/=se -> I end}  %% sprinkle some NULLs
      || I <- lists:seq(1, 300)].
 make_data_ann(Columns, Data) ->
     [lists:zip(Columns, tuple_to_list(Row)) || Row <- Data].


### PR DESCRIPTION
* fixed ts_simple_http_security_SUITE to pass `null` over HTTP, was using `[]` which is an empty array in JSON.

Locally the test now passes, but that is strange given stated lack of support for HTTP security yet in Riak TS. Please verify that the test does not pass. If it does, *surprise* we have HTTP security.