### PR TITLE
correctly spell timeseries_query_max_quanta_span parameter [JIRA: RIAK-3218]

### DIFF
--- a/tests/ts_simple_query_buffers_SUITE.erl
+++ b/tests/ts_simple_query_buffers_SUITE.erl
@@ -158,7 +158,7 @@ rollup(N, FF, Acc) ->
 
 init_per_testcase(query_orderby_max_quanta_error, Cfg) ->
     Node = hd(proplists:get_value(cluster, Cfg)),
-    ok = rpc:call(Node, application, set_env, [riak_kv, max_query_quanta, ?RIDICULOUSLY_SMALL_MAX_QUERY_QUANTA]),
+    ok = rpc:call(Node, application, set_env, [riak_kv, timeseries_query_max_quanta_span, ?RIDICULOUSLY_SMALL_MAX_QUERY_QUANTA]),
     Cfg;
 
 init_per_testcase(query_orderby_max_data_size_error, Cfg) ->
@@ -177,7 +177,7 @@ init_per_testcase(_, Cfg) ->
 
 end_per_testcase(query_orderby_max_quanta_error, Cfg) ->
     Node = hd(proplists:get_value(cluster, Cfg)),
-    ok = rpc:call(Node, application, set_env, [riak_kv, max_query_quanta, 1000]),
+    ok = rpc:call(Node, application, set_env, [riak_kv, timeseries_query_max_quanta_span, 1000]),
     ok;
 
 end_per_testcase(query_orderby_max_data_size_error, Cfg) ->


### PR DESCRIPTION
This is to match the spelling fix in https://github.com/basho/riak_kv/pull/1583.