### PR TITLE
riakc_ts:delete(NXKey) now returns ok with w1ce-optimized delete [JIRA: RTS-1811]

### DIFF
--- a/tests/ts_cluster_comprehensive.erl
+++ b/tests/ts_cluster_comprehensive.erl
@@ -158,7 +158,7 @@ confirm_delete(C, {Pooter1, Pooter2, Timepoint, _} = Record) ->
 
 confirm_nx_delete(C) ->
     ?assertEqual(
-        {error, {1021, <<"notfound">>}},
+        ok,
         riakc_ts:delete(C, ?BUCKET, ?BADKEY, [])
     ),
     ok.


### PR DESCRIPTION
The code path of `riakc_ts:delete`, with w1ce delete work (https://github.com/basho/riak_kv/pull/1630) by @erikleitch merged, uses a version of `riak_client:normal_delete_vclock` that gets a `riak_object:new_w1c_vclock()` for its `VClock` arg -- where it had `undefined` previously. This has one uncorrected-for consequence for the callers of `riakc_ts:delete`: the return value for non-existent keys has changed from `{error, notfound}` to `ok`. The `notfound` for delete was generated in the first head of `riak_kv_delete:delete` when a get was used to obtain a vclock to be used for writing a tombstone.

This patch changes the check for return value of `riakc_ts:delete` on non-existent key in `ts_cluster_comprehensive` to `ok`.

The change appears biggish because it's a change to user API, but I really don't know how to preserve the 'notfound' behaviour and reap the benefits of Erik's improvement at the same time.