### PR TITLE
Set force_hashtree_upgrade to true

### DIFF
--- a/tests/repl_aae_fullsync.erl
+++ b/tests/repl_aae_fullsync.erl
@@ -29,6 +29,7 @@
             [
              %% Specify fast building of AAE trees
              {sweep_tick, 10000},
+             {force_hashtree_upgrade, true},
              {anti_entropy, {on, [debug]}},
              {anti_entropy_build_limit, {100, 1000}},
              {anti_entropy_concurrency, 100}


### PR DESCRIPTION
This removes the race condition where some nodes are upgrading and others arent in the middle of an active fullsync. We are not testing AAE upgrades with this test so we should disable them.