### PR TITLE
Allow redbug to be enabled from the config file

### DIFF
--- a/src/riak_test_escript.erl
+++ b/src/riak_test_escript.erl
@@ -211,10 +211,6 @@ parse_command_line_tests(ParsedArgs) ->
                    [] -> [undefined];
                    UpgradeList -> UpgradeList
                end,
-    %% this is a little ugly, the process that creates the ets table to store
-    %% the tracing state cannot shutdown or the table will be gc'ed, so create
-    %% a dummy proc that doens't die
-    rt_redbug:new(),
     rt_redbug:set_tracing_applied(proplists:is_defined(apply_traces, ParsedArgs)),
     %% Parse Command Line Tests
     {CodePaths, SpecificTests} =

--- a/src/rt_redbug.erl
+++ b/src/rt_redbug.erl
@@ -31,13 +31,17 @@
 -export([trace/2, trace/3]).
 
 set_tracing_applied(TracingApplied) when is_boolean(TracingApplied) ->
-    %% If this flag is set on the command line, but not in the config file
-    %% then switch it on.
-    Enabled = case rt_config:get(apply_traces, undefined) of
-        undefined -> TracingApplied;
-        ConfigValue -> ConfigValue
+    %% Enable redbug tracing if enabled via command-line or config file
+    Enabled = case TracingApplied of
+        true -> TracingApplied;
+        _ -> rt_config:get(apply_traces, false)
     end,
-    lager:info("Setting apply tracing to ~p", [Enabled]),
+    case Enabled of
+        true ->
+            lager:warning("Will enable any redbug traces contained in the test");
+        _ ->
+            lager:warning("Will not enable any redbug traces contained in the test")
+    end,
     rt_config:set(apply_traces, Enabled).
 
 is_tracing_applied() ->

--- a/src/rt_redbug.erl
+++ b/src/rt_redbug.erl
@@ -26,21 +26,22 @@
 -module(rt_redbug).
 
 -export([is_tracing_applied/0]).
--export([new/0]).
 -export([set_tracing_applied/1]).
 -export([stop/1]).
 -export([trace/2, trace/3]).
 
-%% Create a new ets to store globally whether we're tracing or not.
-new() -> 
-    ok.
-
 set_tracing_applied(TracingApplied) when is_boolean(TracingApplied) ->
-    lager:info("Setting apply tracing to ~p", [TracingApplied]),
-    rt_config:set(apply_traces, TracingApplied).
+    %% If this flag is set on the command line, but not in the config file
+    %% then switch it on.
+    Enabled = case rt_config:get(apply_traces, undefined) of
+        undefined -> TracingApplied;
+        ConfigValue -> ConfigValue
+    end,
+    lager:info("Setting apply tracing to ~p", [Enabled]),
+    rt_config:set(apply_traces, Enabled).
 
 is_tracing_applied() ->
-    rt_config:get(apply_traces).
+    rt_config:get(apply_traces, false).
 
 %% Apply traces to one or more nodes using redbug tracing and syntax.
 %%


### PR DESCRIPTION
Now you can also set `{apply_traces, true}` in the `.riak_test.config` file