### PR TITLE
Update build versions and remove git --local options

### DIFF
--- a/bin/rtdev-install.sh
+++ b/bin/rtdev-install.sh
@@ -47,11 +47,14 @@ cd $RT_DEST_DIR
 echo " - Reinitializing git state"
 
 ## Some versions of git and/or OS require these fields
-#git config --local user.name "Riak Test"
-#git config --local user.email "dev@basho.com"
-#git config --local core.autocrlf input
-#git config --local core.safecrlf false
-#git config --local core.filemode true
+HAS_LOCAL=$(git config --local 2>&1 | grep unknown)
+if [ -z "$HAS_LOCAL" ]; then
+    git config --local user.name "Riak Test"
+    git config --local user.email "dev@basho.com"
+    git config --local core.autocrlf input
+    git config --local core.safecrlf false
+    git config --local core.filemode true
+fi
 
 git add --all --force .
 git commit -a -m "riak_test init" --amend > /dev/null


### PR DESCRIPTION
Older versions of git, like those shipped with platforms we are using for testing like CentOS 6 do not support `git config --local`

```
git --version
git version 1.7.1
git config --local user.name "Riak Test"
error: unknown option `local'
```