### PR TITLE
Enhance handoff repair tests

### DIFF
--- a/tests/pipe_verify_exceptions.erl
+++ b/tests/pipe_verify_exceptions.erl
@@ -312,12 +312,15 @@ tail_fitting_crash(Pipe) ->
     Last = lists:last(FittingPids),
     rt_pipe:crash_fitting(Last),
     %% try to avoid racing w/pipeline shutdown
-    timer:sleep(100),
+    lager:info("Pause before attempting to pipe into crash"),
+    timer:sleep(2000),
     {error,[worker_startup_failed]} = riak_pipe:queue_work(Pipe, 30),
     riak_pipe:eoi(Pipe),
     exit({success_so_far, riak_pipe:collect_results(Pipe, 100)}).
 
 verify_tail_fitting_crash([RN|_]) ->
+    lager:info("Pause before tail fitting crash"),
+    timer:sleep(2000),
     lager:info("Verify pipe tears down when a fitting crashes (tail)"),
 
     {badrpc, {'EXIT', {success_so_far, {timeout, Res, Trace}}}} =

--- a/tests/verify_handoff.erl
+++ b/tests/verify_handoff.erl
@@ -122,10 +122,12 @@ assert_using(Node, {CapabilityCategory, CapabilityName}, ExpectedCapabilityName)
     lager:info("assert_using ~p =:= ~p", [ExpectedCapabilityName, CapabilityName]),
     ExpectedCapabilityName =:= rt:capability(Node, {CapabilityCategory, CapabilityName}).
 
-%% For some testing purposes, making these limits smaller is helpful:
+%% For some testing purposes, making these limits smaller is helpful,
+%% or at least exercise some more code:
 deploy_test_nodes(false, N) ->
     Config = [{riak_core, [{ring_creation_size, 8},
-                           {handoff_acksync_threshold, 20},
+                           {handoff_acksync_threshold, 5},
+                           {handoff_batch_threshold_count, 20},
                            {handoff_receive_timeout, 2000}]}],
     rt:deploy_nodes(N, Config);
 deploy_test_nodes(true,  N) ->
@@ -134,7 +136,6 @@ deploy_test_nodes(true,  N) ->
                            {ring_creation_size, 8},
                            {handoff_concurrency, 8},
                            {vnode_inactivity_timeout, 1000},
-                           {handoff_acksync_threshold, 20},
                            {handoff_receive_timeout, 2000},
                            {gossip_limit, {10000000, 60000}}]}],
     rt:deploy_nodes(N, Config).

--- a/tests/verify_rejoin.erl
+++ b/tests/verify_rejoin.erl
@@ -24,21 +24,22 @@
 
 -define(TEST_ITEM_COUNT, 10000).
 -define(B, <<"systest">>).
+-define(EXCHANGE_TICK, 10 * 1000). % Must be > inactivity timeout
 
 -define(CFG, 
-            [{riak_core,
-                [{ring_creation_size, 16},
-                {vnode_inactivity_timeout, 5 * 1000}]},
-            {riak_kv, 
-                [{anti_entropy, {off, []}},
-                {tictacaae_active, active},
-                {tictacaae_parallelstore, leveled_ko},
-                        % if backend not leveled will use parallel key-ordered
-                        % store
-                {tictacaae_exchangetick, 10 * 1000}, % 10 seconds, > inactivity timeout
-                {tictacaae_rebuildtick, 3600000}, % don't tick for an hour!
-                {tictacaae_primaryonly, true}]
-            }]).
+    [{riak_core,
+        [{ring_creation_size, 16},
+        {vnode_inactivity_timeout, 5 * 1000}]},
+    {riak_kv, 
+        [{anti_entropy, {off, []}},
+        {tictacaae_active, active},
+        {tictacaae_parallelstore, leveled_ko},
+                % if backend not leveled will use parallel key-ordered
+                % store
+        {tictacaae_exchangetick, ?EXCHANGE_TICK}, 
+        {tictacaae_rebuildtick, 3600000}, % don't tick for an hour!
+        {tictacaae_primaryonly, true}]
+    }]).
 
 confirm() ->
     %% Bring up a 3-node cluster for the test
@@ -85,23 +86,24 @@ confirm() ->
     check_joined([Node1, Node2, Node3, Node4]),
 
     lager:info("Checking for AAE repairs - should be none"),
-    lager:info("Will check the tictac_deltacount on state"),
-    lager:info("This may be brittle to changes in riak_kv_vnode state"),
-    lager:info("TODO - Add riak stat"),
     Ring = rt:get_ring(Node1),
     Owners = riak_core_ring:all_owners(Ring),
