### PR TITLE
Add Gradle tests for S3 API

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -19,6 +19,7 @@
         {meck, ".*", {git, "https://github.com/basho/meck.git", {tag, "0.8.2"}}},
         {rebar_lock_deps_plugin, ".*", {git, "https://github.com/basho/rebar_lock_deps_plugin.git", {tag, "3.1.0p1"}}},
         {riakc, ".*", {git, "https://github.com/basho/riak-erlang-client", {branch, "develop"}}},
+        {s3_api_tests, ".*", {git, "https://github.com/basho/s3-api-tests", {branch, "minimal-api-tests"}}, [raw]},
         {riakhttpc, ".*", {git, "https://github.com/basho/riak-erlang-http-client", {branch, "develop"}}}
        ]}.
 

--- a/src/rt.erl
+++ b/src/rt.erl
@@ -279,13 +279,16 @@ rpc_get_env(Node, [{App,Var}|Others]) ->
 
 -spec connection_info(node() | [node()]) -> interfaces() | conn_info().
 connection_info(Node) when is_atom(Node) ->
-    {ok, [{PB_IP, PB_Port}]} = get_pb_conn_info(Node),
-    {ok, [{HTTP_IP, HTTP_Port}]} = get_http_conn_info(Node),
-    case get_https_conn_info(Node) of
-        undefined ->
-            [{http, {HTTP_IP, HTTP_Port}}, {pb, {PB_IP, PB_Port}}];
-        {ok, [{HTTPS_IP, HTTPS_Port}]} ->
-            [{http, {HTTP_IP, HTTP_Port}}, {https, {HTTPS_IP, HTTPS_Port}}, {pb, {PB_IP, PB_Port}}]
+    {ok, [PB_Info]} = get_pb_conn_info(Node),
+    {ok, [HTTP_Info]} = get_http_conn_info(Node),
+    Info0 = [{pb, PB_Info}, {http, HTTP_Info}],
+    Info1 = case get_https_conn_info(Node) of
+        undefined -> Info0;
+        {ok, [{HTTPS_IP, HTTPS_Port}]} -> [{https, {HTTPS_IP, HTTPS_Port}} | Info0]
+    end,
+    case get_s3_conn_info(Node) of
+        undefined -> Info1;
+        {ok, [{S3_IP, S3_Port}]} -> [{s3, {S3_IP, S3_Port}} | Info1]
     end;
 connection_info(Nodes) when is_list(Nodes) ->
     [ {Node, connection_info(Node)} || Node <- Nodes].
@@ -319,6 +322,15 @@ get_http_conn_info(Node) ->
 get_https_conn_info(Node) ->
     case rpc_get_env(Node, [{riak_api, https},
                             {riak_core, https}]) of
+        {ok, [{IP, Port}|_]} ->
+            {ok, [{IP, Port}]};
+        _ ->
+            undefined
+    end.
+
+-spec get_s3_conn_info(node()) -> [{inet:ip_address(), pos_integer()}].
+get_s3_conn_info(Node) ->
+    case rpc_get_env(Node, [{riak_s3_api, http}]) of
         {ok, [{IP, Port}|_]} ->
             {ok, [{IP, Port}]};
         _ ->
@@ -1636,6 +1648,12 @@ http_url(Nodes) when is_list(Nodes) ->
      end || {_Node, Connections} <- connection_info(Nodes)];
 http_url(Node) ->
     hd(http_url([Node])).
+
+s3_url(Nodes) when is_list(Nodes) ->
+    [begin
+         {Host, Port} = orddict:fetch(s3, Connections),
+         lists:flatten(io_lib:format("http://~s:~b", [Host, Port]))
+     end || {_Node, Connections} <- connection_info(Nodes)].
 
 %% @doc get me an http client.
 -spec httpc(node()) -> term().

--- a/tests/s3_api_gradle.erl
+++ b/tests/s3_api_gradle.erl
@@ -43,9 +43,9 @@ confirm() ->
         S3_URL
     ],
     Cmd = lists:flatten(io_lib:format(
-        "cd ../s3-api-tests"
+        "cd deps/s3_api_tests"
         " && "
-        "./gradlew -Daws.accessKeyId=~s -Daws.secretKey=~s -Ds3.api.baseUrl=~s test --stacktrace --info",
+        "./gradlew -Daws.accessKeyId=~s -Daws.secretKey=~s -Ds3.api.baseUrl=~s s3MinimalAPITests --stacktrace --info",
         Args)),
     lager:info(Cmd),
     Output = os:cmd(Cmd),

--- a/tests/s3_api_gradle.erl
+++ b/tests/s3_api_gradle.erl
@@ -12,6 +12,12 @@ confirm() ->
     Nodes = rt:deploy_nodes(?NODE_COUNT),
     ok = rt:wait_until_nodes_ready(Nodes),
 
+    %% Set to testing profile backend on all the nodes
+    {[ok, ok, ok], []} = rpc:multicall(Nodes,
+                                       application,
+                                       set_env,
+                                       [riak_s3_api, default_user_backend, riak_s3_user_profile_backend]),
+
     %% Get S3 URLs
     URLs = rt:s3_url(Nodes),
     S3_URL = lists:nth(random:uniform(?NODE_COUNT), URLs),
@@ -20,7 +26,7 @@ confirm() ->
     Cmd = lists:flatten([
                             "cd ../s3-api-tests",
                             " && ",
-                            io_lib:format("./gradlew -Ds3.api.baseUrl=~s s3ApiTests --info", [S3_URL])
+                            io_lib:format("./gradlew -Ds3.api.baseUrl=~s test --info", [S3_URL])
                         ]),
     lager:info(Cmd),
     Output = os:cmd(Cmd),

