### PR TITLE
retry queries on spurious qbuf errors, reorder test cases

### DIFF
--- a/tests/ts_simple_query_buffers_SUITE.erl
+++ b/tests/ts_simple_query_buffers_SUITE.erl
@@ -49,7 +49,6 @@
 -include_lib("eunit/include/eunit.hrl").
 -include("ts_qbuf_util.hrl").
 
--define(TABLE2, "t2").  %% used to check for expiry; not to interfere with t1
 -define(RIDICULOUSLY_SMALL_MAX_QUERY_DATA_SIZE, 100).
 -define(RIDICULOUSLY_SMALL_MAX_QUERY_QUANTA, 3).
 
@@ -63,9 +62,7 @@ init_per_suite(Cfg) ->
     Data = ts_qbuf_util:make_data(),
     ExtraData = ts_qbuf_util:make_extra_data(),
     ok = ts_qbuf_util:create_table(C, ?TABLE),
-    ok = ts_qbuf_util:create_table(C, ?TABLE2),
     ok = ts_qbuf_util:insert_data(C, ?TABLE,  Data),
-    ok = ts_qbuf_util:insert_data(C, ?TABLE2, Data),
     [{cluster, Cluster},
      {data, Data},
      {extra_data, ExtraData}

--- a/tests/ts_simple_query_buffers_SUITE.erl
+++ b/tests/ts_simple_query_buffers_SUITE.erl
@@ -117,9 +117,7 @@ query_orderby_comprehensive(Cfg) ->
                   make_ordby_item_variants(Items),
               lists:foreach(
                 fun(Var) ->
-                        check_sorted(C, ?TABLE, Data, [{order_by, Var}]),
-                        check_sorted(C, ?TABLE, Data, [{order_by, Var}, {limit, 1}]),
-                        check_sorted(C, ?TABLE, Data, [{order_by, Var}, {limit, 2}, {offset, 4}])
+                        check_sorted(C, ?TABLE, Data, [{order_by, Var}, {limit, 12}, {offset, 4}])
                 end,
                 Variants)
       end,

--- a/tests/ts_simple_query_buffers_SUITE.erl
+++ b/tests/ts_simple_query_buffers_SUITE.erl
@@ -76,12 +76,12 @@ groups() ->
 
 all() ->
     [
+     %% 2. check LIMIT and ORDER BY, not involving follow-up queries
+     query_orderby_comprehensive,
      %% 3. check how error conditions are reported
      query_orderby_max_quanta_error,
      query_orderby_max_data_size_error,
-     query_orderby_ldb_io_error,
-     %% 2. check LIMIT and ORDER BY, not involving follow-up queries
-     query_orderby_comprehensive
+     query_orderby_ldb_io_error
      %% 1. check that query buffers persist and do not pick up updates to
      %% the mother table (and do, after expiry)
      %% query_orderby_no_updates


### PR DESCRIPTION
Another attempt to isolate sudden death conditions with qbuf-bound queries:

1. Reorder test cases such that any late query worker FSMs don't cause any trouble while the long comprehensive test is running (the idea being to watch it fail on its own).
2. Only run a single ORDER BY query variant (the one with LIMIT and OFFSET) instead of four (to reduce total running time).
3. Retry queries (3 times) on encountering "internal qbuf errors" arising from qry_buffers gen_server timeouts.
4. Don't create unused table (it was used in a now deleted test case).