### PR TITLE
These ensemble tests passed by chance

### DIFF
--- a/tests/ensemble_basic3.erl
+++ b/tests/ensemble_basic3.erl
@@ -26,7 +26,7 @@ confirm() ->
     NumNodes = 5,
     NVal = 5,
     Quorum = NVal div 2 + 1,
-    Config = ensemble_util:fast_config(NVal),
+    Config = ensemble_util:fast_config(NVal, 64),
     lager:info("Building cluster and waiting for ensemble to stablize"),
     Nodes = ensemble_util:build_cluster(NumNodes, Config, NVal),
     vnode_util:load(Nodes),

--- a/tests/ensemble_basic4.erl
+++ b/tests/ensemble_basic4.erl
@@ -26,7 +26,7 @@ confirm() ->
     NumNodes = 5,
     NVal = 5,
     Quorum = NVal div 2 + 1,
-    Config = ensemble_util:fast_config(NVal),
+    Config = ensemble_util:fast_config(NVal, 64),
     lager:info("Building cluster and waiting for ensemble to stablize"),
     Nodes = ensemble_util:build_cluster(NumNodes, Config, NVal),
     Node = hd(Nodes),


### PR DESCRIPTION
In 2.2.3 and before the ring created by claim for these ensemble tests
was dangerous, but by good fortune the tests passed. The claim/ring
fixes in 2.2.5 cause the tests to fail. Upping the ring-size to 64
allows the tests to pass legitimately, and with a more realistic
scenario. Sadly they are also slower.