-    timer:sleep(10000),
-    lists:foreach(fun check_vnode_stats/1, Owners),
-    timer:sleep(10000),
-    lists:foreach(fun check_vnode_stats/1, Owners),
-    timer:sleep(10000),
-    lists:foreach(fun check_vnode_stats/1, Owners),
+    timer:sleep(?EXCHANGE_TICK),
+    {RCT0, _CCT0} = tictacaae_accumulate_stats(Nodes),
+    timer:sleep(?EXCHANGE_TICK),
+    {RCT1, _CCT1} = tictacaae_accumulate_stats(Nodes),
+    timer:sleep(?EXCHANGE_TICK),
+    {RCT2, CCT2} = tictacaae_accumulate_stats(Nodes),
+
+    true = CCT2 == 0,
+    true = RCT2 > RCT1,
+    true = RCT1 > RCT0,
 
     lager:info("Check all values read"),
     [] = rt:systest_read(Node1, 5 * ?TEST_ITEM_COUNT),
     
-    {0, <<"undefined">>} = repair_stats(Node1),
-    {0, <<"undefined">>} = repair_stats(Node2),
+    {0, <<"undefined">>, <<"undefined">>} = repair_stats(Node1),
+    {0, <<"undefined">>, <<"undefined">>} = repair_stats(Node2),
 
     lager:info("Set Node 1 not to do fallback repair"),
     lager:info("Stop Node 3 so read repairs happen on GET"),
@@ -127,12 +129,14 @@ confirm() ->
             Node2, ?TEST_ITEM_COUNT * 2 + 1, ?TEST_ITEM_COUNT * 5, ?B, 2),
     
     lager:info("Fallbacks repaired only from node 2"),
-    {RRT1, RRFNF1} = repair_stats(Node1),
-    {RRT2, RRFNF2} = repair_stats(Node2),
-    true = RRT1 > 0,
-    true = RRFNF1 == <<"undefined">>,
-    true = RRT2 > 0,
-    true = RRFNF2 == RRT2,
+    {RRT1A, RRFNF1A, RRPNF1A} = repair_stats(Node1),
+    {RRT2A, RRFNF2A, RRPNF2A} = repair_stats(Node2),
+    true = RRT1A > 0,
+    true = RRFNF1A == <<"undefined">>,
+    true = RRT2A > 0,
+    true = RRFNF2A == RRT2A,
+    true = RRPNF1A == <<"undefined">>,
+    true = RRPNF2A == <<"undefined">>,
 
     lager:info("Repeat reads"),
     [] =
@@ -142,18 +146,69 @@ confirm() ->
             Node2, ?TEST_ITEM_COUNT * 2 + 1, ?TEST_ITEM_COUNT * 5, ?B, 2),
 
     lager:info("Previous fallback repairs mean fewer repairs"),
-    {RRT1B, RRFNF1B} = repair_stats(Node1),
-    {RRT2B, RRFNF2B} = repair_stats(Node2),
-    true = RRT1B > RRT1,
-    true = RRFNF1 == <<"undefined">>,
-    true = RRT2B == RRT2,
+    {RRT1B, RRFNF1B, RRPNF1B} = repair_stats(Node1),
+    {RRT2B, RRFNF2B, RRPNF2B} = repair_stats(Node2),
+    true = RRT1B > RRT1A,
+    true = RRFNF1B == <<"undefined">>,
+    true = RRT2B == RRT2A,
+    true = RRFNF2B == RRT2B,
+    true = RRPNF1B == <<"undefined">>,
+    true = RRPNF2B == <<"undefined">>,
 
     lager:info("Restart Node3"),
+    ok = rm_backend_dir(Node3),
     rt:start_and_wait(Node3),
-    ok = rt:wait_until_node_handoffs_complete(Node1),
-    ok = rt:wait_until_node_handoffs_complete(Node2),
+    timer:sleep(1000),
+    ok = rt:wait_until_transfers_complete(Nodes),
 
