### PR TITLE
Extend handoff test

### DIFF
--- a/tests/verify_counter_converge.erl
+++ b/tests/verify_counter_converge.erl
@@ -52,6 +52,8 @@ confirm() ->
 
     PartInfo = rt:partition([N1, N2], [N3, N4]),
 
+    timer:sleep(1000),
+
     %% increment one side
     increment_counter(C1, Key, 5),
 


### PR DESCRIPTION
It is not clear in documentation wrt when one can expect consistent results to a 2i query.

This test proves that join is a safe operation wrt 2i, but recovery from failure isn't.