### PR TITLE
query_buffers: increase timetrap timeout to 2h

### DIFF
--- a/tests/ts_simple_query_buffers_SUITE.erl
+++ b/tests/ts_simple_query_buffers_SUITE.erl
@@ -55,7 +55,7 @@
 
 
 suite() ->
-    [{timetrap, {minutes, 15}}].
+    [{timetrap, {hours, 2}}].
 
 init_per_suite(Cfg) ->
     Cluster = ts_setup:start_cluster(1),


### PR DESCRIPTION
In the latest rc6, the problem described in https://github.com/basho/riak_kv/pull/1563, appears to be finally fixed in https://github.com/basho/riak_kv/pull/1570. But now we hit the CT timetrap_timeout (the test could make some 30% of the distance in 900 sec). This PR increases its value from 900 sec (15 min) to 4 hours.