### PR TITLE
test in-memory ORDER BY

### DIFF
--- a/intercepts/riak_kv_qry_buffers_intercepts.erl
+++ b/intercepts/riak_kv_qry_buffers_intercepts.erl
@@ -1,0 +1,35 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2016 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%%-------------------------------------------------------------------
+
+-module(riak_kv_qry_buffers_intercepts).
+-compile(export_all).
+-include("intercept.hrl").
+
+-define(M, riak_kv_qry_buffers_orig).
+
+%% @doc simulate memory shortage to force inmem->ldb transition
+can_afford_inmem_random(_) ->
+    random:uniform(10) > 5.
+
+can_afford_inmem_yes(_) ->
+    true.
+
+can_afford_inmem_no(_) ->
+    false.

--- a/tests/ts_qbuf_util.hrl
+++ b/tests/ts_qbuf_util.hrl
@@ -31,3 +31,4 @@
 -define(E_QBUF_CREATE_ERROR,     1023).
 -define(E_QBUF_LDB_ERROR,        1024).
 -define(E_QUANTA_LIMIT,          1025).
+-define(E_QBUF_INTERNAL_ERROR,   1027).

--- a/tests/ts_simple_query_buffers_SUITE.erl
+++ b/tests/ts_simple_query_buffers_SUITE.erl
@@ -165,7 +165,7 @@ init_per_testcase(query_orderby_max_data_size_error, Cfg) ->
 
 init_per_testcase(query_orderby_ldb_io_error, Cfg) ->
     Node = hd(proplists:get_value(cluster, Cfg)),
-    QBufDir = filename:join([rtdev:node_path(Node), "data/query_buffers"]),
+    QBufDir = get_qbuf_dir(Node),
     modify_dir_access(take_away, QBufDir),
     Cfg;
 
@@ -184,7 +184,7 @@ end_per_testcase(query_orderby_max_data_size_error, Cfg) ->
 
 end_per_testcase(query_orderby_ldb_io_error, Cfg) ->
     Node = hd(proplists:get_value(cluster, Cfg)),
-    QBufDir = filename:join([rtdev:node_path(Node), "data/query_buffers"]),
+    QBufDir = get_qbuf_dir(Node),
     modify_dir_access(give_back, QBufDir),
     ok;
 end_per_testcase(_, Cfg) ->
@@ -336,6 +336,15 @@ col_no({[A|_], _}) ->
 col_no({[A|_], _, _}) ->
     A - $a + 1.
 
+
+get_qbuf_dir(Node) ->
+    {ok, QBufDir} = rpc:call(Node, application, get_env, [riak_kv, timeseries_query_buffers_root_path]),
+    case hd(QBufDir) of
+        $/ ->
+            QBufDir;
+        _ ->
+            filename:join([rtdev:node_path(Node), QBufDir])
+    end.
 
 modify_dir_access(take_away, QBufDir) ->
     ct:pal("take away access to ~s\n", [QBufDir]),

--- a/tests/ts_simple_query_buffers_SUITE.erl
+++ b/tests/ts_simple_query_buffers_SUITE.erl
@@ -49,7 +49,6 @@
 -include_lib("eunit/include/eunit.hrl").
 -include("ts_qbuf_util.hrl").
 
--define(TABLE2, "t2").  %% used to check for expiry; not to interfere with t1
 -define(RIDICULOUSLY_SMALL_MAX_QUERY_DATA_SIZE, 100).
 -define(RIDICULOUSLY_SMALL_MAX_QUERY_QUANTA, 3).
 
@@ -63,9 +62,7 @@ init_per_suite(Cfg) ->
     Data = ts_qbuf_util:make_data(),
     ExtraData = ts_qbuf_util:make_extra_data(),
     ok = ts_qbuf_util:create_table(C, ?TABLE),
-    ok = ts_qbuf_util:create_table(C, ?TABLE2),
     ok = ts_qbuf_util:insert_data(C, ?TABLE,  Data),
-    ok = ts_qbuf_util:insert_data(C, ?TABLE2, Data),
     [{cluster, Cluster},
      {data, Data},
      {extra_data, ExtraData}

--- a/tests/ts_simple_query_buffers_SUITE.erl
+++ b/tests/ts_simple_query_buffers_SUITE.erl
@@ -373,10 +373,33 @@ sort_by(Data, OrderBy) ->
                             F2 = element(C, R2),
                             if F1 == F2 ->
                                     undefined;  %% let fields of lower precedence decide
-                               F1 == [] andalso F2 /= [] ->
-                                    Nul == "nulls first";
-                               F1 /= [] andalso F2 == [] ->
-                                    Nul == "nulls last";
+
+                               (F1 /= []) and (F2 == []) ->
+                                    %% null < Value?
+                                    case {Nul, Dir} of
+                                        {"nulls first", "asc"} ->
+                                            false;
+                                        {"nulls first", "desc"} ->
+                                            true;
+                                        {"nulls last", "asc"} ->
+                                            true;
+                                        {"nulls last", "desc"} ->
+                                            false
+                                    end;
+
+                               (F1 == []) and (F2 /= []) ->
+                                    %% null > Value?
+                                    case {Nul, Dir} of
+                                        {"nulls first", "asc"} ->
+                                            true;
+                                        {"nulls first", "desc"} ->
+                                            false;
+                                        {"nulls last", "asc"} ->
+                                            false;
+                                        {"nulls last", "desc"} ->
+                                            true
+                                    end;
+
                                F1 < F2 ->
                                     (Dir == "asc");
                                F1 > F2 ->

--- a/utils/riak_test.bash
+++ b/utils/riak_test.bash
@@ -25,5 +25,4 @@ _riak_test()
             ;;
     esac
 }
-complete -F _riak_test riak_test
-
+complete -F _riak_test riak_test ./riak_test


### PR DESCRIPTION
RTS-1641

Depends on https://github.com/basho/riak_kv/pull/1587.

New test case to check the delayed leveldb ops in query buffers, with rudimentary performance stats.