### PR TITLE
Update s3-api-tests dependency

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -19,7 +19,7 @@
         {meck, ".*", {git, "https://github.com/basho/meck.git", {tag, "0.8.2"}}},
         {rebar_lock_deps_plugin, ".*", {git, "https://github.com/basho/rebar_lock_deps_plugin.git", {tag, "3.1.0p1"}}},
         {riakc, ".*", {git, "https://github.com/basho/riak-erlang-client", {branch, "develop"}}},
-        {s3_api_tests, ".*", {git, "git@github.com:basho/s3-api-tests.git", {branch, "minimal-api-tests"}}, [raw]},
+        {s3_api_tests, ".*", {git, "git@github.com:basho/s3-api-tests.git", {branch, "master"}}, [raw]},
         {riakhttpc, ".*", {git, "https://github.com/basho/riak-erlang-http-client", {branch, "develop"}}}
        ]}.
 

--- a/rebar.config.lock
+++ b/rebar.config.lock
@@ -43,7 +43,7 @@
                    "d5d4150799084ce34a36afadfa7cc65df6f4638c"}},
        {s3_api_tests,".*",
                      {git,"git@github.com:basho/s3-api-tests.git",
-                          "ca76d60be7b6433ab231b7d7061aee803362bb85"},
+                          "9df8114b82b83d8b63d9ad967d12d221721d7638"},
                      [raw]},
        {ibrowse,".*",
                 {git,"https://github.com/basho/ibrowse.git",


### PR DESCRIPTION
We will need to update `rebar.config.lock` and merge this after we merge https://github.com/basho/s3-api-tests/pull/8