### PR TITLE
Added test for TS CREATE TABLE query-ready postcondition

### DIFF
--- a/intercepts/riak_kv_ts_newtype_intercepts.erl
+++ b/intercepts/riak_kv_ts_newtype_intercepts.erl
@@ -1,0 +1,37 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2016 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(riak_kv_ts_newtype_intercepts).
+-compile(export_all).
+-include("intercept.hrl").
+
+-define(M, riak_kv_ts_newtype_orig).
+
+delayed_new_type(BucketType) ->
+    intercepted_new_type(BucketType, 10, "delayed").
+
+really_delayed_new_type(BucketType) ->
+    intercepted_new_type(BucketType, 100, "really_delayed").
+
+intercepted_new_type(BucketType, Delay, DelayType) ->
+    DelayTypeFormat = DelayType ++ "~n",
+    io:format(DelayTypeFormat),
+    ?I_INFO(DelayTypeFormat),
+    timer:sleep(Delay),
+    ?M:new_type_orig(BucketType).

--- a/tests/ts_cluster_table_active_state.erl
+++ b/tests/ts_cluster_table_active_state.erl
@@ -28,10 +28,7 @@ confirm() ->
     %% Set the maximum wait between CREATE TABLE and subsequent query in milliseconds.
     MaxWait = 1000,
     NodeCount = 8,
-    %% massive attack perturbed the race condition consistently, not ideal, but
-    %% once identified, this test should be changed to a feature test by reducing
-    %% to a single run.
-    Runs = 100,
+    Runs = 30,
     [_Node,ClientNode|_NodesT] = Cluster = ts_setup:start_cluster(NodeCount),
     PBPid = rt:pbc(ClientNode),
     slow_ddl_compilation(Cluster),
@@ -45,7 +42,7 @@ run(_PBPid, _Cluster, _MaxWait, _Run=0, _Runs) ->
 run(PBPid, Cluster, MaxWait, Run, Runs) ->
     lager:info("Run ~p/~p", [Run, Runs]),
     Waits = [ case Div of
-                  0 -> MaxWait;
+                  0 -> 0;
                   _ -> MaxWait div Div
               end || Div <- [0, 20, 10, 5, 2, 1] ],
     [ create_and_query(PBPid, Wait) || Wait <- Waits ],

--- a/tests/ts_cluster_table_active_state.erl
+++ b/tests/ts_cluster_table_active_state.erl
@@ -1,0 +1,67 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2016 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(ts_cluster_table_active_state).
+
+-behavior(riak_test).
+-export([confirm/0]).
+-include_lib("eunit/include/eunit.hrl").
+
+confirm() ->
+    %% Set the maximum wait between CREATE TABLE and subsequent query in milliseconds.
+    MaxWait = 5000,
+    NodeCount = 8,
+    [_Node,ClientNode|_NodesT] = _Cluster = ts_setup:start_cluster(NodeCount),
+    PBPid = rt:pbc(ClientNode),
+    Waits = [ case Div of
+                  0 -> MaxWait;
+                  _ -> MaxWait div Div
+              end || Div <- [0, 20, 10, 5, 2, 1] ],
+    [ create_and_query(PBPid, Wait) || Wait <- Waits ],
+    pass.
+
+create_and_query(PBPid, PostCreateWait) ->
+    EmptyRes = {ok, {[], []}},
+    Table = "ts_cluster_table_active_state_" ++ timestamp_string(),
+    CreateSql = create_sql(Table),
+    InsertSql = insert_sql(Table),
+    CreateRes = riakc_ts:query(PBPid, CreateSql),
+    timer:sleep(PostCreateWait),
+    InsertRes = riakc_ts:query(PBPid, InsertSql),
+    ?assertMatch(EmptyRes,
+                 CreateRes),
+    ?assertMatch(EmptyRes,
+                 InsertRes).
+
+create_sql(Table) ->
+    "CREATE TABLE " ++ Table ++
+    "(ts TIMESTAMP NOT NULL," ++
+    " PRIMARY KEY((QUANTUM(ts, 1, 'd')), ts))".
+
+insert_sql(Table) ->
+    "INSERT INTO " ++ Table ++
+    " VALUES(" ++ timestamp_string() ++ ")".
+
+timestamp_int() ->
+    {MegaSecs, Secs, MicroSecs} = os:timestamp(),
+    MegaSecs * 1000000000000 + Secs * 1000000 + MicroSecs.
+
+timestamp_string() ->
+    integer_to_list(timestamp_int()).


### PR DESCRIPTION
* added test for post-condition of TS CREATE TABLE resulting in an active, query-ready table.

Relates to: https://github.com/basho/riak_kv/pull/1577