### PR TITLE
Changes to pass some kv_all tests

### DIFF
--- a/groups/kv_all
+++ b/groups/kv_all
@@ -15,7 +15,6 @@ pb_cipher_suites
 pb_security
 proxy_overload_recovery
 pr_pw
-riak727
 riak_rex
 rt_basic_test
 sibling_explosion

--- a/tests/kv679_dataloss.erl
+++ b/tests/kv679_dataloss.erl
@@ -119,6 +119,7 @@ delete_datadir({{Idx, Node}, Type}) ->
     Path = filename:join([rtdev:relpath(current),
                           "dev",
                           "dev"++ integer_to_list(rtdev:node_id(Node)),
+                          "riak",
                           DataRoot,
                           integer_to_list(Idx)]),
     lager:info("Path ~p~n", [Path]),

--- a/tests/pb_cipher_suites.erl
+++ b/tests/pb_cipher_suites.erl
@@ -66,12 +66,12 @@ confirm() ->
     ok = rpc:call(Node, riak_core_console, add_source, [["user", "127.0.0.1/32",
                                                     "password"]]),
 
-    CipherList = "AES128-SHA256:RC4-SHA",
+    CipherList = "AES256-SHA256:RC4-SHA",
     %% set a simple default cipher list, one good one a and one shitty one
     rpc:call(Node, riak_core_security, set_ciphers, [CipherList]),
     rpc:call(Node, application, set_env, [riak_api, honor_cipher_order, true]),
 
