### PR TITLE
Group by time in the GROUP BY clause RTS-1689

### DIFF
--- a/tests/ts_cluster_group_by_SUITE.erl
+++ b/tests/ts_cluster_group_by_SUITE.erl
@@ -116,8 +116,25 @@ group_by_2_test(Ctx) ->
         {ok,{Cols, lists:sort(Rows)}}
     ).
 
-
-
+group_by_time_test(Ctx) ->
+    ?assertMatch(
+        {ok, _},
+        riakc_ts:query(client_pid(Ctx),
+            "CREATE TABLE grouptab3 ("
+            "a TIMESTAMP NOT NULL, "
+            "PRIMARY KEY ((quantum(a,1,s)), a))"
+    )),
+    ok = riakc_ts:put(client_pid(Ctx), <<"grouptab3">>,
+        [{A} || A <- lists:seq(1,10000,2)]),
+    Query =
+        "SELECT COUNT(*) FROM grouptab3 "
+        "WHERE a >= 1 AND a <= 10000"
+        "GROUP BY time(a,1s)",
+    {ok, {Cols, Rows}} = run_query(Ctx, Query),
+    ts_data:assert_row_sets(
+        {rt_ignore_columns, [{N*1000,500} || N <- lists:seq(0,9)]},
+        {ok,{Cols, lists:sort(Rows)}}
+    ).
 
 
 

--- a/tests/ts_cluster_group_by_SUITE.erl
+++ b/tests/ts_cluster_group_by_SUITE.erl
@@ -127,7 +127,7 @@ group_by_time_test(Ctx) ->
     ok = riakc_ts:put(client_pid(Ctx), <<"grouptab3">>,
         [{A} || A <- lists:seq(1,10000,2)]),
     Query =
-        "SELECT COUNT(*) FROM grouptab3 "
+        "SELECT time(a,1s), COUNT(*) FROM grouptab3 "
         "WHERE a >= 1 AND a <= 10000"
         "GROUP BY time(a,1s)",
     {ok, {Cols, Rows}} = run_query(Ctx, Query),


### PR DESCRIPTION
Allowing grouping by time in the `GROUP BY` clause.

RFC: https://github.com/basho/rfc/pull/50
riak_ql: https://github.com/basho/riak_ql/pull/164
riak_kv: https://github.com/basho/riak_kv/pull/1600
riak_test: https://github.com/basho/riak_test/pull/1266