-    [] = rt:systest_read(Node1, 6 * ?TEST_ITEM_COUNT),
+    lager:info(
+        "No primary repairs from reads to Node2 "
+        "As fallback vnodes should have handed off read repairs"),
+    lager:info(
+        "Primary repairs now expected from Node1 though"
+    ),
+    [] =
+        rt:systest_read(Node1, 1, ?TEST_ITEM_COUNT * 2, ?B, 2),
+    [] =
+        rt:systest_read(
+            Node2, ?TEST_ITEM_COUNT * 2 + 1, ?TEST_ITEM_COUNT * 5, ?B, 2),
+    
+    {RRT1C, RRFNF1C, RRPNF1C} = repair_stats(Node1),
+    {RRT2C, RRFNF2C, RRPNF2C} = repair_stats(Node2),
+    true = RRT1C > RRT1B,
+    true = RRFNF1C == <<"undefined">>,
+    lager:info(
+        "AAE may explain why read repairs N2 ~w non-zero, but should be << ~w",
+        [(RRT2C - RRT2B), ?TEST_ITEM_COUNT]),
+    true = (RRT2C - RRT2B) < ?TEST_ITEM_COUNT,
+    true = (RRT2C - RRT2B) < (RRT1C - RRT1B),
+    true = RRPNF1C > 0,
+    true = RRFNF2C == RRFNF2B,
+    lager:info(
+        "AAE may explain why  read repairs N2 ~w non-zero, but should be << ~w",
+        [RRPNF2C, ?TEST_ITEM_COUNT]),
+    true = (RRPNF2C == <<"undefined">>) or (RRPNF2C < ?TEST_ITEM_COUNT),
+
+    {RCT3, CCT3} = tictacaae_accumulate_stats(Nodes),
+    lager:info(
+        "root compares delta ~w clock compares delta ~w",
+        [(RCT3 - RCT2), (CCT3 - CCT2)]),
+    
+    case RRT2C > RRT2B of
+        true ->
+            lager:info("AAE does appear to be the cause of read repairs"),
+            true = (CCT3 - CCT2) > 0;
+        false ->
+            ok
+    end,
+
+    [] =
+        rt:systest_read(
+            Node1, 5 * ?TEST_ITEM_COUNT + 1, 6 * ?TEST_ITEM_COUNT, ?B, 2),
+    {RRT1D, RRFNF1D, RRPNF1D} = repair_stats(Node1),
+    true = RRT1D == RRT1C,
+    true = RRFNF1D == <<"undefined">>,
+    true = RRPNF1D == RRPNF1C,
 
     pass.
 
@@ -163,34 +218,62 @@ check_joined(Nodes) ->
     ?assertEqual(ok, rt:wait_until_no_pending_changes(Nodes)),
     ?assertEqual(ok, rt:wait_until_nodes_agree_about_ownership(Nodes)).
 
-check_vnode_stats({Partition, Node}) ->
-    {ok, Pid} =
-        rpc:call(Node,
-                    riak_core_vnode_manager,
-                    get_vnode_pid,
-                    [Partition, riak_kv_vnode]),
-    {riak_kv_vnode, ModState} =
-        rpc:call(Node,
-                    riak_core_vnode,
-                    get_modstate,
-                    [Pid]),
-    ?assertEqual(0, element(27, ModState)).
-
 upnode_count(Node, Count) ->
     UpNodes = rpc:call(Node, riak_core_node_watcher, nodes, [riak_kv]),
     Count == length(UpNodes).
+
+rm_backend_dir(Node) ->
+    rt:clean_data_dir([Node], backend_dir()).
+
+backend_dir() ->
+    TestMetaData = riak_test_runner:metadata(),
+    KVBackend = proplists:get_value(backend, TestMetaData),
+    backend_dir(KVBackend).
+
+backend_dir(undefined) ->
+    backend_dir(bitcask);
+backend_dir(bitcask) ->
+    "bitcask";
+backend_dir(eleveldb) ->
+    "leveldb";
+backend_dir(leveled) ->
+    "leveled".
 
 repair_stats(Node) ->
     NodeStats = verify_riak_stats:get_stats(Node, 1000),
     {<<"read_repairs_total">>, RRT} =
         lists:keyfind(<<"read_repairs_total">>, 1, NodeStats),
-    {<<"read_repairs">>, RR} =
-        lists:keyfind(<<"read_repairs">>, 1, NodeStats),
     {<<"read_repairs_fallback_notfound_count">>, RRFNF} =
         lists:keyfind(
             <<"read_repairs_fallback_notfound_count">>, 1, NodeStats),
