### PR TITLE
Re-add the G-Sets riak_test code

### DIFF
--- a/tests/verify_crdt_capability.erl
+++ b/tests/verify_crdt_capability.erl
@@ -69,7 +69,8 @@ confirm() ->
                                                         riak_dt_orswot,
                                                         riak_dt_map,
                                                         pncounter,
-                                                        riak_kv_hll])),
+                                                        riak_kv_hll,
+                                                        riak_dt_gset])),
     ?assertMatch(ok, rhc:counter_incr(PrevHttp, ?BUCKET, ?KEY, 1)),
     ?assertMatch({ok, 5}, rhc:counter_val(PrevHttp, ?BUCKET, ?KEY)),
 


### PR DESCRIPTION
Removed from riak_test develop-2.2 branch as the feature was not on the riak_kv develop-2.2 branch, however, the PR https://github.com/basho/riak_kv/pull/1665 will add it for the 2.2.5 release.

I don't think this needs review as it was _already_ in the branch, this is just a pair of `git reverts`