### PR TITLE
ts_simple_http_api_SUITE now allows success on a non-existent key [JIRA: RTS-1815]

### DIFF
--- a/tests/ts_simple_http_api_SUITE.erl
+++ b/tests/ts_simple_http_api_SUITE.erl
@@ -287,10 +287,9 @@ delete_data_existing_row_test(Cfg) ->
 
 
 delete_data_nonexisting_row_test(Cfg) ->
-    {ok, "404", Headers, Body } = delete("bob", "q1", base64:encode_to_string("w1"), 500, Cfg),
-    "text/plain" = content_type(Headers),
-    "Key not found"
-        = Body.
+    {ok, "200", Headers, Body } = delete("bob", "q1", base64:encode_to_string("w1"), 500, Cfg),
+    "application/json" = content_type(Headers),
+    ?assertEqual("{\"success\":true}", Body).
 
 delete_data_nonexisting_table_test(Cfg) ->
     {ok, "404", Headers, Body } = delete("bill", "q1", base64:encode_to_string("w1"), 20, Cfg),


### PR DESCRIPTION
Part of the write-once vclock optimization effort changed this behavior.