+    {<<"read_repairs_primary_notfound_count">>, RRPNF} =
+        lists:keyfind(
+            <<"read_repairs_primary_notfound_count">>, 1, NodeStats),
     lager:info(
-        "For Node ~w read_repairs=~w read_repairs_total=~w"
-        " fallback_notfound=~w",
-        [Node, RR, RRT, RRFNF]),
-    {RRT, RRFNF}.
+        "For Node ~w read_repairs_total=~w"
+        " fallback_notfound=~p primary_notfound=~p",
+        [Node, RRT, RRFNF, RRPNF]),
+    {RRT, RRFNF, RRPNF}.
+
+tictacaae_accumulate_stats(Nodes) ->
+    lists:foldl(
+        fun(N, {RC, CC}) ->
+            {RCN, CCN} = tictacaae_stats(N),
+            {RC + RCN, CC + CCN}
+        end,
+        {0, 0},
+        Nodes
+    ).
+
+tictacaae_stats(Node) ->
+    NodeStats = verify_riak_stats:get_stats(Node, 1000),
+    {<<"tictacaae_root_compare_total">>, RCT} =
+        lists:keyfind(<<"tictacaae_root_compare_total">>, 1, NodeStats),
+    {<<"tictacaae_clock_compare_total">>, CCT} =
+        lists:keyfind(<<"tictacaae_clock_compare_total">>, 1, NodeStats),
+    lager:info(
+        "For Node ~w root_compare_total=~w clock_compare_total=~w",
+        [Node, RCT, CCT]
+    ),
+    {RCT, CCT}.
+    

--- a/tests/verify_rejoin.erl
+++ b/tests/verify_rejoin.erl
@@ -22,7 +22,8 @@
 -export([confirm/0]).
 -include_lib("eunit/include/eunit.hrl").
 
