### PR TITLE
Missed test

### DIFF
--- a/groups/ensemble
+++ b/groups/ensemble
@@ -9,5 +9,4 @@ ensemble_remove_node2
 ensemble_ring_changes
 ensemble_start_without_aae
 ensemble_sync
-ensemble_util
 ensemble_vnode_crash


### PR DESCRIPTION
this test was missed out as ensemble_util is not a tets module, and tests in a group don't run if after someting which is not a test module.

the test ensemble_vnode_crash need a correct numbe rof nodes, and also the kill needed to avoid a race condition, and the intercept needed to be loaded on the node being killed.

Strengthened the check to make sure that n-val downed ensemble_backends are seen