### PR TITLE
get qbuf dir directly from riak_kv env

### DIFF
--- a/tests/ts_simple_query_buffers_SUITE.erl
+++ b/tests/ts_simple_query_buffers_SUITE.erl
@@ -168,7 +168,7 @@ init_per_testcase(query_orderby_max_data_size_error, Cfg) ->
 
 init_per_testcase(query_orderby_ldb_io_error, Cfg) ->
     Node = hd(proplists:get_value(cluster, Cfg)),
-    QBufDir = filename:join([rtdev:node_path(Node), "data/query_buffers"]),
+    {ok, QBufDir} = rpc:call(Node, application, get_env, [riak_kv, timeseries_query_buffers_root_path]),
     modify_dir_access(take_away, QBufDir),
     Cfg;
 
@@ -187,7 +187,7 @@ end_per_testcase(query_orderby_max_data_size_error, Cfg) ->
 
 end_per_testcase(query_orderby_ldb_io_error, Cfg) ->
     Node = hd(proplists:get_value(cluster, Cfg)),
-    QBufDir = filename:join([rtdev:node_path(Node), "data/query_buffers"]),
+    {ok, QBufDir} = rpc:call(Node, application, get_env, [riak_kv, timeseries_query_buffers_root_path]),
     modify_dir_access(give_back, QBufDir),
     ok;
 end_per_testcase(_, Cfg) ->


### PR DESCRIPTION
When "removing" query buffer root dir to emulate IO error in query_orderby_ldb_io_error, a default value for that dir was used. For the cases when it is set to some other value in riak.conf (or similar), we need to correctly read it from application env.