### PR TITLE
Add test that forces rebuild

### DIFF
--- a/groups/kv_all
+++ b/groups/kv_all
@@ -39,6 +39,7 @@ verify_put_opt_node_confirms
 verify_riak_stats
 verify_stats_removal
 verify_tick_change
+verify_tictacrebuild_via_statsfold
 verify_tictac_aae
 verify_vclock
 verify_vclock_raw

--- a/tests/verify_tictacrebuild_via_statsfold.erl
+++ b/tests/verify_tictacrebuild_via_statsfold.erl
@@ -1,0 +1,179 @@
+%% -------------------------------------------------------------------
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+%% @doc Verification of AAE fold's find_keys and object stats
+%% operational fold features
+
+-module(verify_tictacrebuild_via_statsfold).
+-export([confirm/0]).
+-include_lib("eunit/include/eunit.hrl").
+
+-define(DEFAULT_RING_SIZE, 32).
+-define(CFG_TICTACAAE(ExchangeTick, RebuildTick, PoolStrategy),
+        [{riak_kv,
+          [
+           % Speedy AAE configuration
+           {anti_entropy, {off, []}},
+           {tictacaae_active, active},
+           {tictacaae_parallelstore, leveled_ko},
+                % if backend not leveled will use parallel key-ordered
+                % store
+           {tictacaae_rebuildwait, 4},
+           {tictacaae_rebuilddelay, 60},
+           {tictacaae_exchangetick, ExchangeTick}, 
+           {tictacaae_rebuildtick, RebuildTick},
+           {worker_pool_strategy, PoolStrategy}
+          ]},
+         {riak_core,
+          [
+           {ring_creation_size, ?DEFAULT_RING_SIZE},
+           {default_bucket_props, [{allow_mult, true}]}
+          ]}]
+       ).
+-define(CFG_NOAAE, 
+        [{riak_kv,
+          [
+           % Speedy AAE configuration
+           {anti_entropy, {off, []}},
+           {tictacaae_active, passive}
+          ]},
+          {riak_core,
+          [
+           {ring_creation_size, ?DEFAULT_RING_SIZE},
+           {default_bucket_props, [{allow_mult, true}]}
+          ]}]).
+
+-define(NUM_KEYS_PERNODE, 10000).
+-define(BUCKET, <<"test_bucket">>).
+-define(N_VAL, 3).
+-define(DELTA_COUNT, 10).
+
+confirm() ->
+
+    Cluster =
+        rt:deploy_nodes(6, ?CFG_TICTACAAE(60 * 60 * 1000,
+                                            60 * 60 * 1000,
+                                            dscp)),
+        % Build a cluster with AAE - but don't have the AAE do exchanages
+    [Node1, Node2, Node3, _Node4, _Node5, _Node6] = Cluster,
+    rt:set_advanced_conf(Node1, ?CFG_NOAAE),
+    rt:set_advanced_conf(Node2, ?CFG_NOAAE),
+    rt:set_advanced_conf(Node3, ?CFG_NOAAE),
+        % Change 1 node to not use Tictac AAE
+    rt:join_cluster(Cluster),
+    lager:info("Waiting for convergence."),
+    rt:wait_until_ring_converged(Cluster),
+    lists:foreach(fun(N) -> rt:wait_for_service(N, riak_kv) end, Cluster),
+
+    lager:info("Cluster started with one node missing AAE config"),
+
+    HttpCH = rt:httpc(Node1),
+    lager:info("Find Keys for no data "),
+    {ok, {keys, ObjSize}} = rhc:aae_find_keys(HttpCH, ?BUCKET, all, all, {object_size, 1}),
+    ?assertEqual([], ObjSize),
+
+    lager:info("Commencing object load"),
+    KeyLoadFun =
+        fun(KeysPerNode) ->
+            fun(Node, KeyCount) ->
+                    KVs = test_data(KeyCount + 1,
+                                    KeyCount + KeysPerNode,
+                                    list_to_binary("V1")),
+                    ok = write_data(Node, KVs),
+                    KeyCount + KeysPerNode
+            end
+        end,
+
+    TotalKeys = lists:foldl(KeyLoadFun(?NUM_KEYS_PERNODE), 0, Cluster),
+    lager:info("Loaded ~w objects", [?NUM_KEYS_PERNODE * length(Cluster)]),
+    
+    lager:info("get stats"),
+    {ok, {stats, Stats}} = rhc:aae_object_stats(HttpCH, ?BUCKET, all, all),
+    FoldKeyCount = proplists:get_value(<<"total_count">>, Stats),
+
+    lager:info("FoldKeyCount=~w TotalKeys=~w", [FoldKeyCount, TotalKeys]),
+    ?assertMatch(true, FoldKeyCount < TotalKeys),
+
+    lager:info("Changing config on Node 1 back to using AAE"),
+    lager:info("Large exchange tick - we don't want to repair via exchange"),
+    lager:info("Short rebuild tick - we do want to resolve via rebuild"),
+    rt:set_advanced_conf(Node1,
+                            ?CFG_TICTACAAE(60 * 60 * 1000, 60 * 1000, dscp)),
+    rt:wait_for_service(Node1, riak_kv),
+    rt:set_advanced_conf(Node2,
+                            ?CFG_TICTACAAE(60 * 60 * 1000, 60 * 1000, single)),
+    rt:wait_for_service(Node2, riak_kv),
+    rt:set_advanced_conf(Node3,
+                            ?CFG_TICTACAAE(60 * 60 * 1000, 60 * 1000, none)),
+    rt:wait_for_service(Node3, riak_kv),
+    lager:info("Wait until rebuild has caused correct result"),
+    lager:info("This should be immediate for native backend"),
+
+    RebuildCompleteFun = 
+        fun() ->
+            {ok, {stats, RebuildStats}} =
+                rhc:aae_object_stats(HttpCH, ?BUCKET, all, all),
+            RebuildFoldKeyCount =
+                proplists:get_value(<<"total_count">>, RebuildStats),
+            lager:info("RebuildFoldKeyCount=~w TotalKeys=~w",
+                        [RebuildFoldKeyCount, TotalKeys]),
+            RebuildFoldKeyCount == TotalKeys
+        end,
+    ok = rt:wait_until(RebuildCompleteFun, 8, 30000),
+
+    {MegaB4, SecsB4, _} = os:timestamp(),
+    SWbefore = MegaB4 * 1000000 + SecsB4,
+    timer:sleep(1000),
+    TotalModifiedKeys = lists:foldl(KeyLoadFun(1000), 0, Cluster),
+    timer:sleep(1000),
+    {MegaAft, SecsAft, _} = os:timestamp(),
+    SWafter = MegaAft * 1000000 + SecsAft,
+
+    {ok, {stats, ModifiedStats}} =
+        rhc:aae_object_stats(HttpCH, ?BUCKET, all, {SWbefore, SWafter}),
+    ModifiedKeyCount = proplists:get_value(<<"total_count">>, ModifiedStats),
+    lager:info("ModifiedKeyCount=~w TotalModifiedKeys=~w",
+                [ModifiedKeyCount, TotalModifiedKeys]),
+    ?assertMatch(TotalModifiedKeys, ModifiedKeyCount),
+
+    pass.
+
+
+to_key(N) ->
+    list_to_binary(io_lib:format("K~8..0B", [N])).
+
+test_data(Start, End, V) ->
+    Keys = [to_key(N) || N <- lists:seq(Start, End)],
+    [{K, <<K/binary, V/binary>>} || K <- Keys].
+
+write_data(Node, KVs) ->
+    write_data(Node, KVs, []).
+
+write_data(Node, KVs, Opts) ->
+    PB = rt:pbc(Node),
+    [begin
+         O =
+             case riakc_pb_socket:get(PB, ?BUCKET, K) of
+                 {ok, Prev} ->
+                     riakc_obj:update_value(Prev, V);
+                 _ ->
+                     riakc_obj:new(?BUCKET, K, V)
+             end,
+         ?assertMatch(ok, riakc_pb_socket:put(PB, O, Opts))
+     end || {K, V} <- KVs],
+    riakc_pb_socket:stop(PB),
+    ok.


### PR DESCRIPTION
It transpires that the `verify_tictac_aae` test does a poor job of actually testing tictca aae rebuilds.  Even if rebuilds fail, the pace of exchanges will repair discrepancies via read repair.

This test explicitly requires the reuild to work, and cannot solve any issues through exchanges (as exchanges are stopped for the test).

Also fills a gap in testing of modified date ranges in aaefold.