--- a/tests/s3_api_gradle.erl
+++ b/tests/s3_api_gradle.erl
@@ -1,0 +1,41 @@
+-module(s3_api_gradle).
+-include_lib("eunit/include/eunit.hrl").
+
+-behavior(riak_test).
+-export([
+    confirm/0
+]).
+
+-define(NODE_COUNT, 3).
+
+confirm() ->
+    Nodes = rt:deploy_nodes(?NODE_COUNT),
+    ok = rt:wait_until_nodes_ready(Nodes),
+
+    %% Get S3 URLs
+    URLs = rt:s3_url(Nodes),
+    S3_URL = lists:nth(random:uniform(?NODE_COUNT), URLs),
+
+    %% Run Gradle-based tests
+    Cmd = lists:flatten([
+                            "cd ../s3-api-tests",
+                            " && ",
+                            io_lib:format("./gradlew -Ds3.api.baseUrl=~s s3ApiTests --info", [S3_URL])
+                        ]),
+    lager:info(Cmd),
+    Output = os:cmd(Cmd),
+    Lines0 = string:tokens(Output, "\n"),
+
+    %% Log Gradle output
+    [lager:info(O) || O <- Lines0],
+
+    %% Check output for lines that end in 'FAILED'
+    Lines1 = lists:filter(fun ("DELIAF" ++ _) -> true;
+                              (_) -> false
+                          end,
+                          [lists:reverse(L) || L <- Lines0]),
+
+    case length(Lines1) of
+        0 -> pass;
+        _ -> gradle_tests_failed
+    end.

--- a/tests/s3_api_gradle.erl
+++ b/tests/s3_api_gradle.erl
@@ -1,33 +1,54 @@
 -module(s3_api_gradle).
--include_lib("eunit/include/eunit.hrl").
 
 -behavior(riak_test).
+
+-include_lib("eunit/include/eunit.hrl").
+
 -export([
     confirm/0
 ]).
 
 -define(NODE_COUNT, 3).
+-define(TEST_USER, ["test", "test@example.com"]).
+-define(METADATA_KEY, [{<<"security">>, <<"users">>}, <<"test">>]).
 
 confirm() ->
-    Nodes = rt:deploy_nodes(?NODE_COUNT),
-    ok = rt:wait_until_nodes_ready(Nodes),
+    %% Build a simple cluster
+    Nodes = rt:build_cluster(?NODE_COUNT),
 
-    %% Set to testing profile backend on all the nodes
-    {[ok, ok, ok], []} = rpc:multicall(Nodes,
-                                       application,
-                                       set_env,
-                                       [riak_s3_api, default_user_backend, riak_s3_user_profile_backend]),
+    %% Choose random node to interact with
+    Node = lists:nth(random:uniform(?NODE_COUNT), Nodes),
+
+    %% Create test user and wait for it to appear on the cluster
+    _ = rpc:call(Node, riak_s3_user, create, ?TEST_USER),
+    rt:wait_until(fun() ->
+                        {Results, []} = rpc:multicall(Nodes, riak_core_metadata, get, ?METADATA_KEY),
+                        case lists:filter(fun(R) -> R == undefined end, Results) of
+                            [] -> false;
+                            _ -> true
+                        end
+                  end),
+    [
+        {"s3.access_key_id", S3AccessKey},
+        {"s3.display_name", _},
+        {"s3.secret_access_key", S3SecretKey}
+    ] = rpc:call(Node, riak_core_metadata, get, ?METADATA_KEY),
 
     %% Get S3 URLs
     URLs = rt:s3_url(Nodes),
     S3_URL = lists:nth(random:uniform(?NODE_COUNT), URLs),
 
     %% Run Gradle-based tests
-    Cmd = lists:flatten([
-                            "cd ../s3-api-tests",
-                            " && ",
-                            io_lib:format("./gradlew -Ds3.api.baseUrl=~s test --info", [S3_URL])
-                        ]),
+    Args = [
+        S3AccessKey,
+        S3SecretKey,
+        S3_URL
+    ],
+    Cmd = lists:flatten(io_lib:format(
+        "cd ../s3-api-tests"
+        " && "
+        "./gradlew -Daws.accessKeyId=~s -Daws.secretKey=~s -Ds3.api.baseUrl=~s test --info",
+        Args)),
     lager:info(Cmd),
     Output = os:cmd(Cmd),
     Lines0 = string:tokens(Output, "\n"),
@@ -36,8 +57,8 @@ confirm() ->
     [lager:info(O) || O <- Lines0],
 
     %% Check output for lines that end in 'FAILED'
-    Lines1 = lists:filter(fun ("DELIAF" ++ _) -> true;
-                              (_) -> false
+    Lines1 = lists:filter(fun("DELIAF" ++ _) -> true;
+                             (_) -> false
                           end,
                           [lists:reverse(L) || L <- Lines0]),
 


### PR DESCRIPTION
Add a test that delegates to the Gradle-based tests in the `s3-api-tests` repo (a copy of which is expected to be checked out next to `riak_test`). It runs the gradle tests and checks the output for any lines that end in `FAILED`, which would indicate a test failure. If any are found, the test is considered to have failed. Output from the Gradle test run is logged to info level. Still need to add some logic to start riak with the S3 API using the profile backend for testing.