--define(TEST_ITEM_COUNT, 20000).
+-define(TEST_ITEM_COUNT, 10000).
+-define(B, <<"systest">>).
 
 -define(CFG, 
             [{riak_core,
@@ -45,20 +46,22 @@ confirm() ->
     lager:info("Leave and join nodes during write activity"),
     lager:info("Do this with aggressive AAE - but we shouldn't see AAE repairs"),
     lager:info("In the future - need a riak stat for repairs to validate this"),
-    Nodes = rt:build_cluster(3, ?CFG),
-    [Node1, Node2, Node3] = Nodes,
+    Nodes = rt:build_cluster(4, ?CFG),
+    [Node1, Node2, Node3, Node4] = Nodes,
 
     lager:info("Writing ~p items", [?TEST_ITEM_COUNT]),
-    rt:systest_write(Node1, 1, ?TEST_ITEM_COUNT),
+    [] = rt:systest_write(Node1, 1, ?TEST_ITEM_COUNT, ?B, 2),
 
     lager:info("Have node2 leave and continue to write"),
     rt:leave(Node2),
-    rt:systest_write(Node1, ?TEST_ITEM_COUNT + 1, 2 * ?TEST_ITEM_COUNT),
+    [] = rt:systest_write(
+            Node1, ?TEST_ITEM_COUNT + 1, 2 * ?TEST_ITEM_COUNT, ?B, 2),
     ?assertEqual(ok, rt:wait_until_unpingable(Node2)),
 
     lager:info("Have node3 leave and continue to write"),
     rt:leave(Node3),
-    rt:systest_write(Node1, 2 * ?TEST_ITEM_COUNT + 1, 3 * ?TEST_ITEM_COUNT),
+    [] = rt:systest_write(
+            Node1, 2 * ?TEST_ITEM_COUNT + 1, 3 * ?TEST_ITEM_COUNT, ?B, 2),
     ?assertEqual(ok, rt:wait_until_unpingable(Node3)),
     
     lager:info("Restart node2"),
@@ -67,8 +70,9 @@ confirm() ->
     
     lager:info("Rejoin node2 and continue to write"),
     rt:join(Node2, Node1),
-    rt:systest_write(Node1, 3 * ?TEST_ITEM_COUNT + 1, 4 * ?TEST_ITEM_COUNT),
-    check_joined([Node1, Node2]),
+    [] = rt:systest_write(
+            Node1, 3 * ?TEST_ITEM_COUNT + 1, 4 * ?TEST_ITEM_COUNT, ?B, 2),
+    check_joined([Node1, Node2, Node4]),
 
     lager:info("Restart node3"),
     rt:start_and_wait(Node3),
@@ -76,8 +80,9 @@ confirm() ->
 
     lager:info("Rejoin node3 and continue to write"),
     rt:join(Node3, Node1),
-    rt:systest_write(Node1, 4 * ?TEST_ITEM_COUNT + 1, 5 * ?TEST_ITEM_COUNT),
-    check_joined([Node1, Node2, Node3]),
+    [] = rt:systest_write(
+            Node1, 4 * ?TEST_ITEM_COUNT + 1, 5 * ?TEST_ITEM_COUNT, ?B, 2),
+    check_joined([Node1, Node2, Node3, Node4]),
 
     lager:info("Checking for AAE repairs - should be none"),
     lager:info("Will check the tictac_deltacount on state"),
@@ -93,7 +98,63 @@ confirm() ->
     lists:foreach(fun check_vnode_stats/1, Owners),
 
     lager:info("Check all values read"),
-    rt:systest_read(Node1, 5 * ?TEST_ITEM_COUNT),
+    [] = rt:systest_read(Node1, 5 * ?TEST_ITEM_COUNT),
+    
+    {0, <<"undefined">>} = repair_stats(Node1),
+    {0, <<"undefined">>} = repair_stats(Node2),
+
+    lager:info("Set Node 1 not to do fallback repair"),
+    lager:info("Stop Node 3 so read repairs happen on GET"),
+    ok =
+        rpc:call(
+            Node1,
+            application,
+            set_env,
+            [riak_kv, read_repair_primaryonly, true]),
+    rt:stop_and_wait(Node3),
+    ok = rt:wait_until_no_pending_changes([Node1, Node2]),
+    ok = rt:wait_until(fun() -> upnode_count(Node1, 3) end),
+    ok = rt:wait_until(fun() -> upnode_count(Node2, 3) end),
+    timer:sleep(10000),
+    lager:info("Read from node1, write some more, read some from node 2"),
+    [] =
+        rt:systest_read(Node1, 1, ?TEST_ITEM_COUNT * 2, ?B, 2),
+    [] =
+        rt:systest_write(
+            Node1, 5 * ?TEST_ITEM_COUNT + 1, 6 * ?TEST_ITEM_COUNT, ?B, 2),
+    [] =
+        rt:systest_read(
+            Node2, ?TEST_ITEM_COUNT * 2 + 1, ?TEST_ITEM_COUNT * 5, ?B, 2),
+    
+    lager:info("Fallbacks repaired only from node 2"),
+    {RRT1, RRFNF1} = repair_stats(Node1),
+    {RRT2, RRFNF2} = repair_stats(Node2),
+    true = RRT1 > 0,
+    true = RRFNF1 == <<"undefined">>,
+    true = RRT2 > 0,
+    true = RRFNF2 == RRT2,
+
+    lager:info("Repeat reads"),
+    [] =
+        rt:systest_read(Node1, 1, ?TEST_ITEM_COUNT * 2, ?B, 2),
+    [] =
+        rt:systest_read(
+            Node2, ?TEST_ITEM_COUNT * 2 + 1, ?TEST_ITEM_COUNT * 5, ?B, 2),
+
+    lager:info("Previous fallback repairs mean fewer repairs"),
+    {RRT1B, RRFNF1B} = repair_stats(Node1),
+    {RRT2B, RRFNF2B} = repair_stats(Node2),
+    true = RRT1B > RRT1,
+    true = RRFNF1 == <<"undefined">>,
+    true = RRT2B == RRT2,
+
+    lager:info("Restart Node3"),
+    rt:start_and_wait(Node3),
+    ok = rt:wait_until_node_handoffs_complete(Node1),
+    ok = rt:wait_until_node_handoffs_complete(Node2),
+
+    [] = rt:systest_read(Node1, 6 * ?TEST_ITEM_COUNT),
+
     pass.
 
 
@@ -114,3 +175,22 @@ check_vnode_stats({Partition, Node}) ->
                     get_modstate,
                     [Pid]),
     ?assertEqual(0, element(27, ModState)).
+
+upnode_count(Node, Count) ->
+    UpNodes = rpc:call(Node, riak_core_node_watcher, nodes, [riak_kv]),
+    Count == length(UpNodes).
+
+repair_stats(Node) ->
+    NodeStats = verify_riak_stats:get_stats(Node, 1000),
+    {<<"read_repairs_total">>, RRT} =
+        lists:keyfind(<<"read_repairs_total">>, 1, NodeStats),
+    {<<"read_repairs">>, RR} =
+        lists:keyfind(<<"read_repairs">>, 1, NodeStats),
+    {<<"read_repairs_fallback_notfound_count">>, RRFNF} =
+        lists:keyfind(
+            <<"read_repairs_fallback_notfound_count">>, 1, NodeStats),
+    lager:info(
+        "For Node ~w read_repairs=~w read_repairs_total=~w"
+        " fallback_notfound=~w",
+        [Node, RR, RRT, RRFNF]),
+    {RRT, RRFNF}.


### PR DESCRIPTION
verify_rejoin was a completely broken test.  It is now fixed, with a section added at the end to prove the impact of the configuration on fallback repairs.

verify_handoff extended to alter the batch_threhsold_count.