### PR TITLE
Nhse d30 nhskv9 (#6)

### DIFF
--- a/tests/repl_rt_overload.erl
+++ b/tests/repl_rt_overload.erl
@@ -81,7 +81,7 @@ verify_overload_writes(LeaderA, LeaderB) ->
                 <<X>> <= erlang:md5(term_to_binary(os:timestamp()))]),
     TestBucket = <<TestHash/binary, "-rt_test_overload">>,
     First = 1,
-    Last = 10000,
+    Last = 100000,
 
     %% Write some objects to the source cluster (A),
     lager:info("Writing ~p keys to ~p, to ~p",


### PR DESCRIPTION
* Add check of peer discovery

when a sink is suspended or disabled, then the peer discovery process should not crash or re-enable the sink

* Extend key count to hit limit

Issues with hitting limit reliably on faster machines

https://github.com/nhs-riak/riak_test/pull/6