-    [AES128, RC4] = ParsedCiphers = [begin
+    [AES256, RC4] = ParsedCiphers = [begin
                 %% this includes the pseudo random function, which apparently
                 %% we don't want
                 SD = ssl_cipher:suite_definition(E),
@@ -84,9 +84,9 @@ confirm() ->
     
     lager:info("Parsed Ciphers ~w", [ParsedCiphers]),
 
-    lager:info("Check that the server's preference for ECDHE-RSA-AES128-SHA256"
+    lager:info("Check that the server's preference for ECDHE-RSA-AES256-SHA256"
                "is honored"),
-    ?assertEqual({ok, {'tlsv1.2', AES128}},
+    ?assertEqual({ok, {'tlsv1.2', AES256}},
                  pb_connection_info(Port,
                                     [{credentials, "user",
                                       "password"}, {cacertfile,

--- a/tests/pb_cipher_suites.erl
+++ b/tests/pb_cipher_suites.erl
@@ -66,23 +66,27 @@ confirm() ->
     ok = rpc:call(Node, riak_core_console, add_source, [["user", "127.0.0.1/32",
                                                     "password"]]),
 
-    CipherList = "AES256-SHA256:RC4-SHA",
+    CipherList = "AES128-SHA256:RC4-SHA",
     %% set a simple default cipher list, one good one a and one shitty one
-    rpc:call(Node, riak_core_security, set_ciphers,
-             [CipherList]),
+    rpc:call(Node, riak_core_security, set_ciphers, [CipherList]),
+    rpc:call(Node, application, set_env, [riak_api, honor_cipher_order, true]),
 
-    [AES, RC4] = ParsedCiphers = [begin
+    [AES128, RC4] = ParsedCiphers = [begin
                 %% this includes the pseudo random function, which apparently
                 %% we don't want
-                {A, B, C, _D} = ssl_cipher:suite_definition(E),
-                {A, B, C}
+                SD = ssl_cipher:suite_definition(E),
+                {maps:get(key_exchange, SD), 
+                    maps:get(cipher, SD),
+                    maps:get(mac, SD)}
             end ||
             E <- element(1,
                          riak_core_ssl_util:parse_ciphers(CipherList))],
+    
+    lager:info("Parsed Ciphers ~w", [ParsedCiphers]),
 
     lager:info("Check that the server's preference for ECDHE-RSA-AES128-SHA256"
                "is honored"),
-    ?assertEqual({ok, {'tlsv1.2', AES}},
+    ?assertEqual({ok, {'tlsv1.2', AES128}},
                  pb_connection_info(Port,
                                     [{credentials, "user",
                                       "password"}, {cacertfile,
@@ -93,10 +97,9 @@ confirm() ->
                                     ])),
 
     lager:info("disabling honor_cipher_info"),
-    rpc:call(Node, application, set_env, [riak_api, honor_cipher_order,
-                                          false]),
+    rpc:call(Node, application, set_env, [riak_api, honor_cipher_order, false]),
 
-    lager:info("Check that the client's preference for RC4-SHA"
+    lager:info("Check that the client's preference for RC4"
                "is honored"),
     ?assertEqual({ok, {'tlsv1.2', RC4}},
                  pb_connection_info(Port,
@@ -109,7 +112,7 @@ confirm() ->
                                     ])),
 
     lager:info("check that connections trying to use tls 1.1 fail"),
-    ?assertError({badmatch, _},
+    ?assertMatch({error,{tcp,{tls_alert,"protocol version"}}},
                  pb_connection_info(Port,
                                     [{credentials, "user",
                                       "password"}, {cacertfile,
@@ -119,7 +122,7 @@ confirm() ->
                                     ])),
 
     lager:info("check that connections trying to use tls 1.0 fail"),
-    ?assertError({badmatch, _},
+    ?assertMatch({error,{tcp,{tls_alert,"protocol version"}}},
                  pb_connection_info(Port,
                                     [{credentials, "user",
                                       "password"}, {cacertfile,
@@ -128,7 +131,7 @@ confirm() ->
                                      {ssl_opts, [{versions, ['tlsv1']}]}
                                     ])),
     lager:info("check that connections trying to use ssl 3.0 fail"),
-    ?assertError({badmatch, _},
+    ?assertMatch({error,{tcp,{tls_alert,"protocol version"}}},
                  pb_connection_info(Port,
                                     [{credentials, "user",
                                       "password"}, {cacertfile,
@@ -142,7 +145,7 @@ confirm() ->
                                           [sslv3, tlsv1, 'tlsv1.1']]),
 
     lager:info("check that connections trying to use tls 1.2 fail"),
-    ?assertError({badmatch, _},
+    ?assertMatch({error,{tcp,{options,{'tls1.2',{versions,['tls1.2']}}}}},
                  pb_connection_info(Port,
                                     [{credentials, "user",
                                       "password"}, {cacertfile,
@@ -151,8 +154,8 @@ confirm() ->
                                      {ssl_opts, [{versions, ['tls1.2']}]}
                                     ])),
 
-    lager:info("check tls 1.1 works"),
-    ?assertMatch({ok, {'tlsv1.1', _}},
+    lager:info("check tls 1.1 fails - need to be on 1.2"),
+    ?assertMatch({error,{tcp,{tls_alert,"insufficient security"}}},
                  pb_connection_info(Port,
                                     [{credentials, "user",
                                       "password"}, {cacertfile,
@@ -161,8 +164,8 @@ confirm() ->
                                      {ssl_opts, [{versions, ['tlsv1.1']}]}
                                     ])),
 
-    lager:info("check tls 1.0 works"),
-    ?assertMatch({ok, {'tlsv1', _}},
+    lager:info("check tls 1.0 fails - need to be on 1.2"),
+    ?assertMatch({error,{tcp,{tls_alert,"insufficient security"}}},
                  pb_connection_info(Port,
                                     [{credentials, "user",
                                       "password"}, {cacertfile,
@@ -216,12 +219,18 @@ pb_get_socket(PB) ->
     element(6, sys:get_state(PB)).
 
 pb_connection_info(Port, Config) ->
-    {ok, PB} = riakc_pb_socket:start("127.0.0.1", Port, Config),
-    ?assertEqual(pong, riakc_pb_socket:ping(PB)),
+    case riakc_pb_socket:start("127.0.0.1", Port, Config) of
+        {ok, PB} ->
+            ?assertEqual(pong, riakc_pb_socket:ping(PB)),
+            {ok, ConnInfo} = ssl:connection_information(pb_get_socket(PB)),
+            {protocol, P} = lists:keyfind(protocol, 1, ConnInfo),
+            {cipher_suite, CS} = lists:keyfind(cipher_suite, 1, ConnInfo),
+            riakc_pb_socket:stop(PB),
+            {ok, {P, CS}};
+        Error ->
+            Error
+    end.
 
-    ConnInfo = ssl:connection_info(pb_get_socket(PB)),
-
-    riakc_pb_socket:stop(PB),
-    ConnInfo.
+    
 
 

--- a/tests/riak_rex.erl
+++ b/tests/riak_rex.erl
@@ -21,11 +21,11 @@ setup(Type) ->
 rex_test(Node) ->
     % validated we can get the rex pid on the node
     RexPid1 = riak_core_util:safe_rpc(Node, erlang, whereis, [rex]),
-    ?assertEqual(node(RexPid1), Node),
+    ?assertEqual(Node, node(RexPid1)),
     % kill rex on the node and check that safe_rpc works
     kill_rex(Node),
     ErrorTuple = riak_core_util:safe_rpc(Node, erlang, whereis, [rex]),
-    ?assertEqual(ErrorTuple, {badrpc,rpc_process_down}),
+    ?assertEqual(badrpc, element(1, ErrorTuple)),
     % restart rex
     supervisor:restart_child({kernel_sup, Node}, rex),
     RexPid2 = riak_core_util:safe_rpc(Node, erlang, whereis, [rex]),


### PR DESCRIPTION
riak727 is removed from kv_all upgrade, as the test is a test of an upgrade from 1.4.  It has been stated that for 3.0 upgrades will be supported from 2.9 and 2.9.1 only.

Fix to path in kv679 dataloss to reflect change in riak `make devrel` script which now includes `riak` within the path.

The pb_cipher_suites test has been changed to reflect that protocols before TLS1.2 are no longer supported.  Also, the implementation of honor_cipher_order has switched from patched OTP to mainstream OTP - and as part of this change the default of honor_cipher_order has been switched from false to true.  So now, to honour cipher_order this must be explicitly set to true.  This is a change that *must* be recognised in release notes.  It may have been possible to change the code to implement the previous default behaviour, but having an explicit difference between riak and OTP defaults may cause long term confusion.

https://github.com/erlang/otp/blob/OTP-20.3.8.22/lib/ssl/src/ssl_internal.hrl#L133-L135

https://github.com/erlang/otp/edit/maint/lib/ssl/doc/src/ssl.xml#L1034

The riak_rex test was a test of safe_rpc - that rpc to another node would not throw an exception.  Now, though OTP has changed to stop it from throwing an exception.

https://github.com/erlang/otp/commit/cccf762d93640b707f8e1515604cebcfbe379c04

This means that the safe_rpc try/catch is no longer necessary.  Open question about whether the safe_rpc wrapper should be changed to return the previous error for backward compatibility (although nothin other than the test appears to exist in the code to handle this specific error), or whether the try/catch should just be removed