### PR TITLE
Fix test failures caused by riak client not allowing list keys

### DIFF
--- a/tests/bucket_types.erl
+++ b/tests/bucket_types.erl
@@ -8,6 +8,10 @@
 confirm() ->
     application:start(inets),
     lager:info("Deploy some nodes"),
+
+    %% Allow listing of buckets and keys for testing
+    application:set_env(riakc, allow_listing, true),
+
     Nodes = rt:build_cluster(4, [], [
                                      {riak_core, [{default_bucket_props,
                                                    [

--- a/tests/http_security.erl
+++ b/tests/http_security.erl
@@ -11,6 +11,9 @@
 -define(assertDenied(Op), ?assertMatch({error, {forbidden, _}}, Op)).
 
 confirm() ->
+    %% Allow listing of buckets and keys for testing
+    application:set_env(riakc, allow_listing, true),
+
     application:start(crypto),
     application:start(asn1),
     application:start(public_key),

--- a/tests/overload.erl
+++ b/tests/overload.erl
@@ -1,6 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%% Copyright (c) 2013 Basho Technologies, Inc.
+%% Copyright (c) 2013-2017 Basho Technologies, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -81,6 +81,9 @@ default_config(#config{
         {riak_api, [{pb_backlog, 1024}]}].
 
 confirm() ->
+    %% Allow listing of buckets and keys for testing
+    application:set_env(riakc, allow_listing, true),
+
     [Node1 | _] = Nodes = setup(),
 
     ok = create_bucket_type(Nodes, ?NORMAL_TYPE, [{n_val, 3}]),

--- a/tests/pb_security.erl
+++ b/tests/pb_security.erl
@@ -11,6 +11,9 @@
 -define(assertDenied(Op), ?assertMatch({error, <<"Permission",_/binary>>}, Op)).
 
 confirm() ->
+    %% Allow listing of buckets and keys for testing
+    application:set_env(riakc, allow_listing, true),
+
     application:start(crypto),
     application:start(asn1),
     application:start(public_key),

--- a/tests/rolling_capabilities.erl
+++ b/tests/rolling_capabilities.erl
@@ -1,6 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%% Copyright (c) 2012 Basho Technologies, Inc.
+%% Copyright (c) 2012-2017 Basho Technologies, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -23,6 +23,9 @@
 -include_lib("eunit/include/eunit.hrl").
 
 confirm() ->
+    %% Allow listing of buckets and keys for testing
+    application:set_env(riakc, allow_listing, true),
+
     TestMetaData = riak_test_runner:metadata(),
     Count = 4,
     OldVsn = proplists:get_value(upgrade_version, TestMetaData, previous),

--- a/tests/ts_cluster_comprehensive.erl
+++ b/tests/ts_cluster_comprehensive.erl
@@ -1,6 +1,6 @@
 % -------------------------------------------------------------------
 %%
-%% Copyright (c) 2015 Basho Technologies, Inc.
+%% Copyright (c) 2015-2017 Basho Technologies, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -39,6 +39,9 @@ confirm() ->
     run_tests(?PVAL_P1, ?PVAL_P2).
 
 run_tests(PvalP1, PvalP2) ->
+    %% Allow listing of buckets and keys for testing
+    application:set_env(riakc, allow_listing, true),
+
     Data = make_data(PvalP1, PvalP2),
     io:format("Data to be written:\n~p\n...\n~p\n", [hd(Data), lists:last(Data)]),
 

--- a/tests/ts_cluster_list_irreg_keys_SUITE.erl
+++ b/tests/ts_cluster_list_irreg_keys_SUITE.erl
@@ -1,6 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%% Copyright (c) 2016 Basho Technologies, Inc.
+%% Copyright (c) 2016-2017 Basho Technologies, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -39,6 +39,9 @@
 %%--------------------------------------------------------------------
 
 suite() ->
+    %% Allow listing of buckets and keys for testing
+    application:set_env(riakc, allow_listing, true),
+
     [{timetrap,{minutes,10}}].
 
 init_per_suite(Config) ->

--- a/tests/ts_cluster_stream_list_keys_SUITE.erl
+++ b/tests/ts_cluster_stream_list_keys_SUITE.erl
@@ -1,6 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%% Copyright (c) 2016 Basho Technologies, Inc.
+%% Copyright (c) 2016-2017 Basho Technologies, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -31,6 +31,9 @@
 %%--------------------------------------------------------------------
 
 suite() ->
+    %% Allow listing of buckets and keys for testing
+    application:set_env(riakc, allow_listing, true),
+
     [{timetrap,{minutes,10}}].
 
 init_per_suite(Config) ->

--- a/tests/ts_simple_pb_security_SUITE.erl
+++ b/tests/ts_simple_pb_security_SUITE.erl
@@ -1,6 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%% Copyright (c) 2016 Basho Technologies, Inc.
+%% Copyright (c) 2016-2017 Basho Technologies, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -31,6 +31,9 @@
 %%--------------------------------------------------------------------
 
 suite() ->
+    %% Allow listing of buckets and keys for testing
+    application:set_env(riakc, allow_listing, true),
+
     [{timetrap,{minutes,10}}].
 
 init_per_suite(Config) ->

--- a/tests/verify_api_timeouts.erl
+++ b/tests/verify_api_timeouts.erl
@@ -8,6 +8,9 @@
 -define(NUM_KEYS, 1000).
 
 confirm() ->
+    %% Allow listing of buckets and keys for testing
+    application:set_env(riakc, allow_listing, true),
+
     %% test requires allow_mult=false b/c of rt:systest_read
     [Node] = rt:build_cluster(1),
     rt:wait_until_pingable(Node),

--- a/tests/verify_capabilities.erl
+++ b/tests/verify_capabilities.erl
@@ -1,6 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%% Copyright (c) 2012-2013 Basho Technologies, Inc.
+%% Copyright (c) 2012-2017 Basho Technologies, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -25,6 +25,9 @@
 %% 1.4 {riak_kv, handoff_data_encoding} -> [encode_raw, encode_zlib]
 %% 1.3 {riak_kv, anti_entropy} -> [disabled, enabled_v1]
 confirm() ->
+    %% Allow listing of buckets and keys for testing
+    application:set_env(riakc, allow_listing, true),
+
     lager:info("Deploying mixed set of nodes"),
     Legacy = case lists:member(legacy, rt:versions()) of
         true -> legacy;

--- a/tests/verify_dt_data_upgrade.erl
+++ b/tests/verify_dt_data_upgrade.erl
@@ -1,6 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%% Copyright (c) 2016 Basho Technologies, Inc.
+%% Copyright (c) 2016-2017 Basho Technologies, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -47,7 +47,7 @@
 
 confirm() ->
     TestMetaData = riak_test_runner:metadata(),
-    OldVsn = proplists:get_value(upgrade_version, TestMetaData, lts),
+    OldVsn = proplists:get_value(upgrade_version, TestMetaData, legacy),
 
     NumNodes = 4,
     Vsns = [{OldVsn, ?CONFIG} || _ <- lists:seq(1, NumNodes)],
@@ -116,7 +116,7 @@ confirm() ->
     ?assertEqual(FetchSet2, FetchSet3),
 
     %% Downgrade All Nodes and Compare
-    downgrade(Nodes, lts),
+    downgrade(Nodes, legacy),
 
     %% Create PB connection.
     Pid3 = rt:pbc(rt:select_random(Nodes)),

--- a/tests/verify_job_enable_ac.erl
+++ b/tests/verify_job_enable_ac.erl
@@ -1,6 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%% Copyright (c) 2016 Basho Technologies, Inc.
+%% Copyright (c) 2016-2017 Basho Technologies, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -36,6 +36,9 @@
     [Class || {Class, Enabled} <- ?JOB_CLASS_DEFAULTS, Enabled]).
 
 confirm() ->
+    %% Allow listing of buckets and keys for testing
+    application:set_env(riakc, allow_listing, true),
+
     lager:info("Deploying 1 node"),
     rt:set_backend(eleveldb),
     [Node] = rt:build_cluster(1, ?CFG),

--- a/tests/verify_job_enable_rc.erl
+++ b/tests/verify_job_enable_rc.erl
@@ -1,6 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%% Copyright (c) 2016 Basho Technologies, Inc.
+%% Copyright (c) 2016-2017 Basho Technologies, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -47,6 +47,9 @@
 %% ===================================================================
 
 confirm() ->
+    %% Allow listing of buckets and keys for testing
+    application:set_env(riakc, allow_listing, true),
+
     Configs = [
         {current, {cuttlefish,
             ?COMMON_CONFIG ++ config(?TEST_OPS, Bool, [])}}

--- a/tests/verify_listkeys.erl
+++ b/tests/verify_listkeys.erl
@@ -1,6 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%% Copyright (c) 2012 Basho Technologies, Inc.
+%% Copyright (c) 2012-2017 Basho Technologies, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -29,6 +29,9 @@
 -define(UNDEFINED_BUCKET_TYPE,  <<"880bf69d-5dab-44ee-8762-d24c6f759ce1">>).
 
 confirm() ->
+    %% Allow listing of buckets and keys for testing
+    application:set_env(riakc, allow_listing, true),
+
     [Node1, Node2, Node3, Node4] = Nodes = rt:deploy_nodes(4),
     ?assertEqual(ok, rt:wait_until_nodes_ready(Nodes)),
 

--- a/tests/verify_listkeys_eqcfsm.erl
+++ b/tests/verify_listkeys_eqcfsm.erl
@@ -26,6 +26,9 @@
 %% riak_test callback
 %% ====================================================================
 confirm() ->
+    %% Allow listing of buckets and keys for testing
+    application:set_env(riakc, allow_listing, true),
+
     ?assert(eqc:quickcheck(eqc:numtests(?NUM_TESTS, ?MODULE:prop_test()))),
     pass.
 %% ====================================================================

--- a/tests/verify_mr_prereduce_node_down.erl
+++ b/tests/verify_mr_prereduce_node_down.erl
@@ -1,6 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%% Copyright (c) 2013 Basho Technologies, Inc.
+%% Copyright (c) 2013-2017 Basho Technologies, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -42,6 +42,9 @@
 
 %% @doc riak_test callback
 confirm() ->
+    %% Allow listing of buckets and keys for testing
+    application:set_env(riakc, allow_listing, true),
+
     NodeCount = 4,
     lager:info("Build ~b-node cluster", [NodeCount]),
     [Primary,ToKill|_] = rt:build_cluster(NodeCount),


### PR DESCRIPTION
Mostly simply the addition of the `riak-erlang-client` environment variable to allow listing of buckets and keys (now disabled by default).  A couple of actual test changes.